### PR TITLE
fix(configParser): load coffee and livescript for child processes

### DIFF
--- a/lib/configParser.js
+++ b/lib/configParser.js
@@ -3,6 +3,20 @@ var path = require('path'),
     util = require('util'),
     protractor = require('./protractor.js');
 
+// Coffee is required here to enable config files written in coffee-script.
+try {
+  // 
+  require('coffee-script').register();
+} catch (e) {
+  // Intentionally blank - ignore if coffee-script is not available.
+}
+
+// LiveScript is required here to enable config files written in LiveScript.
+try {
+  require('LiveScript');
+} catch (e) {
+  // Intentionally blank - ignore if LiveScript is not available.
+}
 
 module.exports = ConfigParser = function() {
   // Default configuration.


### PR DESCRIPTION
Without loading coffee in configParser.js, child processes which try and load a coffeescript config file do not have coffee registered with node's required, and child tests fail.

Fixes an issue with using coffeescript config files.

This code was copypasta from cli.js, but fixes my issue with using coffeescript config files.
