### PR TITLE
docs(faq.md): fix line wrap issues

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,8 +1,7 @@
 FAQ
 ===
 
-My tests time out in Protractor, but everything's working fine when running
-manually. What's up?
+My tests time out in Protractor, but everything's working fine when running manually. What's up?
 --------------------
 
 Protractor attempts to wait until the page is completely loaded before


### PR DESCRIPTION
The first faq question was broken into two lines, making the markdown interpret the first line as body text of the FAQ header.
