### PR TITLE
Fix --verbose and --stackTrace options

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -58,6 +58,8 @@ var argv = require('optimist').
     alias('verbose', 'jasmineNodeOpts.isVerbose').
     alias('stackTrace', 'jasmineNodeOpts.includeStackTrace').
     string('capabilities.tunnel-identifier').
+    boolean('verbose').
+    boolean('stackTrace').
     check(function(arg) {
       if (arg._.length > 1) {
         throw 'Error: more than one config file specified';


### PR DESCRIPTION
They should be booleans and not eat away arguments following them. E.g.:

--verbose debug config.js

would break before this change.
