### PR TITLE
fix(pageload): Changing how `about:blank` unload waits

### DIFF
--- a/lib/protractor.js
+++ b/lib/protractor.js
@@ -866,7 +866,7 @@ Protractor.prototype.get = function(destination, opt_timeout) {
   // At this point, we need to make sure the new url has loaded before
   // we try to execute any asynchronous scripts.
   this.driver.wait(function() {
-    return self.driver.getCurrentUrl().then(function(url) {
+    return self.driver.executeScript('return window.location.href;').then(function(url) {
       return url !== 'about:blank';
     });
   }, timeout * 1000, 'Timed out waiting for page to load');
@@ -899,7 +899,7 @@ Protractor.prototype.get = function(destination, opt_timeout) {
   }
 
   return this.driver.executeScript(function() {
-    // Continue to bootstrap Angular.
+    /* Continue to bootstrap Angular. */
     angular.resumeBootstrap(arguments[0]);
   }, this.moduleNames_);
 };


### PR DESCRIPTION
Also changing `executeScript` script comment from `//` to `/**/`
format.

These two small changes should not affect functionality but
make Protractor work properly with Selendroid.

See https://github.com/selendroid/selendroid/issues/254
