### PR TITLE
feat(jasminewd): Return promise from wrapped matcher

### DIFF
--- a/jasminewd/index.js
+++ b/jasminewd/index.js
@@ -91,7 +91,7 @@ function wrapMatcher(matcher, actualPromise, not) {
     var originalArgs = arguments;
     var matchError = new Error("Failed expectation");
     matchError.stack = matchError.stack.replace(/ +at.+jasminewd.+\n/, '');
-    actualPromise.then(function(actual) {
+    return actualPromise.then(function(actual) {
       var expected = originalArgs[0];
 
       var expectation = expect(actual);


### PR DESCRIPTION
- Allows you to call done from the last expect in an asynchronous test
- Example
  expect(browser.isElementPresent(by.css('SELECTOR')).toBe(true).then(done);
