### PR TITLE
Added explicit process.exit in CLI cleanup()

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -46,6 +46,8 @@ var cleanUp = function(runner, log) {
     util.puts('Shutting down selenium standalone server');
     server.stop();
   }
+
+  process.exit(passed? 0 : 1);
 };
 
 var printVersion = function () {


### PR DESCRIPTION
When tests fail, the protractor runner will exit with a code of 1.
Fixes #24
