### PR TITLE
Display error message when runner fails

### DIFF
--- a/lib/runFromLauncher.js
+++ b/lib/runFromLauncher.js
@@ -31,6 +31,10 @@ process.on('message', function(m) {
       var runner = new Runner(config);
       runner.run().then(function(exitCode) {
         process.exit(exitCode);
+      }).catch(function(err) {
+        console.log(err.message);
+
+        process.exit();
       });
       break;
     default:


### PR DESCRIPTION
When running protractor without the `chromedriver` installed the process stalls without any error message.
