### PR TITLE
fix(config): allow CoffeeScript 1.7 to be used

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -9,9 +9,9 @@
 // Coffee is required here to enable config files written in coffee-script.
 // It's not directly used in this file, and not required.
 try {
-  require('coffee-script');
+  require('coffee-script').register();
 } catch (e) {
-  // Intentinally blank - ignore if coffee-script is not available.
+  // Intentionally blank - ignore if coffee-script is not available.
 }
 
 var util = require('util');


### PR DESCRIPTION
CoffeeScript now requires a register call to be made.

Ref #38
