### PR TITLE
feat(cli): add option to show bin usage

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -21,6 +21,7 @@ var argv = require('optimist').
     usage('Usage: protractor [options] [configFile]\n' +
         'The [options] object will override values from the config file.\n' +
         'See the reference config for a full list of options.').
+    describe('help', 'Print Protractor help menu').
     describe('version', 'Print Protractor version').
     describe('browser', 'Browsername, e.g. chrome or firefox').
     describe('seleniumAddress', 'A running seleium address to use').
@@ -43,6 +44,9 @@ var argv = require('optimist').
     alias('stackTrace', 'jasmineNodeOpts.includeStackTrace').
     string('capabilities.tunnel-identifier').
     check(function(arg) {
+      if (arg.help) {
+        throw '';
+      }
       if (arg._.length > 1) {
         throw 'Error: more than one config file specified'
       }


### PR DESCRIPTION
Passing in `--help` will display the Protractor usage menu
