### PR TITLE
Full stack trace on expectation failures and WebDriver exceptions

### DIFF
--- a/debugging/failure_spec.js
+++ b/debugging/failure_spec.js
@@ -15,6 +15,11 @@ describe('modes of failure', function() {
     var nonExistant = element(by.binding('nopenopenope')).getText();
   });
 
+  it('should fail to click a hidden element', function () {
+    browser.get('index.html#/form');
+    element(by.id("hiddenbutton")).click();
+  });
+
   it('should fail to use protractor on a non-Angular site', function() {
     browser.get('http://www.google.com');
   }, 20000);

--- a/testapp/form/form.html
+++ b/testapp/form/form.html
@@ -66,6 +66,7 @@
   <button id="exacttext">Exact text</button>
   <button id="otherbutton">Partial button text</button>
   <button id="trapbutton">No match</button>
+  <button id="hiddenbutton" style="display:none">Can't see me!</button>
   <input type="submit" value="Exact text" id="submitbutton"/>
   <input type="button" value="Hello text" id="inputbutton"/>
 </div>


### PR DESCRIPTION
It's very convenient to see exactly which line in my spec a failure came from, but protractor's jasmine output normally doesn't include that information. This PR adds that information in by recording the stack at the time of the original call to expect().

There is probably be a better way to do this, it's pretty hacky as-is. I'm mostly posting this PR as a way of soliciting suggestions for the right way to solve the problem.
