### PR TITLE
chore(selenium): update to latest version

### DIFF
--- a/bin/install_selenium_standalone
+++ b/bin/install_selenium_standalone
@@ -11,20 +11,20 @@ var AdmZip = require('adm-zip')
 // Thanks to http://www.hacksparrow.com/using-node-js-to-download-files.html
 // for the outline of this code.
 var SELENIUM_URL =
-    'http://selenium.googlecode.com/files/selenium-server-standalone-2.35.0.jar';
+    'https://selenium.googlecode.com/files/selenium-server-standalone-2.37.0.jar';
 var CHROMEDRIVER_URL_MAC =
-    'https://chromedriver.googlecode.com/files/chromedriver_mac32_2.2.zip';
+    'https://chromedriver.storage.googleapis.com/2.4/chromedriver_mac32.zip';
 var CHROMEDRIVER_URL_LINUX32 =
-    'https://chromedriver.googlecode.com/files/chromedriver_linux32_2.2.zip';
+    'https://chromedriver.storage.googleapis.com/2.4/chromedriver_linux32.zip';
 var CHROMEDRIVER_URL_LINUX64 =
-    'https://chromedriver.googlecode.com/files/chromedriver_linux64_2.2.zip';
+    'https://chromedriver.storage.googleapis.com/2.4/chromedriver_linux64.zip';
 var CHROMEDRIVER_URL_WINDOWS =
-    'https://chromedriver.googlecode.com/files/chromedriver_win32_2.2.zip';
+    'https://chromedriver.storage.googleapis.com/2.4/chromedriver_win32.zip';
 
 var DOWNLOAD_DIR = './selenium/';
 var START_SCRIPT_FILENAME = DOWNLOAD_DIR + 'start';
 var chromedriver_url = '';
-var start_script = 'java -jar selenium/selenium-server-standalone-2.35.0.jar';
+var start_script = 'java -jar selenium/selenium-server-standalone-2.37.0.jar';
 
 
 if (!fs.existsSync(DOWNLOAD_DIR) || !fs.statSync(DOWNLOAD_DIR).isDirectory()) {

--- a/referenceConf.js
+++ b/referenceConf.js
@@ -11,7 +11,7 @@ exports.config = {
   // 3. sauceUser/sauceKey - to use remote Selenium servers via SauceLabs.
 
   // The location of the selenium standalone server .jar file.
-  seleniumServerJar: './selenium/selenium-server-standalone-2.35.0.jar',
+  seleniumServerJar: './selenium/selenium-server-standalone-2.37.0.jar',
   // The port to start the selenium server on, or null if the server should
   // find its own unused port.
   seleniumPort: null,


### PR DESCRIPTION
- Old .jar and chromedriver versions out of date.
- Chromedriver URL paths slightly changed as well.
- Paths found on this page: http://www.seleniumhq.org/download/

No known breaking changes.
