### PR TITLE
fix(Protractor.prototype.get): resolve `baseUrl` before ignoring synchronization

### DIFF
--- a/lib/protractor.js
+++ b/lib/protractor.js
@@ -528,11 +528,12 @@ Protractor.prototype.clearMockModules = function() {
  * @param {=number} opt_timeout Number of seconds to wait for Angular to start.
  */
 Protractor.prototype.get = function(destination, opt_timeout) {
+  var timeout = opt_timeout || 10;
+  destination = url.resolve(this.baseUrl, destination);
+  
   if (this.ignoreSynchronization) {
     return this.driver.get(destination);
   }
-  var timeout = opt_timeout || 10;
-  destination = url.resolve(this.baseUrl, destination);
 
   this.driver.get('about:blank');
   this.driver.executeScript(


### PR DESCRIPTION
Fixes issues where setting `ignoreSynchronization = true` ignores the value of `baseUrl` entirely.
