### PR TITLE
Multi-argument matchers broken

### DIFF
--- a/jasminewd/spec/adapterSpec.js
+++ b/jasminewd/spec/adapterSpec.js
@@ -42,7 +42,12 @@ var getFakeDriver = function() {
       return flow.execute(function() {
         return webdriver.promise.fulfilled(1111);
       });
-    }
+    },
+    getDecimalNumber: function() {
+        return flow.execute(function() {
+          return webdriver.promise.fulfilled(3.14159);
+        });
+      }
   };
 };
 
@@ -110,6 +115,16 @@ describe('webdriverJS Jasmine adapter', function() {
     expect(500).toBeLotsMoreThan(3);
     expect(fakeDriver.getBigNumber()).toBeLotsMoreThan(33);
   });
+  
+  it('should pass multiple arguments to matcher', function() {
+      // Passing specific precision
+      expect(fakeDriver.getDecimalNumber()).toBeCloseTo(3.1, 1);
+      expect(fakeDriver.getDecimalNumber()).not.toBeCloseTo(3.1, 2);
+      
+      // Using default precision (2)
+      expect(fakeDriver.getDecimalNumber()).not.toBeCloseTo(3.1);
+      expect(fakeDriver.getDecimalNumber()).toBeCloseTo(3.14);
+    });
 
   describe('not', function() {
     it('should still pass normal synchronous tests', function() {


### PR DESCRIPTION
Jasmine has multi-argument matchers, such as `toBeCloseTo`. They don't work with the promise wrapper - only the first argument is passed to the actual matcher.

In this test code:

```
expect(20.0123).toBeCloseTo(20, 0);
var d = protractor.promise.defer();
d.fulfill(20.0123);
expect(d.promise).toBeCloseTo(20, 0);
```

The first assertion passes, but the second does not (falling back to default, which is 2 decimal places).
