### PR TITLE
Added jsdoc for findElement and protractor.By

### DIFF
--- a/lib/protractor.js
+++ b/lib/protractor.js
@@ -317,9 +317,9 @@ Protractor.prototype.waitForAngular = function() {
 };
 
 /**
- * See webdriver.WebDriver.findElement
- *
  * Waits for Angular to finish rendering before searching for elements.
+ * @see webdriver.WebDriver.findElement
+ * @returns {!webdriver.WebElement}
  */
 Protractor.prototype.findElement = function(locator, varArgs) {
   this.waitForAngular();
@@ -330,9 +330,10 @@ Protractor.prototype.findElement = function(locator, varArgs) {
 };
 
 /**
- * See webdriver.WebDriver.findElements
- *
  * Waits for Angular to finish rendering before searching for elements.
+ * @see webdriver.WebDriver.findElements
+ * @return {!webdriver.promise.Promise} A promise that will be resolved to an
+ *     array of the located {@link webdriver.WebElement}s.
  */
 Protractor.prototype.findElements = function(locator, varArgs) {
   this.waitForAngular();
@@ -431,7 +432,8 @@ exports.getInstance = function() {
 
 
 /**
- * Locators.
+ * The Protractor Locator.
+ * @augments webdriver.Locator.Strategy
  */
 var ProtractorBy = function() {};
 var WebdriverBy = function() {};
@@ -546,4 +548,7 @@ ProtractorBy.prototype.repeater = function(repeatDescriptor) {
   };
 };
 
+/**
+ * @type {ProtractorBy}
+ */
 exports.By = new ProtractorBy();


### PR DESCRIPTION
I've recently started using this excellent library and found I was manually editing the protractor files to add a little bit more jsdoc in order to make it easier to discover what it could do. This adds just a few bits of jsdoc to achieve the following:
## protractor.By

Before:
![image](https://f.cloud.github.com/assets/1056441/906754/2a1569cc-fcd6-11e2-86c0-11387e9a4969.png)

After:
![image](https://f.cloud.github.com/assets/1056441/906758/f80828f6-fcd6-11e2-8acf-e08d0a9ead80.png)

Note how it shows options from both the webdriver By and protractor-specific functions.
## ptor.findElement

Before:
![image](https://f.cloud.github.com/assets/1056441/906761/47e9ed1e-fcd7-11e2-9a52-ec5212d5e4ce.png)

After:
![image](https://f.cloud.github.com/assets/1056441/906764/b7b9fb52-fcd7-11e2-8102-d877eb87415a.png)
## ptor.findElements

Before:
![image](https://f.cloud.github.com/assets/1056441/906766/4a67a940-fcd8-11e2-9bf7-7a0a3855c83d.png)

After:
![image](https://f.cloud.github.com/assets/1056441/906777/37bf52c8-fcda-11e2-9f9f-dae26df068aa.png)

Not so useful as all you know is that you are getting a promise back.
