### PR TITLE
fix(runner): only run selenium with spec files

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -215,9 +215,6 @@ var runTests = function() {
         'since Protractor 0.6.0. Please switch to config.specs.');
   }
   var specs = config.specs;
-  if (!specs || specs.length == 0) {
-    throw new Error('No spec files found.');
-  }
   var resolvedSpecs = [];
   for (var i = 0; i < specs.length; ++i) {
     var matches = glob.sync(specs[i], {cwd: config.configDir});
@@ -360,6 +357,12 @@ var runTests = function() {
  * Run Protractor once.
  */
 var runOnce = function() {
+  var specs = config.specs;
+  if (!specs || specs.length === 0) {
+    util.puts('No spec files found');
+    process.exit(0);
+  }
+
   return setUpSelenium().then(function() {
     // cleanUp must be registered directly onto runTests, not onto
     // the chained promise, so that cleanUp is still called in case of a


### PR DESCRIPTION
Only setup Selenium if there are actual spec files passed in. Previously, selenium would spin up and then a check for the spec files would be done. Checking for the spec files first speeds up that process.
