### PR TITLE
feat(framework.cucumber): Allow multiple tags on cucumber tests.

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -132,7 +132,13 @@ Runner.prototype.runCucumber_ = function(specs, done) {
     }
 
     // Process Cucumber Tag param
-    if (self.config_.cucumberOpts.tags) {
+    if (Array.isArray(self.config_.cucumberOpts.tags)) {
+        for (var i in self.config_.cucumberOpts.tags) {
+            var tags = self.config_.cucumberOpts.tags[i];
+            execOptions.push('-t');
+            execOptions.push(tags);
+        }
+    } else if (self.config_.cucumberOpts.tags) {
       execOptions.push('-t');
       execOptions.push(self.config_.cucumberOpts.tags);
     }


### PR DESCRIPTION
Motivation:
Support for multiple tags on the cucumber test execution, to be able to filter with more complex expressions the scenarios to run.

How to use:

```
cucumberOpts: {
    tags: '@dev'
}
```

or

```
cucumberOpts: {
    tags: ['@dev', '~@ignore']
}
```

More information on tags:
https://github.com/cucumber/cucumber/wiki/Tags
