### PR TITLE
Add Cucumber to the CLI help text

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -48,7 +48,7 @@ var argv = require('optimist').
     describe('verbose', 'Print full spec names').
     describe('stackTrace', 'Print stack trace on error').
     describe('params', 'Param object to be passed to the tests').
-    describe('framework', 'Test framework to use. jasmine or mocha.').
+    describe('framework', 'Test framework to use: jasmine, cucumber or mocha').
     alias('browser', 'capabilities.browserName').
     alias('name', 'capabilities.name').
     alias('platform', 'capabilities.platform').


### PR DESCRIPTION
Running `protractor --help` did not previously tell you about cucumber support
