### PR TITLE
feat(runner): return a promise from runner.runOnce

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -304,12 +304,12 @@ var runJasmineTests = function() {
  * Run Protractor once.
  */
 var runOnce = function() {
-  setUpSelenium().then(function() {
+  return setUpSelenium().then(function() {
     // cleanUp must be registered directly onto runJasmineTests, not onto
     // the chained promise, so that cleanUp is still called in case of a
     // timeout error. Timeout errors need to clear the control flow, which
     // would mess up chaining promises.
-    runJasmineTests().then(cleanUp);
+    return runJasmineTests().then(cleanUp);
   });
 };
 


### PR DESCRIPTION
In some cases knowing when the runner has finished is a requirement. Without it this [simple grunt task](https://gist.github.com/angelyordanov/8004180) that uses the runner directly would not be possible.
