### PR TITLE
fix: onMocha.js example to pass all tests

### DIFF
--- a/example/mocha/onMocha.js
+++ b/example/mocha/onMocha.js
@@ -44,7 +44,7 @@ describe('angularjs.org homepage', function() {
     ptor.get('http://www.angularjs.org');
 
     var todo = ptor.findElement(
-        protractor.By.repeater('todo in todos').row(2));
+        protractor.By.repeater('todo in todos').row(1));
 
     todo.getText().then(function(text) {
       expect(text).to.eql('build an angular app');


### PR DESCRIPTION
fix: onMocha.js example to pass all tests

The 'should list todos' test will produce the following error if attempting to access .row(2): 'JS locator script result was not a WebElement'. The test has been updated to access .row(1).

-nv
