### PR TITLE
docs(referenceConfjs) Add require('jasmine-reporters')

### DIFF
--- a/referenceConf.js
+++ b/referenceConf.js
@@ -85,6 +85,9 @@ exports.config = {
     // will be available. For example, you can add a Jasmine reporter with:
     //     jasmine.getEnv().addReporter(new jasmine.JUnitXmlReporter(
     //         'outputdir/', true, true));
+
+    // For junit reporting
+    require('jasmine-reporters');
   },
 
   // The params object will be passed directly to the protractor instance,


### PR DESCRIPTION
Add `require('jasmine-reporters')` to `onPrepare()`

Related issue: #404

BREAKING CHANGE: update `referenceConf.js` to include `require('jasmine-reporters');`

Before:

No call to `require()`.

After:

Call to `require()` added within `onPrepare()` method.
