### PR TITLE
Fixed bug related to Issue #230

### DIFF
--- a/lib/protractor.js
+++ b/lib/protractor.js
@@ -431,6 +431,12 @@ Protractor.prototype.findElements = function(locator, varArgs) {
  */
 Protractor.prototype.isElementPresent = function(locatorOrElement, varArgs) {
   this.waitForAngular();
+  
+  if (locatorOrElement.findOverride) {
+    return locatorOrElement.findOverride(this.driver).then(function(arr) {
+      return !!arr.length;
+    });
+  }
   if (locatorOrElement.findArrayOverride) {
     return locatorOrElement.findArrayOverride(this.driver).then(function(arr) {
       return !!arr.length;


### PR DESCRIPTION
The Protractor isElementPresent function did not include an override for single web elements, only array. This was causing it to throw an error for locators using findOverride.
