### PR TITLE
Improve elementFinder.find documentation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -196,7 +196,7 @@ ElementFinder |
 
 ##[elementFinder.find](https://github.com/angular/protractor/blob/master/lib/protractor.js#L117)
 #### Use as: element(locator).find()
-Return the actual WebElement.
+Returns the specified WebElement. Throws an error if the element doesn't exist.
 
 
 


### PR DESCRIPTION
The documentation for elementFinder.find() didn't say what happened if there was no element matching the criterion. I added that information.
