### PR TITLE
feat(locators): add textarea locator

### DIFF
--- a/lib/clientsidescripts.js
+++ b/lib/clientsidescripts.js
@@ -279,6 +279,27 @@ clientSideScripts.findSelectedOption = function() {
 };
 
 /**
+ * Find a textarea element by model name.
+ *
+ * arguments[0] {Element} The scope of the search.
+ * arguments[1] {String} The model name.
+ *
+ * @return {Element} The first matching textarea element.
+*/
+clientSideScripts.findTextarea = function() {
+  var using = arguments[0] || document;
+  var model = arguments[1];
+  var prefixes = ['ng-', 'ng_', 'data-ng-', 'x-ng-', 'ng\\:'];
+  for (var p = 0; p < prefixes.length; ++p) {
+    var selector = 'textarea[' + prefixes[p] + 'model="' + model + '"]';
+    var textareas = using.querySelectorAll(selector);
+    if (textareas.length) {
+      return textareas[0];
+    }
+  }
+};
+
+/**
  * Tests whether the angular global variable is present on a page. Retries
  * in case the page is just loading slowly.
  *

--- a/lib/locators.js
+++ b/lib/locators.js
@@ -77,6 +77,15 @@ ProtractorBy.prototype.input = function(model) {
   };
 };
 
+ProtractorBy.prototype.textarea = function(model) {
+  return {
+    findOverride: function(driver, using) {
+      return driver.findElement(
+          webdriver.By.js(clientSideScripts.findTextarea), using, model);
+    }
+  };
+};
+
 /**
  * Usage:
  * <div ng-repeat = "cat in pets">

--- a/spec/findelements_spec.js
+++ b/spec/findelements_spec.js
@@ -48,6 +48,17 @@ describe('finding elements', function() {
           toBe(false);
     });
 
+    it('should find an element by textarea model', function() {
+      var about = ptor.findElement(protractor.By.textarea('aboutbox'));
+      expect(about.getAttribute('value')).toEqual('This is a text box');
+
+      about.clear();
+      about.sendKeys('Something else to write about');
+
+      var textarea = ptor.findElement(protractor.By.textarea('aboutbox'));
+      expect(textarea.getAttribute('value')).toEqual('Something else to write about');
+    });
+
     it('should find inputs with alternate attribute forms', function() {
       var letterList = ptor.findElement(protractor.By.id('letterlist'));
       expect(letterList.getText()).toBe('');

--- a/testapp/app/js/controllers.js
+++ b/testapp/app/js/controllers.js
@@ -101,6 +101,7 @@ BindingsCtrl.$inject = ['$scope'];
 function FormCtrl($scope) {
   $scope.greeting = "Hiya";
   $scope.username = "Anon";
+  $scope.aboutbox = "This is a text box";
   $scope.color = "blue";
   $scope.show = true;
   $scope.days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'];

--- a/testapp/app/partials/form.html
+++ b/testapp/app/partials/form.html
@@ -2,6 +2,9 @@
 <div>Username
   <input ng-model="username" type="text"/>
 </div>
+<div>Textarea
+  <textarea ng-model="aboutbox"></textarea>
+</div>
 <div ng-style="{'color': color}">Color <br/>
   <input ng-model="color" value="blue" type="radio"/> blue <br/>
   <input ng-model="color" value="green" type="radio"/> green <br/>


### PR DESCRIPTION
There are plenty of locators for other form elements but nothing for `textarea`. This adds a locator for `textarea` elements.
