### PR TITLE
feat(config): add check to filter out spec files

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -64,7 +64,9 @@ if (argv.version) {
 if (argv.specs) {
   argv.specs = argv.specs.split(',');
   argv.specs.forEach(function(spec, index, arr) {
-    arr[index] = path.resolve(process.cwd(), spec);
+    var exclude = spec.charAt(0) === '!';
+    arr[index] = (exclude ? '!' : '') +
+        path.resolve(process.cwd(), (exclude ? spec.slice(1) : spec));
   });
 }
 ['seleniumServerJar', 'chromeDriver', 'onPrepare'].forEach(function(name) {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -227,17 +227,25 @@ var runTests = function() {
     throw new Error('Using config.jasmineNodeOpts.specFolders is deprecated ' +
         'since Protractor 0.6.0. Please switch to config.specs.');
   }
-  var specs = config.specs;
+
+  var excludeSpecs = [];
+  var matchedSpecs = [];
   var resolvedSpecs = [];
-  for (var i = 0; i < specs.length; ++i) {
-    var matches = glob.sync(specs[i], {cwd: config.configDir});
-    if (!matches.length) {
-      util.puts('Warning: pattern ' + specs[i] + ' did not match any files.');
+
+  config.specs.forEach(function(spec) {
+    var matches = glob.sync(spec, {cwd: config.configDir});
+    if ( spec.charAt(0) === '!' ) {
+      excludeSpecs = excludeSpecs.concat(matches);
     }
-    for (var j = 0; j < matches.length; ++j) {
-      resolvedSpecs.push(path.resolve(config.configDir, matches[j]));
+    matchedSpecs = matchedSpecs.concat(matches);
+  });
+
+  matchedSpecs.forEach(function(spec) {
+    if ( excludeSpecs.indexOf(spec) < 0 ) {
+      resolvedSpecs.push(path.resolve(config.configDir, spec));
     }
-  }
+  });
+
   if (!resolvedSpecs.length) {
     throw new Error('Spec patterns did not match any files.');
   }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "main": "lib/protractor.js",
   "scripts": {
-    "test": "node lib/cli.js spec/basicConf.js; node lib/cli.js spec/altRootConf.js; node lib/cli.js spec/onPrepareConf.js; node lib/cli.js spec/mochaConf.js; node lib/cli.js spec/withLoginConf.js; node_modules/.bin/minijasminenode jasminewd/spec/adapterSpec.js"
+    "test": "node lib/cli.js spec/basicConf.js; node lib/cli.js spec/altRootConf.js; node lib/cli.js spec/onPrepareConf.js; node lib/cli.js spec/mochaConf.js; node lib/cli.js spec/withLoginConf.js; node lib/cli.js spec/excludesConf.js; node_modules/.bin/minijasminenode jasminewd/spec/adapterSpec.js"
   },
   "license" : "MIT",
   "version": "0.17.0",

--- a/spec/basic/actions_exclude.js
+++ b/spec/basic/actions_exclude.js
@@ -1,0 +1,15 @@
+describe('a test that should not get run', function() {
+  beforeEach(function() {
+    browser.get('index.html#/form');
+  });
+
+  it('should deal with alerts', function() {
+    var alertButton = $('#alertbutton');
+    alertButton.click();
+    var alertDialog = browser.switchTo().alert();
+
+    expect(alertDialog.getText()).toEqual('Hello');
+
+    alertDialog.accept();
+  });
+});

--- a/spec/excludesConf.js
+++ b/spec/excludesConf.js
@@ -1,0 +1,23 @@
+// The main suite of Protractor tests.
+exports.config = {
+  seleniumAddress: 'http://localhost:4444/wd/hub',
+
+  // Spec patterns are relative to this directory.
+  specs: [
+    'basic/actions_*.js',
+    '!basic/*_exclude.js'
+  ],
+
+  capabilities: {
+    'browserName': 'chrome'
+  },
+
+  baseUrl: 'http://localhost:8000',
+
+  params: {
+    login: {
+      user: 'Jane',
+      password: '1234'
+    }
+  }
+};


### PR DESCRIPTION
This is an alternate fix for #464

Add a check that will allow spec files to be excluded if they are prefixed with a !

Ref #464
