### PR TITLE
fix(cli): convert capabilities arguments to dot-notation for WebDriver compatibility

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -83,6 +83,21 @@ if (argv.exclude) {
   argv.exclude = processFilePatterns(argv.exclude);
 }
 
+// WebDriver capabilities properties require dot notation
+var flattenObject = function(obj) {
+  var prefix = arguments[1] || '';
+  var out = arguments[2] || {};
+    for (var prop in obj) {
+      if (obj.hasOwnProperty(prop)) {
+        typeof obj[prop] === 'object' ? flattenObject(obj[prop], prefix + prop + '.', out) : out[prefix + prop] = obj[prop];
+      }
+    }
+  return out;
+}
+if (argv.capabilities) {
+  argv.capabilities = flattenObject(argv.capabilities);
+}
+
 ['seleniumServerJar', 'chromeDriver', 'onPrepare'].forEach(function(name) {
   if (argv[name]) {
     argv[name] = path.resolve(process.cwd(), argv[name]);


### PR DESCRIPTION
WebDriver requires capabilities properties to be written in dot-notation, like when specifying the path of PhantomJS for instance:

```
capabilities: {
  'phantomjs.binary.path': 'node_modules/phantomjs/bin/phantomjs'
}
```

But when setting this path using the command line like this:

```
protractor --capabilities.phantomjs.binary.path node_modules/phantomjs/bin/phantomjs
```

`cli.js` converts this setting to a nested object:

```
{  capabilities: 
   { browserName: [ 'phantomjs', 'phantomjs' ],
     phantomjs: { binary: [Object] }
```

The nested object doesn't get interpreted, so PhantomJS can't be executed.

It's highly desirable to be able to configure Protractor entirely by a command-line command as Protractor gets configured that way by tools like Grunt. Currently that's not possible though due to this limitation.
