### PR TITLE
fix(pageload): increase wait timeout

### DIFF
--- a/lib/protractor.js
+++ b/lib/protractor.js
@@ -659,7 +659,7 @@ Protractor.prototype.get = function(destination, opt_timeout) {
     return self.driver.getCurrentUrl().then(function(url) {
       return url !== 'about:blank';
     });
-  }, 300);
+  }, timeout * 1000);
 
   var assertAngularOnPage = function(arr) {
     var hasAngular = arr[0];


### PR DESCRIPTION
The 300 ms wait caused problems when testing IE on Sauce Labs. It seems way too short. "browser.get()" invariably timed out. Increasing it solved our problem.
