### PR TITLE
(feature):Aysc promises in config

### DIFF
--- a/lib/configParser.js
+++ b/lib/configParser.js
@@ -2,6 +2,7 @@ var path = require('path'),
     glob = require('glob'),
     util = require('util'),
     _ = require('lodash'),
+    Q = require('q'),
     protractor = require('./protractor.js');
 
 // Coffee is required here to enable config files written in coffee-script.
@@ -46,6 +47,7 @@ module.exports = ConfigParser = function() {
     chromeDriver: null,
     configDir: './'
   };
+  this.configMergeQueue_ = [this.config_];
 };
 
 /**
@@ -97,7 +99,7 @@ ConfigParser.resolveFilePatterns =
     for (var i = 0; i < patterns.length; ++i) {
       var matches = glob.sync(patterns[i], {cwd: cwd});
       if (!matches.length && !opt_omitWarnings) {
-        util.puts('Warning: pattern ' + patterns[i] + ' did not match any files.');
+        util.puts('Warning: pattern ' + patterns[i] + ' did not match any files in' + cwd);
       }
       for (var j = 0; j < matches.length; ++j) {
         resolvedFiles.push(path.resolve(cwd, matches[j]));
@@ -132,23 +134,31 @@ ConfigParser.getSpecs = function(config) {
  * @param {Object} additionalConfig
  * @param {string} relativeTo the file path to resolve paths against
  */
-ConfigParser.prototype.addConfig_ = function(additionalConfig, relativeTo) {
-  // All filepaths should be kept relative to the current config location.
-  // This will not affect absolute paths.
-  ['seleniumServerJar', 'chromeDriver', 'onPrepare'].forEach(function(name) {
-    if (additionalConfig[name] && typeof additionalConfig[name] === 'string') {
-      additionalConfig[name] =
-          path.resolve(relativeTo, additionalConfig[name]);
-    }
-  });
+ConfigParser.prototype.addConfig_ = function(additionalConfig, relativeTo, setConfigDir) {
+  this.configMergeQueue_.push(Q(additionalConfig).then(function(additionalConfig){
+    // All filepaths should be kept relative to the current config location.
+    // This will not affect absolute paths.
 
-  // Make sure they're not trying to add in deprecated config vals.
-  if (additionalConfig.jasmineNodeOpts &&
-        additionalConfig.jasmineNodeOpts.specFolders) {
-    throw new Error('Using config.jasmineNodeOpts.specFolders is deprecated ' +
-        'since Protractor 0.6.0. Please switch to config.specs.');
-  }
-  merge_(this.config_, additionalConfig);
+    ['seleniumServerJar', 'chromeDriver', 'onPrepare'].forEach(function(name) {
+      if (additionalConfig[name] && typeof additionalConfig[name] === 'string') {
+        additionalConfig[name] =
+            path.resolve(relativeTo, additionalConfig[name]);
+      }
+    });
+
+    // Make sure they're not trying to add in deprecated config vals.
+    if (additionalConfig.jasmineNodeOpts &&
+          additionalConfig.jasmineNodeOpts.specFolders) {
+      throw new Error('Using config.jasmineNodeOpts.specFolders is deprecated ' +
+          'since Protractor 0.6.0. Please switch to config.specs.');
+    }
+    if (setConfigDir){
+      additionalConfig.configDir = relativeTo;
+    }
+    return additionalConfig;
+  }, function(err){
+    throw err;
+  }));
 };
 
 /**
@@ -163,8 +173,7 @@ ConfigParser.prototype.addFileConfig = function(filename) {
   }
   var filePath = path.resolve(process.cwd(), filename);
   var fileConfig = require(filePath).config;
-  fileConfig.configDir = path.dirname(filePath);
-  this.addConfig_(fileConfig, fileConfig.configDir);
+  this.addConfig_(fileConfig, path.dirname(filePath), true);
   return this;
 };
 
@@ -176,7 +185,7 @@ ConfigParser.prototype.addFileConfig = function(filename) {
  * @param {Object} argv
  */
 ConfigParser.prototype.addConfig = function(argv) {
-  this.addConfig_(argv, process.cwd());
+  this.addConfig_(argv, process.cwd(), false);
   return this;
 };
 
@@ -188,5 +197,11 @@ ConfigParser.prototype.addConfig = function(argv) {
  * @return {Object} config
  */
 ConfigParser.prototype.getConfig = function() {
-  return this.config_;
+  // Start resolving all the configurations before merging them
+  return this.configMergeQueue_.reduce(function(prevValue, currentValue){
+    return Q.allSettled([prevValue, currentValue]).then(function(val){
+      // All configurations (promises or objects) are now resolved, so merge them
+      return merge_(val[0].value, val[1].value);
+    });
+  }, {});
 };

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -83,133 +83,135 @@ var init = function(argv) {
     });
   };
 
-  if (config.multiCapabilities.length) {
-    if (config.debug) {
-      throw new Error('Cannot run in debug mode with multiCapabilities');
-    }
-    log_('Running using config.multiCapabilities - ' +
-        'config.capabilities will be ignored');
-  }
-
-  // Merge 'capabilities' and 'multiCapabilities', if applicable.
-  if (!config.multiCapabilities.length) {
-    config.multiCapabilities = [config.capabilities];
-  }
-
-  // Loop through capabilities and launch forks of runner.js
-  for (var i = 0; i < config.multiCapabilities.length; i++) {
-
-    // Determine how many times to run the capability
-    capabilityRunCount = (config.multiCapabilities[i].count) ?
-        config.multiCapabilities[i].count : 1;
-
-    // Fork the child runners.
-    for (var j = 0; j < capabilityRunCount; j++) {
-      childForks.push({
-        cliArgs: argv,
-        capability: config.multiCapabilities[i],
-        runNumber: j + 1
-      });
-    }
-  }
-
-  // If we're launching multiple runners, aggregate output until completion.
-  // Otherwise, there is a single runner, let's pipe the output straight
-  // through to maintain realtime reporting.
-  if (childForks.length === 1) {
-    var childFork = childForks[0];
-    childFork.process = child.fork(
-        __dirname + "/runFromLauncher.js",
-        process.argv.slice(2),
-        {cwd: process.cwd()});
-    reportHeader_(childFork);
-
-    childFork.process.send({
-      command: 'run',
-      cliArgs: childFork.cliArgs,
-      capability: childFork.capability
-    });
-
-    childFork.process.on('error', function(err) {
-      log_('Runner Process(' + childFork.process.pid + ') Error: ' + err);
-    });
-
-
-    childFork.process.on('message', function(m) {
-      switch (m.event) {
-        case 'testsDone':
-          childFork.failedCount = m.failedCount;
-          break;
+  config.then(function(config){
+    if (config.multiCapabilities.length) {
+      if (config.debug) {
+        throw new Error('Cannot run in debug mode with multiCapabilities');
       }
-    });
+      log_('Running using config.multiCapabilities - ' +
+          'config.capabilities will be ignored');
+    }
 
-    childFork.process.on('exit', function(code, signal) {
-      if (code) {
-        log_('Runner Process Exited With Error Code: ' + code);
-        launcherExitCode = 1;
+    // Merge 'capabilities' and 'multiCapabilities', if applicable.
+    if (!config.multiCapabilities.length) {
+      config.multiCapabilities = [config.capabilities];
+    }
+
+    // Loop through capabilities and launch forks of runner.js
+    for (var i = 0; i < config.multiCapabilities.length; i++) {
+
+      // Determine how many times to run the capability
+      capabilityRunCount = (config.multiCapabilities[i].count) ?
+          config.multiCapabilities[i].count : 1;
+
+      // Fork the child runners.
+      for (var j = 0; j < capabilityRunCount; j++) {
+        childForks.push({
+          cliArgs: argv,
+          capability: config.multiCapabilities[i],
+          runNumber: j + 1
+        });
       }
-    });
-  } else {
-    noLineLog_('Running ' + childForks.length +
-        ' instances of WebDriver');
+    }
 
-    // Launch each fork and set up listeners
-    childForks.forEach(function(childFork) {
-
+    // If we're launching multiple runners, aggregate output until completion.
+    // Otherwise, there is a single runner, let's pipe the output straight
+    // through to maintain realtime reporting.
+    if (childForks.length === 1) {
+      var childFork = childForks[0];
       childFork.process = child.fork(
-          __dirname + "/runFromLauncher.js", process.argv.slice(2),
-          {silent: true, cwd: process.cwd()});
-
-      childFork.output = '';
-
-      // stdin pipe
-      childFork.process.stdout.on('data', function(chunk) {
-        childFork.output += chunk;
-      });
-
-      // stderr pipe
-      childFork.process.stderr.on('data', function(chunk) {
-        childFork.output += chunk;
-      });
-
-      childFork.process.on('message', function(m) {
-        switch (m.event) {
-          case 'testPass':
-            process.stdout.write('.');  
-            break;
-          case 'testFail':
-            process.stdout.write('F');
-            break;
-          case 'testsDone':
-            childFork.failedCount = m.failedCount;
-            break;
-        }
-      });
-
-      // err handler
-      childFork.process.on('error', function(err) {
-        log_('Runner Process(' + childFork.process.pid + ') Error: ' + err);
-      });
-
-      // exit handlers
-      childFork.process.on('exit', function(code, signal) {
-        if (code) {
-          log_('Runner Process Exited With Error Code: ' + code);
-          launcherExitCode = 1;
-        }
-        reportHeader_(childFork);
-        util.puts(childFork.output);
-        childFork.done = true;
-        listRemainingForks();
-      });
+          __dirname + "/runFromLauncher.js",
+          process.argv.slice(2),
+          {cwd: process.cwd()});
+      reportHeader_(childFork);
 
       childFork.process.send({
         command: 'run',
         cliArgs: childFork.cliArgs,
         capability: childFork.capability
       });
-    });
-  }
+
+      childFork.process.on('error', function(err) {
+        log_('Runner Process(' + childFork.process.pid + ') Error: ' + err);
+      });
+
+
+      childFork.process.on('message', function(m) {
+        switch (m.event) {
+          case 'testsDone':
+            childFork.failedCount = m.failedCount;
+            break;
+        }
+      });
+
+      childFork.process.on('exit', function(code, signal) {
+        if (code) {
+          log_('Runner Process Exited With Error Code: ' + code);
+          launcherExitCode = 1;
+        }
+      });
+    } else {
+      noLineLog_('Running ' + childForks.length +
+          ' instances of WebDriver');
+
+      // Launch each fork and set up listeners
+      childForks.forEach(function(childFork) {
+
+        childFork.process = child.fork(
+            __dirname + "/runFromLauncher.js", process.argv.slice(2),
+            {silent: true, cwd: process.cwd()});
+
+        childFork.output = '';
+
+        // stdin pipe
+        childFork.process.stdout.on('data', function(chunk) {
+          childFork.output += chunk;
+        });
+
+        // stderr pipe
+        childFork.process.stderr.on('data', function(chunk) {
+          childFork.output += chunk;
+        });
+
+        childFork.process.on('message', function(m) {
+          switch (m.event) {
+            case 'testPass':
+              process.stdout.write('.');
+              break;
+            case 'testFail':
+              process.stdout.write('F');
+              break;
+            case 'testsDone':
+              childFork.failedCount = m.failedCount;
+              break;
+          }
+        });
+
+        // err handler
+        childFork.process.on('error', function(err) {
+          log_('Runner Process(' + childFork.process.pid + ') Error: ' + err);
+        });
+
+        // exit handlers
+        childFork.process.on('exit', function(code, signal) {
+          if (code) {
+            log_('Runner Process Exited With Error Code: ' + code);
+            launcherExitCode = 1;
+          }
+          reportHeader_(childFork);
+          util.puts(childFork.output);
+          childFork.done = true;
+          listRemainingForks();
+        });
+
+        childFork.process.send({
+          command: 'run',
+          cliArgs: childFork.cliArgs,
+          capability: childFork.capability
+        });
+      });
+    }
+  });
 
   process.on('exit', function(code) {
     logSummary();

--- a/lib/runFromLauncher.js
+++ b/lib/runFromLauncher.js
@@ -24,35 +24,39 @@ process.on('message', function(m) {
           addConfig(argv).
           getConfig();
 
-      // Grab capability to run from launcher.
-      config.capabilities = m.capability;
+      config.then(function(config){
+        // Grab capability to run from launcher.
+        config.capabilities = m.capability;
 
-      // Launch test run.
-      var runner = new Runner(config);
+        // Launch test run.
+        var runner = new Runner(config);
 
-      // Pipe events back to the launcher.
-      runner.on('testPass', function() {
-        process.send({
-          event: 'testPass'
+        // Pipe events back to the launcher.
+        runner.on('testPass', function() {
+          process.send({
+            event: 'testPass'
+          });
         });
-      });
-      runner.on('testFail', function() {
-        process.send({
-          event: 'testFail'
+        runner.on('testFail', function() {
+          process.send({
+            event: 'testFail'
+          });
         });
-      });
-      runner.on('testsDone', function(failedCount) {
-        process.send({
-          event: 'testsDone',
-          failedCount: failedCount
+        runner.on('testsDone', function(failedCount) {
+          process.send({
+            event: 'testsDone',
+            failedCount: failedCount
+          });
         });
-      });
 
-      runner.run().then(function(exitCode) {
-        process.exit(exitCode);
-      }).catch(function(err) {
-        console.log(err.message);
-        process.exit(1);
+        runner.run().then(function(exitCode) {
+          process.exit(exitCode);
+        }).catch(function(err) {
+          console.log(err.message);
+          process.exit(1);
+        });
+      }, function(err){
+        throw err;
       });
       break;
     default:

--- a/spec/unit/config_test.js
+++ b/spec/unit/config_test.js
@@ -1,66 +1,146 @@
 var ConfigParser = require('../../lib/configParser');
-var path = require('path');
+var path = require('path'),
+  Q = require('q');
 
 describe('the config parser', function() {
 
-  it('should have a default config', function() {
-    var config = new ConfigParser().getConfig();
-    expect(config.specs).toEqual([]);
-    expect(config.rootElement).toEqual('body');
+  it('should have a default config', function(done) {
+    var config = new ConfigParser().getConfig().then(function(config){
+      expect(config.specs).toEqual([]);
+      expect(config.rootElement).toEqual('body');
+      done();
+    });
   });
 
-  it('should merge in config from an object', function() {
+  it('should merge in config from an object', function(done) {
     var toAdd = {
       rootElement: '.mydiv'
     }
-    var config = new ConfigParser().addConfig(toAdd).getConfig();
-    expect(config.specs).toEqual([]);
-    expect(config.rootElement).toEqual('.mydiv');
+    var config = new ConfigParser().addConfig(toAdd).getConfig().then(function(config){
+      expect(config.specs).toEqual([]);
+      expect(config.rootElement).toEqual('.mydiv');
+      done();
+    });
   });
 
-  it('should merge in config from a file', function() {
+  it('should merge in config from a file', function(done) {
     var config = new ConfigParser().
         addFileConfig(__dirname + '/data/config.js').
-        getConfig();
-
-    expect(config.rootElement).toEqual('.mycontainer');
-    expect(config.onPrepare.indexOf(path.normalize('/spec/unit/data/foo/bar.js'))).not.toEqual(-1);
-    expect(config.specs.length).toEqual(1);
-    expect(config.specs[0]).toEqual('fakespec*.js');
+        getConfig().
+        then(function(config){
+          expect(config.rootElement).toEqual('.mycontainer');
+          expect(config.onPrepare.indexOf(path.normalize('/spec/unit/data/foo/bar.js'))).not.toEqual(-1);
+          expect(config.specs.length).toEqual(1);
+          expect(config.specs[0]).toEqual('fakespec*.js');
+          done();
+        });
   });
 
-  it('should keep filepaths relative to the cwd when merging', function() {
+  it('should keep filepaths relative to the cwd when merging', function(done) {
     var toAdd = {
       onPrepare: 'baz/qux.js'
     }
 
-    var config = new ConfigParser().addConfig(toAdd).getConfig();
-
-    expect(config.onPrepare).toEqual(path.normalize(process.cwd() + '/baz/qux.js'));
+    var config = new ConfigParser().addConfig(toAdd).getConfig().then(function(config){
+      expect(config.onPrepare).toEqual(path.normalize(process.cwd() + '/baz/qux.js'));
+      done();
+    });
   });
 
   describe('resolving globs', function() {
-    it('should resolve relative to the cwd', function() {
-      spyOn(process, 'cwd').andReturn(__dirname + '/');
+    it('should resolve relative to the cwd', function(done) {
       var toAdd = {
         specs: 'data/*spec*.js'
       }
-      var config = new ConfigParser().addConfig(toAdd).getConfig();
-      var specs = ConfigParser.resolveFilePatterns(config.specs);
-      expect(specs.length).toEqual(2);
-      expect(specs[0].indexOf(path.normalize('unit/data/fakespecA.js'))).not.toEqual(-1);
-      expect(specs[1].indexOf(path.normalize('unit/data/fakespecB.js'))).not.toEqual(-1);
+      var config = new ConfigParser().addConfig(toAdd).getConfig().then(function(config){
+        spyOn(process, 'cwd').andReturn(__dirname + '/');
+        var specs = ConfigParser.resolveFilePatterns(config.specs);
+        expect(specs.length).toEqual(2);
+        expect(specs[0].indexOf(path.normalize('unit/data/fakespecA.js'))).not.toEqual(-1);
+        expect(specs[1].indexOf(path.normalize('unit/data/fakespecB.js'))).not.toEqual(-1);
+        done();
+      });
     });
 
-    it('should resolve relative to the config file dir', function() {
+    it('should resolve relative to the config file dir', function(done) {
       var config = new ConfigParser().
           addFileConfig(__dirname + '/data/config.js').
-          getConfig();
-      var specs = ConfigParser.resolveFilePatterns(
-          config.specs, false, config.configDir);
-      expect(specs.length).toEqual(2);
-      expect(specs[0].indexOf(path.normalize('unit/data/fakespecA.js'))).not.toEqual(-1);
-      expect(specs[1].indexOf(path.normalize('unit/data/fakespecB.js'))).not.toEqual(-1);
+          getConfig().then(function(config){
+            var specs = ConfigParser.resolveFilePatterns(config.specs, false, config.configDir);
+            expect(specs.length).toEqual(2);
+            expect(specs[0].indexOf(path.normalize('unit/data/fakespecA.js'))).not.toEqual(-1);
+            expect(specs[1].indexOf(path.normalize('unit/data/fakespecB.js'))).not.toEqual(-1);
+            done();
+          });
+    });
+  });
+
+  describe('with promises', function() {
+
+    it('should merge in config from an object', function(done) {
+      var toAdd = Q({
+        rootElement: '.mydiv'
+      }).delay(1);
+
+      var config = new ConfigParser().addConfig(toAdd).getConfig().then(function(config){
+        expect(config.specs).toEqual([]);
+        expect(config.rootElement).toEqual('.mydiv');
+        done();
+      });
+    });
+
+    it('should merge in config from a file', function(done) {
+      var config = new ConfigParser().
+          addFileConfig(__dirname + '/data/config.promise.js').
+          getConfig().
+          then(function(config){
+            expect(config.rootElement).toEqual('.mycontainer');
+            expect(config.onPrepare.indexOf(path.normalize('/spec/unit/data/foo/bar.js'))).not.toEqual(-1);
+            expect(config.specs.length).toEqual(1);
+            expect(config.specs[0]).toEqual('fakespec*.js');
+            done();
+          });
+    });
+
+    it('should keep filepaths relative to the cwd when merging', function(done) {
+      var toAdd = Q({
+        onPrepare: 'baz/qux.js'
+      }).delay(100);
+
+      var config = new ConfigParser().addConfig(toAdd).getConfig().then(function(config){
+        expect(config.onPrepare).toEqual(path.normalize(process.cwd() + '/baz/qux.js'));
+        done();
+      });
+    });
+
+    describe('resolving globs', function() {
+      it('should resolve relative to the cwd', function(done) {
+        var toAdd = Q({
+          specs: 'data/*spec*.js'
+        }).delay(10);
+
+        var config = new ConfigParser().addConfig(toAdd).getConfig().then(function(config){
+          var specs = ConfigParser.resolveFilePatterns(config.specs, false, __dirname + '/');
+          expect(specs.length).toEqual(2);
+          expect(specs[0].indexOf(path.normalize('unit/data/fakespecA.js'))).not.toEqual(-1);
+          expect(specs[1].indexOf(path.normalize('unit/data/fakespecB.js'))).not.toEqual(-1);
+          done();
+        });
+      });
+
+      it('should resolve relative to the config file dir', function(done) {
+        var config = new ConfigParser().
+            addFileConfig(__dirname + '/data/config.promise.js').
+            getConfig();
+        config.then(function(config){
+          var specs = ConfigParser.resolveFilePatterns(
+            config.specs, false, config.configDir);
+          expect(specs.length).toEqual(2);
+          expect(specs[0].indexOf(path.normalize('unit/data/fakespecA.js'))).not.toEqual(-1);
+          expect(specs[1].indexOf(path.normalize('unit/data/fakespecB.js'))).not.toEqual(-1);
+          done();
+        });
+      });
     });
   });
 });

--- a/spec/unit/data/config.promise.js
+++ b/spec/unit/data/config.promise.js
@@ -1,0 +1,8 @@
+var Q = require('q');
+
+exports.config = Q({
+  onPrepare: 'foo/bar.js',
+  specs: [ 'fakespec*.js' ],
+  rootElement: '.mycontainer'
+}).delay(10);
+	


### PR DESCRIPTION
Enabling the ability to specify a promise in the configuration. This is primarily required for specifying the browser `capabilities` object that can be generated asynchronously. For example, 
- packages like firefox-profile have an async API for setting preferences for Firefox. 
- Creating a zip file to load as a Chrome extension also have async API. 

This pull request _does not break_ existing way of specifying configurations. It simply wraps the configuration object inside a `Q()` promise. This way, the config can also be specified as a promise that resolves eventually before the tests are not. 

Tested this on Windows and Linux. Also update the test cases to reflect this change. New test cases have also been added to ensure that the config files with promises work.  

Issue here - https://github.com/angular/protractor/issues/578
