### PR TITLE
docs(api.md): fixed typo and updated incorrect info

### DIFF
--- a/docs/apitemplate.mustache
+++ b/docs/apitemplate.mustache
@@ -28,7 +28,7 @@ Locator Strategies
 
 The `findElement`, `findElements`, and `isElementPresent` functions take
 a _locator strategy_ as their parameter. The following locator strategies
-are avaiable)
+are available:
 
 
 {{#locatorInfos}}
@@ -41,8 +41,9 @@ are avaiable)
 WebElements
 -----------
 
-The `findElement`, `findElements`, and `isElementPresent` functions return
-a WebElement object. The following functions are available on WebElements.
+The `findElement` function returns a WebElement object and the `findElements`
+function returns a promise that resolves to an array of WebElement objects.
+The following functions are available on WebElement objects:
 
 {{#elementInfos}}
 {{#wd}}[**WD**]({{&link}}) {{/wd}}{{#p}}[**P**]({{&link}}){{/p}} : 


### PR DESCRIPTION
In Locator Strategies:
- Fixed typo

In WebElements:
- Corrected what 'findElements' should return
- Removed mention of isElementPresent

Closes #443
