### PR TITLE
fix($protractor): Issue #764

### DIFF
--- a/lib/protractor.js
+++ b/lib/protractor.js
@@ -835,10 +835,13 @@ Protractor.prototype.isElementPresent = function(locatorOrElement, varArgs) {
  * so any module registered here will override preexisting modules with the same
  * name.
  *
- * @param {!string} name The name of the module to load or override.
+ * @param {!string} name The name of the module to load or override.  If a
+ * module was previously added with the same name, it will be removed first
+ * and the new module will be added to the end of of the list.
  * @param {!string|Function} script The JavaScript to load the module.
  */
 Protractor.prototype.addMockModule = function(name, script) {
+  this.removeMockModule(name);
   this.moduleNames_.push(name);
   this.moduleScripts_.push(script);
 };
@@ -857,6 +860,8 @@ Protractor.prototype.clearMockModules = function() {
  */
 Protractor.prototype.removeMockModule = function(name) {
   var index = this.moduleNames_.indexOf(name);
+  if(index == -1) return;
+
   this.moduleNames_.splice(index, 1);
   this.moduleScripts_.splice(index, 1);
 };

--- a/spec/unit/protractor_tests.js
+++ b/spec/unit/protractor_tests.js
@@ -1,0 +1,86 @@
+var Protractor = require('../../lib/protractor');
+
+describe('Protractor', function () {
+
+  var protractor, webDriver, loadedModules;
+
+  beforeEach(function () {
+
+    loadedModules = [];
+
+    webDriver = {
+      get: function(){},
+      wait: function(cb){ cb(); },
+      executeAsyncScript: function(){ return { then: function(cb){ cb([true]); }}; },
+      executeScript: function(script){
+
+        switch(script) {
+          case 'return window.location.href;':
+            return { then: function(cb){ cb('index.html'); }};
+          case 'window.name = "NG_DEFER_BOOTSTRAP!" + window.name;window.location.replace("index.html");':
+          case 'angular.resumeBootstrap(arguments[0]);':
+            return { then: function(cb){ cb(); }};
+          default:
+            //this should all be calls to load modules.
+            loadedModules.push(script);
+            return { then: function(cb){ }};
+        }
+
+    }};
+
+    protractor = Protractor.wrapDriver(webDriver, '', '');
+
+  });
+
+  describe('when two modules with the same name are added', function () {
+
+    beforeEach(function () {
+      protractor.addMockModule('moduleA', 'first-module');
+      protractor.addMockModule('moduleA', 'last-module');
+      protractor.get('index.html');
+    });
+
+    it('should only load one module', function () {
+      expect(loadedModules.length).toEqual(1);
+    });
+
+    it('should load the last module added', function () {
+      expect(loadedModules[0]).toEqual('last-module');
+    });
+
+  });
+
+  describe('when two modules with the same name are added and then removed (once)', function () {
+
+    beforeEach(function () {
+      protractor.addMockModule('moduleA', 'first-module');
+      protractor.addMockModule('moduleA', 'last-module');
+      protractor.removeMockModule('moduleA');
+      protractor.get('index.html');
+    });
+
+    it('should not load either module', function () {
+      expect(loadedModules.length).toEqual(0);
+    });
+
+  });
+
+  describe('when a module is removed that was never added', function () {
+
+    beforeEach(function () {
+      protractor.addMockModule('moduleA', 'first-module');
+      protractor.removeMockModule('moduleB');
+      protractor.get('index.html');
+    });
+
+    it('should load all registered modules', function () {
+      expect(loadedModules.length).toEqual(1);
+    });
+
+    it('should load the last module registered', function () {
+      expect(loadedModules[0]).toEqual('first-module');
+    });
+
+  });
+
+});


### PR DESCRIPTION
This is one approach to fixing issue #764.  The removeMockModule fix is straight forward.  An alternative approach to the addMockModule fix is available in that we could swap in the new module for the old one at the same position on the list of modules.
