### PR TITLE
fix(clientSideScripts): bind-template directive shouldn't break bind locators

### DIFF
--- a/lib/clientsidescripts.js
+++ b/lib/clientsidescripts.js
@@ -41,13 +41,12 @@ clientSideScripts.findBindings = function() {
   var bindings = using.getElementsByClassName('ng-binding');
   var matches = [];
   for (var i = 0; i < bindings.length; ++i) {
-    var elemData  = angular.element(bindings[i]).data();
-    if (!elemData || !elemData.$binding) {
-      continue;
-    }
-    var bindingName = elemData.$binding[0].exp || elemData.$binding;
-    if (bindingName.indexOf(binding) != -1) {
-      matches.push(bindings[i]);
+    var dataBinding = angular.element(bindings[i]).data('$binding');
+    if(dataBinding) {
+      var bindingName = dataBinding.exp || dataBinding[0].exp || dataBinding;
+      if (bindingName.indexOf(binding) != -1) {
+        matches.push(bindings[i]);
+      }
     }
   }
   return matches; // Return the whole array for webdriver.findElements.
@@ -150,13 +149,12 @@ clientSideScripts.findRepeaterElement = function() {
     bindings.push(childBindings[i]);
   }
   for (var i = 0; i < bindings.length; ++i) {
-    var elemData  = angular.element(bindings[i]).data();
-    if (!elemData || !elemData.$binding) {
-      continue;
-    }
-    var bindingName = elemData.$binding[0].exp || elemData.$binding;
-    if (bindingName.indexOf(binding) != -1) {
-      matches.push(bindings[i]);
+    var dataBinding = angular.element(bindings[i]).data('$binding');
+    if(dataBinding) {
+      var bindingName = dataBinding.exp || dataBinding[0].exp || dataBinding;
+      if (bindingName.indexOf(binding) != -1) {
+        matches.push(bindings[i]);
+      }
     }
   }
   return matches;
@@ -199,13 +197,12 @@ clientSideScripts.findRepeaterColumn = function() {
       bindings.push(childBindings[k]);
     }
     for (var j = 0; j < bindings.length; ++j) {
-      var elemData  = angular.element(bindings[j]).data();
-      if (!elemData || !elemData.$binding) {
-        continue;
-      }
-      var bindingName = elemData.$binding[0].exp || elemData.$binding;
-      if (bindingName.indexOf(binding) != -1) {
-        matches.push(bindings[j]);
+      var dataBinding = angular.element(bindings[j]).data('$binding');
+      if(dataBinding) {
+        var bindingName = dataBinding.exp || dataBinding[0].exp || dataBinding;
+        if (bindingName.indexOf(binding) != -1) {
+          matches.push(bindings[j]);
+        }
       }
     }
   }

--- a/spec/basic/findelements_spec.js
+++ b/spec/basic/findelements_spec.js
@@ -18,11 +18,18 @@ describe('locators', function() {
       expect(greeting.getText()).toEqual('Hiya');
     });
 
-    it('should find an element by binding with ng-binding attribute',
+    it('should find an element by binding with ng-bind attribute',
         function() {
       var name = element(by.binding('username'));
 
       expect(name.getText()).toEqual('Anon');
+    });
+
+    it('should find an element by binding with ng-bind-template attribute',
+        function() {
+      var name = element(by.binding('{{username|uppercase}}'));
+
+      expect(name.getText()).toEqual('ANON');
     });
   });
 

--- a/testapp/form/form.html
+++ b/testapp/form/form.html
@@ -4,6 +4,7 @@
   <h4>Bindings</h4>
   <span>{{greeting}}</span>
   <span data-ng-bind="username"></span>
+  <span data-ng-bind-template="{{username|uppercase}}"></span>
 </div>
 
 <div>


### PR DESCRIPTION
If you try to use the locator "by.binding" on a page that contains at least one "bind-template" directive, the following error will be raised: "UnknownError: angular.element(...).data(...).$binding[0] is undefined".

Ex:

HTML:

``` html
...
<div>{{ myVar }}</div>
<div ng-bind-template="This directive will cause error: {{ myOtherVar }}"></div>
...
```

TEST:

``` javascript
...
element(by.binding('myVar')).getText();
...
```
