### PR TITLE
feat(runner): Verfiy config.seleniumAddress or set null.

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -112,11 +112,12 @@ var setUpSelenium = function() {
   }
 
   /**
-   * Verify the provided seleniumAddress is valid 
-   * by attempting to connect with http.get(). If the address
-   * is not accessible, on('error'), we reset the seleniumAddress
-   * to null. This simplifies our config file as we can now specify
-   *
+   * Verify the provided seleniumAddress is valid by attempting to connect 
+   * with http.get(). If the address is not accessible - on('error') - we 
+   * reset the seleniumAddress to null. This simplifies our config file: 
+   * we can specify both seleniumAddress and seleniumServerJar in our config
+   * and protractor will be smart about it figuring out which to use.  
+   * 
    */
   if (config.seleniumAddress) { 
     http.get(config.seleniumAddress, function(res) {


### PR DESCRIPTION
This PR introduces a feature that simplifies protractor configuration. If a seleniumAddress is provided in the config file, protractor smartly verifies this address is valid, else protractor sets seleniumAddress to null and moves on. With this feature, users can set both `seleniumAddress` and `seleniumServerJar` in the config. 

To verify the address we use node http.get(). Since this is async, we also wrap the main logic for `setUpSelenium` in a callback, `proceed`. 
