### PR TITLE
fix(webdriver-manager): upcase in IE download url

### DIFF
--- a/bin/webdriver-manager
+++ b/bin/webdriver-manager
@@ -59,7 +59,7 @@ var binaries = {
         if (os.arch() == 'x64') {
           return urlPrefix + '_x64_' + versions.iedriver + '.zip';
         } else {
-          return urlPrefix + '_win32_' + versions.iedriver + '.zip';
+          return urlPrefix + '_Win32_' + versions.iedriver + '.zip';
         }
       }
     }


### PR DESCRIPTION
The url for the Win32 version of the IEDriverServer is apparently case
sensitive: _win32_ vs _Win32_. Without the change, I get an invalid zip
error with the downloaded file:

```
downloading https://selenium.googlecode.com/files/IEDriverServer_win32_2.39.0.zip...
IEDriverServer_2.39.0.zip downloaded to C:\Users\Daniel\AppData\Roaming\npm\node_modules\protractor\selenium\IEDriverServer_2.39.0.zip

C:\Users\Daniel\AppData\Roaming\npm\node_modules\protractor\node_modules\adm-zip\zipFile.js:66
            throw Utils.Errors.INVALID_FORMAT;
                              ^
Invalid or unsupported zip format. No END header found
```

```
c:\Users\Daniel\protractor>curl -s -D - https://selenium.googlecode.com/files/IEDriverServer_win32_2.39.0.zip -o $null
HTTP/1.1 404 Not Found
[...]

c:\Users\Daniel\protractor>curl -s -D - https://selenium.googlecode.com/files/IEDriverServer_Win32_2.39.0.zip -o $null
HTTP/1.1 200 OK
[...]
```

Feel free to close the PR in favor of wrapping in this tiny change with other 
things, if that's easier for you!
