### PR TITLE
fix(clientSideScripts): waitForAngular for manually bootstapped apps

### DIFF
--- a/lib/clientsidescripts.js
+++ b/lib/clientsidescripts.js
@@ -20,8 +20,16 @@ clientSideScripts.waitForAngular = function() {
   var el = document.querySelector(arguments[0]);
   var callback = arguments[1];
   try {
-    angular.element(el).injector().get('$browser').
-        notifyWhenNoOutstandingRequests(callback);
+      if (angular.element(el).injector()){
+          angular.element(el).injector().get('$browser').
+              notifyWhenNoOutstandingRequests(callback);
+      } else if (angular.bootstrap().get('$browser')){
+          // get $browser when app is manually bootstrapped
+          angular.bootstrap().get('$browser').
+              notifyWhenNoOutstandingRequests(callback);
+      } else {
+          callback("Error: Cannot get $browser object from Angular.");
+      }
   } catch (e) {
     callback(e);
   }


### PR DESCRIPTION
With some manual bootstrapped applications the client-side call to waitForAngular threw an error because
angular.element(el).injector() did not exists. For these applications the injector can be gotten with
angular.bootstrap().get('$browser'). This fix also returns a more readable error-message when $browser cannot be determined by protractor.
