### PR TITLE
feat(protractor): Add the browser.navigateTo method to perform in-page navigation

### DIFF
--- a/lib/clientsidescripts.js
+++ b/lib/clientsidescripts.js
@@ -528,3 +528,21 @@ clientSideScripts.getLocationAbsUrl = function(selector) {
   var el = document.querySelector(selector);
   return angular.element(el).injector().get('$location').absUrl();
 };
+
+/**
+ * Browse to another page using in-page navigation.
+ *
+ * @param {string} selector The selector housing an ng-app
+ * @param {string} url In page URL using the same syntax as $location.url()
+ */
+clientSideScripts.navigateTo = function(selector, url) {
+  var el = document.querySelector(selector);
+  var $injector = angular.element(el).injector();
+  var $location = $injector.get('$location');
+  var $rootScope = $injector.get('$rootScope');
+
+  if (url !== $location.url()) {
+    $location.url(url);
+    $rootScope.$digest();
+  }
+};

--- a/lib/protractor.js
+++ b/lib/protractor.js
@@ -904,6 +904,24 @@ Protractor.prototype.get = function(destination, opt_timeout) {
 };
 
 /**
+ * Browse to another page using in-page navigation.
+ *
+ * @param {string} url In page URL using the same syntax as $location.url()
+ * @returns {!webdriver.promise.Promise} A promise that will resolve once
+ *    page has been changed.
+ */
+Protractor.prototype.navigateTo = function(url) {
+  this.waitForAngular();
+  return this.driver.executeScript(clientSideScripts.navigateTo, this.rootEl, url)
+    .then(function(browserErr) {
+      if (browserErr) {
+        throw 'Error while navigating to \'' + url + '\' : ' +
+            JSON.stringify(browserErr);
+      }
+    });
+};
+
+/**
  * Returns the current absolute url from AngularJS.
  */
 Protractor.prototype.getLocationAbsUrl = function() {

--- a/spec/basic/lib_spec.js
+++ b/spec/basic/lib_spec.js
@@ -102,5 +102,14 @@ describe('protractor library', function() {
       expect(browser.getLocationAbsUrl()).
           toEqual('http://localhost:'+port+'/index.html#/repeater');
     });
+
+    it('should navigate to another url', function() {
+      browser.get('index.html');
+
+      browser.navigateTo('/repeater');
+
+      expect(browser.getLocationAbsUrl()).
+        toEqual('http://localhost:'+port+'/index.html#/repeater');
+    });
   })
 });


### PR DESCRIPTION
Allow a faster way to navigate within the app.
The current browser.get method forces the entire app to load every time you navigate to a new page.
The proposed browser.navigateTo method uses the same format as $location.url().

Closes #368
