### PR TITLE
fix(cli): allow passing the config file before the options

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -231,13 +231,14 @@ while(args.length) {
       break;
     default:
       var configPath = path.resolve(process.cwd(), arg);
-      merge(config, require(configPath).config);
-      merge (config, commandLineConfig);
       configDir = path.dirname(configPath);
       break;
   }
 }
 
+merge(config, require(configPath).config);
+merge(config, commandLineConfig);
+  
 var sauceAccount;
 if (config.sauceUser && config.sauceKey) {
   sauceAccount = new SauceLabs({


### PR DESCRIPTION
The cli usage says:

> USAGE: protractor configFile [options]

However, the options passed as argument are merged into the default
configuration as soon as the configFile is met in the args parsing
loop.

This fix merges the options in the default configuration only after
the loop, allowing to pass the options to the cli before or after,
or around the config file.
