### PR TITLE
refactor(cli): use node to read package version

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -16,7 +16,6 @@ try {
 
 var util = require('util');
 var path = require('path');
-var fs = require('fs');
 var runner = require('./runner.js');
 var argv = require('optimist').
     usage('Usage: protractor [options] [configFile]\n' +
@@ -55,8 +54,7 @@ var argv = require('optimist').
     argv;
 
 if (argv.version) {
-  util.puts('Version ' + JSON.parse(
-      fs.readFileSync(__dirname + '/../package.json', 'utf8')).version);
+  util.puts('Version ' + require(path.join(__dirname, '../package.json')).version);
   process.exit(0);
 }
 


### PR DESCRIPTION
Node will natively parse a json file if it is passed into a require
statement. One less variable and function call. Also passes OS correct
path separators with the path.join call.
