### PR TITLE
feat(runner): add mocha options to config file

### DIFF
--- a/docs/using-mocha.md
+++ b/docs/using-mocha.md
@@ -33,4 +33,13 @@ expect(myElement.getText()).to.eventually.equal('some text');
 
 Finally, set the 'framework' property of the config to 'mocha', either by adding `framework: mocha` to the config file or adding `--framework=mocha` to the command line.
 
+Options for mocha such as 'reporter', 'slow', can be given in config file with `mochaOpts` :
+
+```javascript
+mochaOpts: {
+  reporter: "spec",
+  slow: 3000
+}
+```
+
 See a full [example in protractor's own tests](https://github.com/angular/protractor/tree/master/spec/mocha).

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -32,6 +32,10 @@ var config = {
     showColors: true,
     includeStackTrace: true,
     stackFilter: protractor.filterStackTrace
+  },
+  mochaOpts: {
+    ui: 'bdd',
+    reporter: 'list'
   }
 }
 
@@ -277,10 +281,7 @@ var runTests = function() {
     } else if (config.framework == 'mocha') {
       var Mocha = require('mocha');
 
-      mocha = new Mocha({
-        ui: 'bdd',
-        reporter: 'list'
-      });
+      mocha = new Mocha(config.mochaOpts);
 
       resolvedSpecs.forEach(function(file) {
         mocha.addFile(file);

--- a/referenceConf.js
+++ b/referenceConf.js
@@ -121,4 +121,12 @@ exports.config = {
     // Default time to wait in ms before a test fails.
     defaultTimeoutInterval: 30000
   }
+
+  // ----- Options to be passed to mocha -----
+  //
+  // See the full list at http://visionmedia.github.io/mocha/
+  mochaOpts: {
+    ui: 'bdd',
+    reporter: 'list'
+  }
 };


### PR DESCRIPTION
Change lib/runner to allow setting mocha options from config.

Maybe not all mocha opts can be used with protractor, but this allows to set up commonly used options (for example slow trheshold or reporter)
