### PR TITLE
feat(runner): add error message for bad jar path

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -137,6 +137,12 @@ var setUpSelenium = function() {
       config.seleniumArgs.push(
           '-Dwebdriver.chrome.driver=' + config.chromeDriver);
     }
+
+    if (config.seleniumServerJar && !fs.existsSync(config.seleniumServerJar)) {
+      throw new Error('there\'s no selenium server jar at the specified location.'+
+        'Do you have the correct version?');
+    }
+
     server = new remote.SeleniumServer(config.seleniumServerJar, {
       args: config.seleniumArgs,
       port: config.seleniumPort


### PR DESCRIPTION
If a bad path was provided in the protractor
configuration, the runner would fail with an
ambiguous error.
This fix checks that a file exists at the
provided path, and throws an error if not,
suggesting that perhaps the version is
wrong in the configuration.
