### PR TITLE
feat(cli): allow running without a config file

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -46,9 +46,6 @@ var argv = require('optimist').
       if (arg._.length > 1) {
         throw 'Error: more than one config file specified'
       }
-      if (!(process.argv.length > 2)) {
-        throw '';
-      }
     }).
     argv;
 


### PR DESCRIPTION
The config file is not needed since all the options specified in it can
be passed in as options
