### PR TITLE
testing chrome extensions

### DIFF
--- a/lib/protractor.js
+++ b/lib/protractor.js
@@ -376,6 +376,7 @@ Protractor.prototype.get = function(destination) {
   this.driver.get('about:blank');
   this.driver.executeScript('window.name += "' + DEFER_LABEL + '";' +
       'window.location.href = "' + destination + '"');
+  this.driver.executeScript('window.name += "' + DEFER_LABEL + '";');
 
   // Make sure the page is an Angular page.
   this.driver.executeAsyncScript(clientSideScripts.testForAngular).


### PR DESCRIPTION
when testing chrome extensions, somehow we need to set window.name again after window.location.
