### PR TITLE
fix(locators): addLocator with multiple arguments

### DIFF
--- a/lib/locators.js
+++ b/lib/locators.js
@@ -29,15 +29,29 @@ util.inherits(ProtractorBy, WebdriverBy);
  *     that contains any args passed into the locator followed by the
  *     element scoping the search. It should return an array of elements.
  */
-ProtractorBy.prototype.addLocator = function(name, script) {
-  this[name] = function(varArgs) {
+ProtractorBy.prototype.addLocator = function (name, script) {
+  this[name] = function () {
+    var locatorArguments = toArray(arguments);
     return {
-      findElementsOverride: function(driver, using) {
-        return driver.findElements(
-          webdriver.By.js(script), varArgs, using);
+      findElementsOverride: function (driver, using) {
+        return driver.findElements.apply(driver, buildFindElementsArguments(
+          webdriver.By.js(script), locatorArguments, using));
       },
-      message: 'by.' + name + '("' + varArgs + '")'
+      message: 'by.' + name + '("' + locatorArguments + '")'
     };
+    function toArray(arguments) {
+      var locatorArguments = [];
+      for (var i = 0; i < arguments.length; i++) {
+        locatorArguments.push(arguments[i]);
+      }
+      return locatorArguments;
+    }
+    function buildFindElementsArguments(locator, locatorArguments, scope) {
+      var findArguments = locatorArguments.slice(0);
+      findArguments.unshift(locator);
+      findArguments.push(scope);
+      return findArguments;
+    }
   };
 };
 

--- a/spec/basic/lib_spec.js
+++ b/spec/basic/lib_spec.js
@@ -69,6 +69,28 @@ describe('protractor library', function() {
     expect(element(by.menuItem('repeater')).getText()).toEqual('repeater');
   });
 
+  it('should allow adding custom varargs locators', function() {
+    var findMenuItemWithName = function() {
+      var css = arguments[0];
+      var itemName = arguments[1];
+      var using = arguments[2]; // unused
+      var menu = document.querySelectorAll(css);
+      for (var i = 0; i < menu.length; ++i) {
+        if (menu[i].textContent == itemName) {
+          return [menu[i]];
+        }
+      }
+    };
+
+    by.addLocator('menuItemWithName', findMenuItemWithName);
+
+    expect(by.menuItemWithName).toBeDefined();
+
+    browser.get('index.html');
+    expect(element(by.menuItemWithName('.menu li', 'repeater')).isPresent());
+    expect(element(by.menuItemWithName('.menu li', 'repeater')).getText()).toEqual('repeater');
+  });
+
   describe('helper functions', function() {
     it('should get the absolute URL', function() {
       browser.get('index.html');


### PR DESCRIPTION
When using a custom locator with multiple arguments, only the first argument was used when calling `webdriver.findElements`.
