### PR TITLE
Remove unnecessary quotes around 'browserName'

### DIFF
--- a/referenceConf.js
+++ b/referenceConf.js
@@ -66,7 +66,7 @@ exports.config = {
   // and
   // https://code.google.com/p/selenium/source/browse/javascript/webdriver/capabilities.js
   capabilities: {
-    'browserName': 'chrome'
+    browserName: 'chrome'
   },
 
   // If you would like to run more than one instance of webdriver on the same


### PR DESCRIPTION
`browserName` is a valid key without the quotes, so I removed them.
