### PR TITLE
feat(cli): add proxy support for webdriver-manager

### DIFF
--- a/bin/webdriver-manager
+++ b/bin/webdriver-manager
@@ -8,6 +8,7 @@ var path = require('path');
 var AdmZip = require('adm-zip');
 var optimist = require('optimist');
 var childProcess = require('child_process');
+var tunnel = require('tunnel');
 
 /**
  * Download the requested binaries to node_modules/protractor/selenium/
@@ -112,11 +113,45 @@ if (!fs.existsSync(argv.out_dir) || !fs.statSync(argv.out_dir).isDirectory()) {
  */
 var httpGetFile = function(fileUrl, fileName, outputDir, callback) {
   console.log('downloading ' + fileUrl + '...');
+  var targetUrl = url.parse(fileUrl);
   var options = {
-    host: url.parse(fileUrl).host,
-    port: 80,
-    path: url.parse(fileUrl).pathname
+    host: targetUrl.host,
+    port: (targetUrl.port || targetUrl.protocol === 'https:' ? 443 : 80),
+    path: targetUrl.pathname
   };
+
+  if (targetUrl.protocol === 'http:' && (process.env.HTTP_PROXY || process.env.http_proxy)) {
+    var proxy = process.env.HTTP_PROXY || process.env.http_proxy;
+  } else if (targetUrl.protocol === 'https:' && (process.env.HTTPS_PROXY || process.env.https_proxy)) {
+    var proxy = process.env.HTTPS_PROXY || process.env.https_proxy;
+  }
+
+  if (proxy) {
+    var proxyUrl = url.parse(proxy);
+
+    // Proxy settings
+    var proxyObj = {
+      host: proxyUrl.hostname,
+      port: proxyUrl.port,
+      headers: {
+        Host: options.host + ':' + options.port
+      },
+      // Basic authorization for proxy server if necessary
+      proxyAuth: proxyUrl.auth
+    };
+
+    if (proxyUrl.protocol === 'https:' && targetUrl.protocol === 'http:') {
+      var tunnelingAgent = tunnel.httpOverHttps({ proxy: proxyObj } );
+    } else if (proxyUrl.protocol === 'https:' && targetUrl.protocol === 'https:') {
+      var tunnelingAgent = tunnel.httpsOverHttps({ proxy: proxyObj } );
+    } else if (proxyUrl.protocol === 'http:' && targetUrl.protocol ===  'http:') {
+      var tunnelingAgent = tunnel.httpOverHttp({ proxy: proxyObj });
+    } else if (proxyUrl.protocol === 'http:' && targetUrl.protocol ===  'https:') {
+      var tunnelingAgent = tunnel.httpsOverHttp({ proxy: proxyObj });
+    }
+
+    options.agent = tunnelingAgent;
+  }
 
   http.get(options, function(res) {
     if (res.statusCode !== 200) {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "adm-zip": "0.4.4",
     "optimist": "~0.6.0",
     "q": "1.0.0",
-    "lodash": "~2.4.1"
+    "lodash": "~2.4.1",
+    "tunnel": "~0.0.3"
   },
   "devDependencies": {
     "expect.js": "~0.2.0",


### PR DESCRIPTION
Following the discussion in #663 and #537, here's a patch that reads HTTP_PROXY/http_proxy and HTTPS_PROXY/https_proxy environment variables for configuring a proxy when downloading webdrivers. It does not support CLI configuration. It does not require `request`, just `node-tunnel`, which should be less heavy than `request`.
