### PR TITLE
Prevent Sauce Labs login credentials from showing up in logs.

### DIFF
--- a/lib/driverProviders/sauce.dp.js
+++ b/lib/driverProviders/sauce.dp.js
@@ -57,7 +57,7 @@ SauceDriverProvider.prototype.setupEnv = function() {
       this.config_.sauceKey + '@ondemand.saucelabs.com:80/wd/hub';
 
   util.puts('Using SauceLabs selenium server at ' +
-      this.config_.seleniumAddress);
+      this.config_.seleniumAddress.replace(/\/\/.+@/, '//'));
   deferred.resolve();
   return deferred.promise;
 };


### PR DESCRIPTION
Prevent Sauce Labs login credentials from showing up in logs.
Username and key are both pieces of sensitive information, that you would rather not have in, say, CI logs.
