### PR TITLE
feat(config): allow CoffeeScript configuration files

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -5,6 +5,10 @@
  * Values from command line options override values from the config.
  */
 
+// Coffee is required here to enable config files written in coffee-script.
+// It's not directly used in this file.
+require('coffee-script');
+
 var util = require('util');
 var path = require('path')
 var fs = require('fs');

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "saucelabs": "~0.1.0",
     "glob": ">=3.1.14",
     "adm-zip": ">=0.4.2",
-    "optimist": "~0.6.0"
+    "optimist": "~0.6.0",
+    "coffee-script": "~1.6.3"
   },
   "devDependencies": {
     "expect.js": "~0.2.0",


### PR DESCRIPTION
Require CoffeeScript in the cli file to enable CS configuration and spec files. No other changes are needed to get CS files working. Possibly needs a readme or doc for the `by` issue but I haven't researched that much yet

Possibly fixes #38
