### PR TITLE
refactor(spec/basic): create and make use of a new bindings PageObject

### DIFF
--- a/spec/basic/findelements_spec.js
+++ b/spec/basic/findelements_spec.js
@@ -1,4 +1,5 @@
 var util = require('util');
+var bindings = require('../page_objects/bindings')();
 
 describe('locators', function() {
   beforeEach(function() {
@@ -566,19 +567,19 @@ describe('evaluating statements', function() {
 
 describe('shortcut css notation', function() {
   beforeEach(function() {
-    browser.get('index.html#/bindings');
+    bindings.load();
   });
 
   describe('via the driver', function() {
     it('should return the same results as web driver', function() {
-      element(by.css('.planet-info')).getText().then(function(textFromLongForm) {
+      bindings.getPlanetInfo().then(function(textFromLongForm) {
         var textFromShortcut = $('.planet-info').getText();
         expect(textFromShortcut).toEqual(textFromLongForm);
       });
     });
 
     it('should return the same array results as web driver', function() {
-      element.all(by.css('option')).then(function(optionsFromLongForm) {
+      bindings.getOptions().then(function(optionsFromLongForm) {
         $$('option').then(function(optionsFromShortcut) {
           expect(optionsFromShortcut.length).toEqual(optionsFromLongForm.length);
 
@@ -596,19 +597,19 @@ describe('shortcut css notation', function() {
     var select;
 
     beforeEach(function() {
-      select = element(by.css('select'));
+      select = bindings.getSelect();
     });
 
     it('should return the same results as web driver', function() {
-      select.findElement(by.css('option[value="4"]')).getText().then(function(textFromLongForm) {
-        var textFromShortcut = select.$('option[value="4"]').getText();
+      select.getOption(4).then(function(textFromLongForm) {
+        var textFromShortcut = select.getElement().$('option[value="4"]').getText();
         expect(textFromShortcut).toEqual(textFromLongForm);
       });
     });
 
     it('should return the same array results as web driver', function() {
-      select.findElements(by.css('option')).then(function(optionsFromLongForm) {
-        select.$$('option').then(function(optionsFromShortcut) {
+      select.getOptions().then(function(optionsFromLongForm) {
+        select.getElement().$$('option').then(function(optionsFromShortcut) {
           expect(optionsFromShortcut.length).toEqual(optionsFromLongForm.length);
 
           optionsFromLongForm.forEach(function(option, i) {
@@ -630,49 +631,48 @@ describe('wrapping web driver elements', function() {
   }
 
   beforeEach(function() {
-    browser.get('index.html#/bindings');
+    bindings.load();
   });
 
   describe('when found via #findElement', function() {
     it('should wrap the result', function() {
-      browser.findElement(by.binding('planet.name')).then(verifyMethodsAdded);
-
-      browser.findElement(by.css('option[value="4"]')).then(verifyMethodsAdded);
+      bindings.getPlanet().then(verifyMethodsAdded);
+      bindings.getOption(4).then(verifyMethodsAdded);
     });
 
     describe('when found with global element', function() {
       it('should wrap the result', function() {
-        element(by.binding('planet.name')).find().then(verifyMethodsAdded);
-        element(by.css('option[value="4"]')).find().then(verifyMethodsAdded);
+        bindings.getPlanetWithGlobalElement().then(verifyMethodsAdded);
+        bindings.getOptionWithGlobalElement(4).then(verifyMethodsAdded);
       });
     });
   });
 
   describe('when found via #findElements', function() {
     it('should wrap the results', function() {
-      browser.findElements(by.binding('planet.name')).then(function(results) {
+      bindings.getPlanets().then(function(results) {
         results.forEach(verifyMethodsAdded);
       });
-      browser.findElements(by.css('option[value="4"]')).then(function(results) {
+      bindings.getOptionsWithValue(4).then(function(results) {
         results.forEach(verifyMethodsAdded);
       });
     });
 
     describe('when found with global element', function() {
       it('should wrap the result', function() {
-        element.all(by.binding('planet.name')).then(function(results) {
+        bindings.getPlanetsWithGlobalElement().then(function(results) {
           results.forEach(verifyMethodsAdded);
         });
-        element.all(by.binding('planet.name')).get(0).then(function(elem) {
+        bindings.getPlanetsWithGlobalElement().get(0).then(function(elem) {
           elem.verifyMethodsAdded;
         });
-        element.all(by.binding('planet.name')).first().then(function(elem) {
+        bindings.getPlanetsWithGlobalElement().first().then(function(elem) {
           elem.verifyMethodsAdded;
         });
-        element.all(by.binding('planet.name')).last().then(function(elem) {
+        bindings.getPlanetsWithGlobalElement().last().then(function(elem) {
           elem.verifyMethodsAdded;
         });
-        element.all(by.css('option[value="4"]')).then(function(results) {
+        bindings.getOptionsWithValueWithGlobalElement(4).then(function(results) {
           results.forEach(verifyMethodsAdded);
         });
       });
@@ -683,19 +683,19 @@ describe('wrapping web driver elements', function() {
     var info;
 
     beforeEach(function() {
-      info = browser.findElement(by.css('.planet-info'));
+      info = bindings.getInfo();
     });
 
     describe('when found via #findElement', function() {
       describe('when using a locator that specifies an override', function() {
         it('should wrap the result', function() {
-          info.findElement(by.binding('planet.name')).then(verifyMethodsAdded);
+          info.getPlanetName().then(verifyMethodsAdded);
         });
       });
 
       describe('when using a locator that does not specify an override', function() {
         it('should wrap the result', function() {
-          info.findElement(by.css('div:last-child')).then(verifyMethodsAdded);
+          info.getLastChild().then(verifyMethodsAdded);
         });
       });
     });
@@ -703,7 +703,7 @@ describe('wrapping web driver elements', function() {
     describe('when querying for many elements', function() {
       describe('when using a locator that specifies an override', function() {
         it('should wrap the result', function() {
-          info.findElements(by.binding('planet.name')).then(function(results) {
+          info.getPlanetNames().then(function(results) {
             results.forEach(verifyMethodsAdded);
           });
         });
@@ -711,7 +711,7 @@ describe('wrapping web driver elements', function() {
 
       describe('when using a locator that does not specify an override', function() {
         it('should wrap the result', function() {
-          info.findElements(by.css('div:last-child')).then(function(results) {
+          info.getLastChildren().then(function(results) {
             results.forEach(verifyMethodsAdded);
           });
         });

--- a/spec/page_objects/bindings.js
+++ b/spec/page_objects/bindings.js
@@ -1,0 +1,219 @@
+/**
+ *  A PageObject for the bindings page.
+ */
+
+var bindings = function () {
+
+  /**
+   *  Load the bindings page.
+   */
+  this.load = function () {
+    browser.get('index.html#/bindings');
+  };
+
+  /**
+   *  Get planet info
+   *  @returns {object} a promise.
+   */
+  this.getPlanetInfo = function () {
+    return element(by.css('.planet-info')).getText();
+  };
+
+  /**
+   *  Get the select element.
+   *  Returns a Select object which encapsulates the select element
+   */
+  this.getSelect = function () {
+    return new Select(element(by.css('select')));
+  };
+
+  /**
+   *  Get the info element.
+   *  Returns an Info object which encapsulates the info element
+   */
+  this.getInfo = function () {
+    return new Info(browser.findElement(by.css('.planet-info')));
+  };
+
+  /**
+   *  Get all select options.
+   *  @returns {object} a promise.
+   */
+  this.getOptions = function () {
+    return element.all(by.css('option'));
+  };
+
+  /**
+   *  Get a planet.
+   *  Found via findElement.
+   *  @returns {object} a promise.
+   */
+  this.getPlanet = function () {
+    return browser.findElement(by.binding('planet.name'));
+  };
+
+  /**
+   *  Get all planets.
+   *  Found via findElements.
+   *  @returns {object} a promise.
+   */
+  this.getPlanets = function () {
+    return browser.findElements(by.binding('planet.name'));
+  };
+
+  /**
+   *  Get an option with a particular value.
+   *  Found via findElement.
+   *  @param {string} the value.
+   *  @returns {object} a promise.
+   */
+  this.getOption = function (value) {
+    var optionString = getOptionString(value);
+    return browser.findElement(by.css(optionString));
+  };
+
+  /**
+   *  Get all options with a particular value.
+   *  Found via findElements.
+   *  @param {string} the value.
+   *  @returns {object} a promise.
+   */
+  this.getOptionsWithValue = function (value) {
+    var optionString = getOptionString(value);
+    return browser.findElements(by.css(optionString));
+  };
+
+  /**
+   *  Get a planet.
+   *  Found with global element.
+   *  @returns {object} a promise.
+   */
+  this.getPlanetWithGlobalElement = function () {
+    return element(by.binding('planet.name')).find();
+  };
+
+  /**
+   *  Get an option having a particular value.
+   *  Found with global element.
+   *  @param {string} the value.
+   *  @returns {object} a promise.
+   */
+  this.getOptionWithGlobalElement = function (value) {
+    var optionString = getOptionString(value);
+    return element(by.css(optionString)).find();
+  };
+
+  /*
+   *  Get all planets.
+   *  Found with global element.
+   *  @returns {object} a promise.
+   */
+  this.getPlanetsWithGlobalElement = function () {
+    return element.all(by.binding('planet.name'));
+  };
+
+  /**
+   *  Get all option having a particular value.
+   *  Found with global element.
+   *  @returns {object} a promise.
+   */
+  this.getOptionsWithValueWithGlobalElement = function (value) {
+    var optionString = getOptionString(value);
+    return element.all(by.css(optionString));
+  };
+
+  return this;
+
+};
+
+/**
+ *  Like PageObjects, but within a page.
+ *  Select encapsulates the select element.
+ *  Info encapsulates the planet info element.
+ */
+
+var Select = function (selectElement) {
+
+  this.selectElement = selectElement;
+
+  /**
+   *  Get an option with a particular value.
+   *  Found using findElement.
+   *  @param {string} the value.
+   *  @returns {object} a promise.
+   */
+  this.getOption = function (value) {
+    var optionString = getOptionString(value);
+    return this.selectElement.findElement(by.css(optionString)).getText()
+  };
+
+  /**
+   *  Get all options.
+   *  Found using findElements.
+   *  @returns {object} a promise.
+   */
+  this.getOptions = function () {
+    return this.selectElement.findElements(by.css('option'));
+  };
+
+  /**
+   *  Get the underlying element.
+   *  @returns {object} ElementFinder.
+   */
+  this.getElement = function () {
+    return this.selectElement;
+  };
+
+};
+
+var Info = function (infoElement) {
+
+  this.info = infoElement;
+
+  /**
+   *  Get a planet name
+   *  Found using findElement.
+   *  @returns {object} a promise.
+   */
+  this.getPlanetName = function () {
+    return this.info.findElement(by.binding('planet.name'));
+  };
+
+  /**
+   *  Get all planet names
+   *  Found using findElements.
+   *  @returns {object} a promise.
+   */
+  this.getPlanetNames = function () {
+    return this.info.findElements(by.binding('planet.name'));
+  };
+
+  /**
+   *  Get a last-child element.
+   *  Found using findElement.
+   *  @returns {object} a promise.
+   */
+  this.getLastChild = function () {
+    return this.info.findElement(by.css('div:last-child'));
+  };
+
+  /**
+   *  Get all last-child elements.
+   *  Found using findElement.
+   *  @returns {object} a promise.
+   */
+  this.getLastChildren = function () {
+    return this.info.findElements(by.css('div:last-child'));
+  };
+
+};
+
+/**
+ *  Helper methods
+ */
+
+var getOptionString = function (value) {
+  return 'option[value="' + value + '"]';
+};
+
+module.exports = bindings;


### PR DESCRIPTION
- Created a PageObject for the bindings page, which is a page in the testapp
- Updated `spec/basic/findelements_spec.js` to use the new PageObject
- Protractor recommends using [PageObjects](https://github.com/angular/protractor/blob/master/docs/getting-started.md#organizing-real-tests-page-objects) for writing tests. This is an initial attempt to use the pattern in the Protractor test code.
