### PR TITLE
feat(locators): Added a By.cssContainingText locator.

### DIFF
--- a/lib/clientsidescripts.js
+++ b/lib/clientsidescripts.js
@@ -486,6 +486,32 @@ clientSideScripts.findTextareas = function() {
 };
 
 /**
+ * Find elements by css selector and textual content.
+ *
+ * arguments[0] {string} The css selector to match.
+ * arguments[1] {string} The exact text to match.
+ * arguments[2] {Element} The scope of the search.
+ *
+ * @return {Array.<Element>} The matching elements.
+ */
+clientSideScripts.findByCssContainingText = function() {
+  var cssSelector = arguments[0];
+  var searchText = arguments[1];
+  var using = arguments[2] || document;
+  var elements = using.querySelectorAll(cssSelector);
+  var matches = [];
+  for (var i = 0; i < elements.length; ++i) {
+    var element = elements[i];
+    var elementText = element.innerText || element.textContent;
+    if (elementText.indexOf(searchText) > -1) {
+      matches.push(element);
+    }
+  }
+
+  return matches;
+};
+
+/**
  * Tests whether the angular global variable is present on a page. Retries
  * in case the page is just loading slowly.
  *

--- a/lib/locators.js
+++ b/lib/locators.js
@@ -239,4 +239,20 @@ ProtractorBy.prototype.repeater = function(repeatDescriptor) {
   };
 };
 
+/**
+ * Usage:
+ *   <ul><li class="pet">Dog</li></ul>
+ *   element(by.cssContainingText("ul .pet", "Dog"));
+ */
+ProtractorBy.prototype.cssContainingText = function(cssSelector, searchText) {
+  return {
+    findElementsOverride: function(driver, using) {
+      return driver.findElements(
+        webdriver.By.js(clientSideScripts.findByCssContainingText),
+        cssSelector, searchText, using);
+    },
+    message: 'by.cssContainingText("' + cssSelector + '", "' + searchText + '")'
+  };
+};
+
 exports.ProtractorBy = ProtractorBy;

--- a/spec/basic/findelements_spec.js
+++ b/spec/basic/findelements_spec.js
@@ -330,6 +330,16 @@ describe('locators', function() {
     });
   });
 
+  describe('by css containing text', function () {
+    it('should find elements by css and partial text', function () {
+      element.all(by.cssContainingText('#inner ul .pet', 'dog')).then(function(arr) {
+        expect(arr.length).toEqual(2);
+        expect(arr[0].getAttribute('id')).toBe('bigdog');
+        expect(arr[1].getAttribute('id')).toBe('smalldog');
+      });
+    });
+  });
+
   it('should determine if an element is present', function() {
     expect(browser.isElementPresent(by.binding('greet'))).toBe(true);
     expect(browser.isElementPresent(by.binding('nopenopenope'))).toBe(false);

--- a/testapp/form/form.html
+++ b/testapp/form/form.html
@@ -69,3 +69,13 @@
   <input type="submit" value="Exact text" id="submitbutton"/>
   <input type="button" value="Hello text" id="inputbutton"/>
 </div>
+
+<div id="inner">
+  <h4>Inner text</h4>
+  <ul>
+    <li class="pet" id="bigdog">Big dog</li>
+    <li class="pet" id="smalldog">Small dog</li>
+    <li class="notpet" id="otherdog">Other dog</li>
+    <li class="pet" id="cat">Cat</li>
+  </ul>
+</div>


### PR DESCRIPTION
This new locator find elements by css selector and inner text in response to the lack of ':contains' selector.

Example: By.cssContainingText('ul .pet', 'Dog') will find all ul children with class 'pet' containing the text 'Dog'.
