### PR TITLE
feat(runner): add adapter for cucumber.js

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -229,17 +229,32 @@ var runTests = function() {
   }
   var specs = config.specs;
   var resolvedSpecs = [];
-  for (var i = 0; i < specs.length; ++i) {
-    var matches = glob.sync(specs[i], {cwd: config.configDir});
+  var i, j, matches;
+  for (i = 0; i < specs.length; ++i) {
+    matches = glob.sync(specs[i], {cwd: config.configDir});
     if (!matches.length) {
       util.puts('Warning: pattern ' + specs[i] + ' did not match any files.');
     }
-    for (var j = 0; j < matches.length; ++j) {
+    for (j = 0; j < matches.length; ++j) {
       resolvedSpecs.push(path.resolve(config.configDir, matches[j]));
     }
   }
   if (!resolvedSpecs.length) {
     throw new Error('Spec patterns did not match any files.');
+  }
+  if (config.cucumberOpts && config.cucumberOpts.require) {
+    var cucumberRequire = config.cucumberOpts.require;
+    var cucumberResolvedRequire = [];
+    cucumberRequire = typeof cucumberRequire === 'string' ? [cucumberRequire] : cucumberRequire;
+    for (i = 0; i < cucumberRequire.length; ++i) {
+      matches = glob.sync(cucumberRequire[i], {cwd: config.configDir});
+      if (!matches.length) {
+        util.puts('Warning: pattern ' + cucumberRequire[i] + ' did not match any files.');
+      }
+      for (j = 0; j < matches.length; ++j) {
+        cucumberResolvedRequire.push(path.resolve(config.configDir, matches[j]));
+      }
+    }
   }
 
   // TODO: This should not be tied to the webdriver promise loop, it should use
@@ -279,7 +294,7 @@ var runTests = function() {
 
     // Do the framework setup here so that jasmine and mocha globals are
     // available to the onPrepare function.
-    var minijn, mocha;
+    var minijn, mocha, cucumber;
     if (config.framework === 'jasmine') {
       minijn = require('minijasminenode');
       require('../jasminewd');
@@ -308,6 +323,31 @@ var runTests = function() {
       });
 
       mocha.loadFiles();
+    } else if (config.framework === 'cucumber') {
+        var Cucumber = require('cucumber');
+        var execOptions = ['node', 'node_modules/.bin/cucumber-js'];
+        execOptions = execOptions.concat(resolvedSpecs);
+
+        if (config.cucumberOpts) {
+
+          if (cucumberResolvedRequire && cucumberResolvedRequire.length) {
+            execOptions.push('-r');
+            execOptions = execOptions.concat(cucumberResolvedRequire);
+          }
+
+          if (config.cucumberOpts.tags) {
+            execOptions.push('-t');
+            execOptions.push(config.cucumberOpts.tags);
+          }
+
+          if (config.cucumberOpts.format) {
+            execOptions.push('-f');
+            execOptions.push(config.cucumberOpts.format);
+          }
+
+        }
+
+        cucumber = Cucumber.Cli(execOptions);
     } else {
       throw 'config.framework ' + config.framework +
           ' is not a valid framework.';
@@ -350,6 +390,18 @@ var runTests = function() {
               results: function() {
                 return {
                   failedCount: failures
+                };
+              }
+            });
+          });
+        });
+      } else if (config.framework === 'cucumber') {
+        cucumber.run(function(succeeded) {
+          driver.quit().then(function() {
+            runDeferred.fulfill({
+              results: function() {
+                return {
+                  failedCount: succeeded ? 0 : 1
                 };
               }
             });

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "chai-as-promised": "~4.1.0",
     "jasmine-reporters": "~0.2.1",
     "mocha": "~1.16.0",
+    "cucumber": "~0.3.3",
     "express": "~3.3.4",
     "mustache": "~0.7.2"
   },
@@ -38,7 +39,7 @@
   },
   "main": "lib/protractor.js",
   "scripts": {
-    "test": "node lib/cli.js spec/basicConf.js; node lib/cli.js spec/altRootConf.js; node lib/cli.js spec/onPrepareConf.js; node lib/cli.js spec/mochaConf.js; node lib/cli.js spec/withLoginConf.js; node_modules/.bin/minijasminenode jasminewd/spec/adapterSpec.js"
+    "test": "node lib/cli.js spec/basicConf.js; node lib/cli.js spec/altRootConf.js; node lib/cli.js spec/onPrepareConf.js; node lib/cli.js spec/mochaConf.js; node lib/cli.js spec/cucumberConf.js; node lib/cli.js spec/withLoginConf.js; node_modules/.bin/minijasminenode jasminewd/spec/adapterSpec.js"
   },
   "license" : "MIT",
   "version": "0.17.0",

--- a/referenceConf.js
+++ b/referenceConf.js
@@ -101,7 +101,7 @@ exports.config = {
 
   // ----- The test framework -----
   //
-  // Jasmine is fully supported as a test and assertion framework.
+  // Jasmine and Cucumber are fully supported as a test and assertion framework.
   // Mocha has limited beta support. You will need to include your own
   // assertion framework if working with mocha.
   framework: 'jasmine',
@@ -128,6 +128,18 @@ exports.config = {
   mochaOpts: {
     ui: 'bdd',
     reporter: 'list'
+  },
+
+  // ----- Options to be passed to cucumber -----
+  //
+  // See the full list by running cucumber.js --help
+  cucumberOpts: {
+    // Require files before executing the features.
+    require: 'cucumber/stepDefinitions.js',
+    // Only execute the features or scenarios with tags matching @dev.
+    tags: '@dev',
+    // How to format features (default: progress)
+    format: 'summary'
   },
 
   // ----- The cleanup step -----

--- a/spec/cucumber/lib.feature
+++ b/spec/cucumber/lib.feature
@@ -1,0 +1,15 @@
+Feature: Running Cucumber with Protractor
+  As a user of Protractor
+  I should be able to use Cucumber
+  to run my E2E tests
+
+  @dev
+  Scenario: Running Cucumber with Protractor
+    Given I run Cucumber with Protractor
+    Then it should still do normal tests
+    Then it should expose the correct global variables
+
+  @dev
+  Scenario: Wrapping WebDriver
+    Given I go on "index.html"
+    Then the title should equal "My AngularJS App"

--- a/spec/cucumber/stepDefinitions.js
+++ b/spec/cucumber/stepDefinitions.js
@@ -1,0 +1,38 @@
+// Use the external Chai As Promised to deal with resolving promises in
+// expectations.
+var chai = require('chai');
+var chaiAsPromised = require('chai-as-promised');
+chai.use(chaiAsPromised);
+
+var expect = chai.expect;
+
+module.exports = function() {
+
+    this.Given(/^I run Cucumber with Protractor$/, function(next) {
+        next();
+    });
+
+    this.Given(/^I go on(?: the website)? "([^"]*)"$/, function(url, next) {
+        browser.get(url);
+        next();
+    });
+
+    this.Then(/^it should still do normal tests$/, function(next) {
+        expect(true).to.equal(true);
+        next();
+    });
+
+    this.Then(/^it should expose the correct global variables$/, function(next) {
+        expect(protractor).to.exist;
+        expect(browser).to.exist;
+        expect(by).to.exist;
+        expect(element).to.exist;
+        expect($).to.exist;
+        next();
+    });
+
+    this.Then(/the title should equal "([^"]*)"$/, function(text, next) {
+        expect(browser.getTitle()).to.eventually.equal(text).and.notify(next);
+    });
+
+};

--- a/spec/cucumberConf.js
+++ b/spec/cucumberConf.js
@@ -1,0 +1,30 @@
+// A small suite to make sure the cucumber framework works.
+exports.config = {
+  seleniumAddress: 'http://localhost:4444/wd/hub',
+
+  framework: 'cucumber',
+
+  // Spec patterns are relative to this directory.
+  specs: [
+    'cucumber/*.feature'
+  ],
+
+  capabilities: {
+    'browserName': 'chrome'
+  },
+
+  baseUrl: 'http://localhost:8000',
+
+  params: {
+    login: {
+      user: 'Jane',
+      password: '1234'
+    }
+  },
+
+  cucumberOpts: {
+    require: 'cucumber/stepDefinitions.js',
+    tags: '@dev',
+    format: 'summary'
+  }
+};


### PR DESCRIPTION
As a fix for #15 I make an adapter for [Cucumber.js](https://github.com/cucumber/cucumber-js) to Protractor.

Like the other adapters (Jasmine, Mocha), the Cucumber adapter is merged in lib/runner.js. (Not perfect, I think there is room for improvement here).

It adds a new configuration parameter `cucumberOpts` that can be used to pass parameter to the Cucumber instance. The `steps`, `tags` and `format` options are supported.

Config file example:

``` javascript
exports.config = {
  seleniumAddress: 'http://localhost:4444/wd/hub',

  framework: 'cucumber',

  specs: [
    'cucumber/*.feature'
  ],

  capabilities: {
    'browserName': 'chrome'
  },

  baseUrl: 'http://localhost:8000',

  cucumberOpts: {
    require: 'cucumber/definitions',
    tags: '@dev',
    format: 'pretty'
  }
}
```

You can read the Cucumber.js CLI documentation for more informations about options.

I also added some tests (inspired by the Jasmine one's) in `spec`, they was added to the main `npm test` script.
