### PR TITLE
feat(cli): add an onPrepare callback to the config

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -161,6 +161,11 @@ var startJasmineTests = function() {
     originalOnComplete = options.onComplete;
     options.onComplete = cleanUp;
 
+    // let the configuration configure the protractor instance before running the tests
+    if (config.onPrepare) {
+      config.onPrepare();
+    }
+    
     minijn.executeSpecs(options);
   });
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "bin": "bin/protractor",
   "main": "lib/protractor.js",
   "scripts": {
-    "test": "node lib/cli.js spec/basicConf.js; node lib/cli.js spec/altRootConf.js; node_modules/.bin/minijasminenode jasminewd/spec/adapterSpec.js"
+    "test": "node lib/cli.js spec/basicConf.js; node lib/cli.js spec/altRootConf.js; node lib/cli.js spec/onPrepareConf.js; node_modules/.bin/minijasminenode jasminewd/spec/adapterSpec.js"
   },
   "version": "0.9.0"
 }

--- a/referenceConf.js
+++ b/referenceConf.js
@@ -58,6 +58,12 @@ exports.config = {
   // body, but is necessary if ng-app is on a descendant of <body>  
   rootElement: 'body',
 
+  // optional: a callback function called once protractor is ready and available, and before the 
+  // specs are executed
+  // onPrepare: function() {
+    // use protractor here
+  //}
+  
   // ----- Options to be passed to minijasminenode -----
   jasmineNodeOpts: {
     // onComplete will be called just before the driver quits.

--- a/spec/onPrepare/onPrepare_spec.js
+++ b/spec/onPrepare/onPrepare_spec.js
@@ -1,0 +1,23 @@
+describe('tests that use the shortcut functions and globals set by the onPrepare function in the config', function() {
+  beforeEach(function() {
+    // ptor is in the globals thanks to the onPrepare callback function in the config
+    ptor.get('app/index.html#/form');
+  });
+
+  it('should find an element using elem instead of findElement', function() {
+    var greeting = ptor.elem(protractor.By.binding('{{greeting}}'));
+    expect(greeting.getText()).toEqual('Hiya');
+  });
+
+  it('should find multiple elements using elems instead of findElements', function() {
+    ptor.elems(protractor.By.input('color')).then(function(arr) {
+      expect(arr.length).toEqual(3);
+    });
+  });
+
+  it('should find an element using the global by function', function() {
+    var greeting = ptor.elem(by.binding('{{greeting}}'));
+    expect(greeting.getText()).toEqual('Hiya');
+  });
+});
+ 

--- a/spec/onPrepareConf.js
+++ b/spec/onPrepareConf.js
@@ -1,0 +1,26 @@
+// The main suite of Protractor tests.
+exports.config = {
+  seleniumServerJar: './selenium/selenium-server-standalone-2.35.0.jar',
+  chromeDriver: './selenium/chromedriver',
+
+  seleniumAddress: 'http://localhost:4444/wd/hub',
+
+  // Spec patterns are relative to this directory.
+  specs: [
+    'onPrepare/*_spec.js'
+  ],
+
+  capabilities: {
+    'browserName': 'chrome'
+  },
+
+  baseUrl: 'http://localhost:8000',
+  
+  onPrepare: function() {
+    var ptor = protractor.getInstance();
+    ptor.elem = ptor.findElement;
+    ptor.elems = ptor.findElements;
+    global.by = protractor.By;
+    global.ptor = ptor;
+  }
+};


### PR DESCRIPTION
This onPrepare callback is useful when you want to do something with
protractor before running the specs. For example, you might want
to monkey-patch protractor with custom functions used by all the
specs, or add the protractor instance to the globals.

An example usage is shown in the spec/onPrepareConf.js file and its
associated spec.
