### PR TITLE
IE 8 "page reload during async" fix, some better error reporting

### DIFF
--- a/lib/clientsidescripts.js
+++ b/lib/clientsidescripts.js
@@ -22,7 +22,7 @@ clientSideScripts.waitForAngular = function() {
     angular.element(el).injector().get('$browser').
         notifyWhenNoOutstandingRequests(callback);
   } catch (e) {
-    callback(e.toString());
+    callback(e);
   }
 };
 
@@ -386,12 +386,16 @@ clientSideScripts.testForAngular = function() {
       if (window.angular && window.angular.resumeBootstrap) {
         callback([true, null]);
       } else if (n < 1) {
-        callback([false, "timeout exceeded"]);
+        if (window.angular) {
+          callback([false, "angular never provided resumeBootstrap"]);
+        } else {
+          callback([false, "timeout exceeded"]);
+        }
       } else {
         window.setTimeout(function() {check(n - 1)}, 1000);
       }
     } catch (e) {
-      callback([false, e.toString()]);
+      callback([false, e]);
     }
   };
   check(attempts);

--- a/lib/protractor.js
+++ b/lib/protractor.js
@@ -483,21 +483,42 @@ Protractor.prototype.get = function(destination, timeout) {
       'window.name = "' + DEFER_LABEL + '" + window.name;' +
       'window.location.href = "' + destination + '"');
 
+  var angularTestHandler = function(arr) {
+    var hasAngular = arr[0];
+    if (!hasAngular) {
+      var message = arr[1];
+      throw new Error('Angular could not be found on the page ' +
+          destination + " : " + message);
+    }
+  };
+
   // Make sure the page is an Angular page.
-  this.driver.executeAsyncScript(clientSideScripts.testForAngular, timeout).
-    then(function(arr) {
-      var hasAngular = arr[0];
-      if (!hasAngular) {
-        var message = arr[1];
-        throw new Error('Angular could not be found on the page ' +
-            destination + " : " + message);
+  var me = this;
+  me.driver.executeAsyncScript(clientSideScripts.testForAngular, timeout).
+    then(angularTestHandler, function(err) {
+      if (/reload detected during async script/.test(err.message)) {
+        // Sometimes IE will fail to run scripts right after a location change
+        // Let's try it once more
+        me.driver.executeAsyncScript(clientSideScripts.testForAngular, timeout).
+          then(angularTestHandler, function(err) {
+            if (/reload detected during async script/.test(err.message)) {
+              throw "Persistent async reload interrupt problem: " + err.message;
+            } else {
+              throw "While running testForAngular: " + err.message;
+            }
+          });
+      } else {
+        throw "While running testForAngular: " + err.message;
       }
     });
 
   // At this point, Angular will pause for us, until angular.resumeBootstrap
   // is called.
   for (var i = 0; i < this.moduleScripts_.length; ++i) {
-    this.driver.executeScript(this.moduleScripts_[i]);
+    this.driver.executeScript(this.moduleScripts_[i]).
+      then(null, function(err) {
+        throw "While running module script: " + err.message;
+      });
   }
 
   return this.driver.executeScript(function() {


### PR DESCRIPTION
Internet Explorer 8 will occasionally mess up the waitForAngular script by finishing the page load while it's still running. This is sporadic, though I notice it tends to happen more if the Selenium server is farther away from the test runner latency-wise (e.g. running on Sauce).

This change just re-runs the waitForAngular script once more if this particular error occurs, which solves the problem for me; I can now run 20 Sauce tests in a row on IE 8, whereas before this fix they fail every fourth time on average.

I also am including some of the error reporting improvements that I used to track down this issue.
