### PR TITLE
Allow use of custom matchers.

### DIFF
--- a/jasminewd/index.js
+++ b/jasminewd/index.js
@@ -90,7 +90,10 @@ function wrapMatcher(matcher, actualPromise) {
  */
 function promiseMatchers(actualPromise) {
   var promises = {};
-  for (matcher in jasmine.Matchers.prototype) {
+  var env = jasmine.getEnv();
+  var matchersClass = env.currentSpec.matchersClass || env.matchersClass;
+
+  for (matcher in matchersClass.prototype) {
     promises[matcher] = wrapMatcher(matcher, actualPromise);
   };
 

--- a/jasminewd/spec/adapterSpec.js
+++ b/jasminewd/spec/adapterSpec.js
@@ -98,6 +98,12 @@ describe('webdriverJS Jasmine adapter', function() {
     expect(fakeDriver.getValueB()).toEqual('b');
   })
 
+  it('should allow the use of custom matchers', function() {
+    var customMatcher = expect(fakeDriver.getValueA()).toBeLotsMoreThan;
+    expect(customMatcher).toBeDefined()
+  })
+
+
   // Uncomment to see timeout failures.
   // it('should timeout after 200ms', function() {
   //   expect(fakeDriver.getValueA()).toEqual('a');


### PR DESCRIPTION
Using jasmine.Matchers.prototype to generate the chained methods for
expect() calls is flawed because it does not pick up custom matchers
defined using addMatcher.  Instead, use either the matchersClass for
the current spec or from the environment.
