### PR TITLE
Fix link to API docs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -141,7 +141,7 @@ You may also use plain old WebDriver strategies such as `by.id` and
 `by.css`. Since locating by CSS selector is so common, the global variable `$` is an alias for `element.by.css`.
 
 `element` returns an ElementFinder. This is an object which allows you to interact with the element on your page, but since all interaction with the browser must be done over webdriver, it is important to remember that this is *not* a DOM element. You can interact with it with methods such as
-`sendKeys`, `getText`, and `click`. Check out the [API](/api.md) for a list of
+`sendKeys`, `getText`, and `click`. Check out the [API](https://github.com/angular/protractor/blob/master/docs/api.md) for a list of
 all available methods.
 
 See Protractor's [findelements test suite](https://github.com/angular/protractor/blob/master/spec/basic/findelements_spec.js)


### PR DESCRIPTION
The previous link to the API docs returned a 404. This change will make the link correctly point to the API docs. (Sorry for the branch name; I was experimenting with GitHub's web-based forking/editing/pull request workflow!)
