### PR TITLE
test(config): allow to set dynamic baseUrl beyond localhost

### DIFF
--- a/debugging/failureConf.js
+++ b/debugging/failureConf.js
@@ -13,7 +13,8 @@ exports.config = {
     'browserName': 'chrome'
   },
 
-  baseUrl: 'http://localhost:' + (process.env.HTTP_PORT || '8000'),
+  baseUrl: 'http://' + (process.env.HTTP_HOST || 'localhost') + 
+    ':' + (process.env.HTTP_PORT || '8000'),
 
   // ----- Options to be passed to minijasminenode.
   jasmineNodeOpts: {

--- a/debugging/timeoutConf.js
+++ b/debugging/timeoutConf.js
@@ -14,7 +14,8 @@ exports.config = {
     'browserName': 'chrome'
   },
 
-  baseUrl: 'http://localhost:' + (process.env.HTTP_PORT || '8000'),
+  baseUrl: 'http://' + (process.env.HTTP_HOST || 'localhost') + 
+    ':' + (process.env.HTTP_PORT || '8000'),
 
   // ----- Options to be passed to minijasminenode.
   jasmineNodeOpts: {

--- a/docs/browser-setup.md
+++ b/docs/browser-setup.md
@@ -226,7 +226,8 @@ exports.config = {
     app: 'safari'
   },
 
-  baseUrl: 'http://localhost:' + (process.env.HTTP_PORT || '8000')
+  baseUrl: 'http://' + (process.env.HTTP_HOST || 'localhost') + 
+    ':' + (process.env.HTTP_PORT || '8000')
 };
 ```
 
@@ -248,7 +249,8 @@ exports.config = {
     deviceName: 'iPad Simulator'
   },
 
-  baseUrl: 'http://localhost:' + (process.env.HTTP_PORT || '8000')
+  baseUrl: 'http://' + (process.env.HTTP_HOST || 'localhost') + 
+    ':' + (process.env.HTTP_PORT || '8000')
 };
 
 ```

--- a/referenceConf.js
+++ b/referenceConf.js
@@ -86,7 +86,8 @@ exports.config = {
   //
   // A base URL for your application under test. Calls to protractor.get()
   // with relative paths will be prepended with this.
-  baseUrl: 'http://localhost:' + (process.env.HTTP_PORT || '8000'),
+  baseUrl: 'http://' + (process.env.HTTP_HOST || 'localhost') + 
+    ':' + (process.env.HTTP_PORT || '8000'),
 
   // Selector for the element housing the angular app - this defaults to
   // body, but is necessary if ng-app is on a descendant of <body>  

--- a/spec/altRootConf.js
+++ b/spec/altRootConf.js
@@ -14,7 +14,8 @@ exports.config = {
   // Selector for the element housing the angular app.
   rootElement: 'div#nested-ng-app',
 
-  baseUrl: 'http://localhost:' + (process.env.HTTP_PORT || '8000'),
+  baseUrl: 'http://' + (process.env.HTTP_HOST || 'localhost') + 
+    ':' + (process.env.HTTP_PORT || '8000'),
 
   jasmineNodeOpts: {
     onComplete: null,

--- a/spec/basic/actions_spec.js
+++ b/spec/basic/actions_spec.js
@@ -41,32 +41,34 @@ describe('using an ActionSequence', function() {
   /*   
   it('should navigate back and forward properly', function() {
     var port =  process.env.HTTP_PORT || '8000';
+    var host =  process.env.HTTP_HOST || 'localhost';
     browser.get('index.html#/repeater');
     expect(browser.getCurrentUrl()).
-      toEqual('http://localhost:'+port+'/index.html#/repeater');
+      toEqual('http://'+host+':'+port+'/index.html#/repeater');
 
     browser.navigate().back();
     expect(browser.getCurrentUrl()).
-      toEqual('http://localhost:'+port+'/index.html#/form');
+      toEqual('http://'+host+':'+port+'/index.html#/form');
     
     browser.navigate().forward();
     expect(browser.getCurrentUrl()).
-      toEqual('http://localhost:'+port+'/index.html#/repeater'); 
+      toEqual('http://'+host+':'+port+'/index.html#/repeater'); 
   });
   */
 
   it('should navigate back and forward properly from link', function() {
     var port =  process.env.HTTP_PORT || '8000';
+    var host =  process.env.HTTP_HOST || 'localhost';
     element(by.linkText('repeater')).click();
     expect(browser.getCurrentUrl()).
-      toEqual('http://localhost:'+port+'/index.html#/repeater');
+      toEqual('http://'+host+':'+port+'/index.html#/repeater');
 
     browser.navigate().back();
     expect(browser.getCurrentUrl()).
-      toEqual('http://localhost:'+port+'/index.html#/form');
+      toEqual('http://'+host+':'+port+'/index.html#/form');
     
     browser.navigate().forward();
     expect(browser.getCurrentUrl()).
-      toEqual('http://localhost:'+port+'/index.html#/repeater'); 
+      toEqual('http://'+host+':'+port+'/index.html#/repeater'); 
   });
 });

--- a/spec/basic/lib_spec.js
+++ b/spec/basic/lib_spec.js
@@ -1,5 +1,6 @@
 var util = require('util');
 var port =  process.env.HTTP_PORT || '8000';
+var host =  process.env.HTTP_HOST || 'localhost';
 
 describe('no protractor at all', function() {
   it('should still do normal tests', function() {
@@ -32,15 +33,15 @@ describe('protractor library', function() {
     function() {
       browser.get('index.html');
       expect(browser.getCurrentUrl()).
-          toEqual('http://localhost:'+port+'/index.html#/form');
+          toEqual('http://'+host+':'+port+'/index.html#/form');
 
       browser.driver.findElement(protractor.By.linkText('repeater')).click();
       expect(browser.driver.getCurrentUrl()).
-          toEqual('http://localhost:'+port+'/index.html#/repeater');
+          toEqual('http://'+host+':'+port+'/index.html#/repeater');
 
       browser.navigate().back();
       expect(browser.driver.getCurrentUrl()).
-          toEqual('http://localhost:'+port+'/index.html#/form');
+          toEqual('http://'+host+':'+port+'/index.html#/form');
     });
 
   it('should export other webdriver classes onto the global protractor',
@@ -96,11 +97,11 @@ describe('protractor library', function() {
     it('should get the absolute URL', function() {
       browser.get('index.html');
       expect(browser.getLocationAbsUrl()).
-          toEqual('http://localhost:'+port+'/index.html#/form');
+          toEqual('http://'+host+':'+port+'/index.html#/form');
 
       element(by.linkText('repeater')).click();
       expect(browser.getLocationAbsUrl()).
-          toEqual('http://localhost:'+port+'/index.html#/repeater');
+          toEqual('http://'+host+':'+port+'/index.html#/repeater');
     });
 
     it('should navigate to another url with setLocation', function() {
@@ -109,7 +110,7 @@ describe('protractor library', function() {
       browser.setLocation('/repeater');
 
       expect(browser.getLocationAbsUrl()).
-        toEqual('http://localhost:' + port + '/index.html#/repeater');
+        toEqual('http://'+host+':' + port + '/index.html#/repeater');
     });
   });
 });

--- a/spec/basicConf.js
+++ b/spec/basicConf.js
@@ -18,7 +18,8 @@ exports.config = {
     'browserName': 'chrome'
   },
 
-  baseUrl: 'http://localhost:' + (process.env.HTTP_PORT || '8000'),
+  baseUrl: 'http://' + (process.env.HTTP_HOST || 'localhost') + 
+    ':' + (process.env.HTTP_PORT || '8000'),
 
   params: {
     login: {

--- a/spec/ciConf.js
+++ b/spec/ciConf.js
@@ -25,7 +25,8 @@ exports.config = {
     'name': 'Protractor smoke tests'
   }],
 
-  baseUrl: 'http://localhost:' + (process.env.HTTP_PORT || '8000'),
+  baseUrl: 'http://' + (process.env.HTTP_HOST || 'localhost') + 
+    ':' + (process.env.HTTP_PORT || '8000'),
 
   params: {
     login: {

--- a/spec/cucumberConf.js
+++ b/spec/cucumberConf.js
@@ -13,7 +13,8 @@ exports.config = {
     'browserName': 'chrome'
   },
 
-  baseUrl: 'http://localhost:' + (process.env.HTTP_PORT || '8000'),
+  baseUrl: 'http://' + (process.env.HTTP_HOST || 'localhost') + 
+    ':' + (process.env.HTTP_PORT || '8000'),
 
   params: {
     login: {

--- a/spec/junitOutputConf.js
+++ b/spec/junitOutputConf.js
@@ -30,5 +30,6 @@ exports.config = {
     }
   },
 
-  baseUrl: 'http://localhost:' + (process.env.HTTP_PORT || '8000'),
+  baseUrl: 'http://' + (process.env.HTTP_HOST || 'localhost') + 
+    ':' + (process.env.HTTP_PORT || '8000'),
 };

--- a/spec/login/login_spec.js
+++ b/spec/login/login_spec.js
@@ -1,6 +1,8 @@
 describe('pages with login', function() {
   it('should log in with a non-Angular page', function() {
-    browser.get('http://localhost:8000/index.html');
+    var port =  process.env.HTTP_PORT || '8000';
+    var host =  process.env.HTTP_HOST || 'localhost';
+    browser.get('http://'+host+':'+port+'/index.html');
 
     var angularElement = element(by.model('username'));
     expect(angularElement.getAttribute('value')).toEqual('Anon');

--- a/spec/mochaConf.js
+++ b/spec/mochaConf.js
@@ -13,7 +13,8 @@ exports.config = {
     'browserName': 'chrome'
   },
 
-  baseUrl: 'http://localhost:' + (process.env.HTTP_PORT || '8000'),
+  baseUrl: 'http://' + (process.env.HTTP_HOST || 'localhost') + 
+    ':' + (process.env.HTTP_PORT || '8000'),
 
   params: {
     login: {

--- a/spec/multiConf.js
+++ b/spec/multiConf.js
@@ -20,7 +20,8 @@ exports.config = {
     'browserName': 'firefox'
   }],
 
-  baseUrl: 'http://localhost:' + (process.env.HTTP_PORT || '8000'),
+  baseUrl: 'http://' + (process.env.HTTP_HOST || 'localhost') + 
+    ':' + (process.env.HTTP_PORT || '8000'),
 
   params: {
     login: {

--- a/spec/onPrepareConf.js
+++ b/spec/onPrepareConf.js
@@ -11,7 +11,8 @@ exports.config = {
     'browserName': 'chrome'
   },
 
-  baseUrl: 'http://localhost:' + (process.env.HTTP_PORT || '8000'),
+  baseUrl: 'http://' + (process.env.HTTP_HOST || 'localhost') + 
+    ':' + (process.env.HTTP_PORT || '8000'),
   
   onPrepare: function() {
     browser.params.password = '12345';

--- a/spec/onPrepareStringConf.js
+++ b/spec/onPrepareStringConf.js
@@ -12,7 +12,8 @@ exports.config = {
     'browserName': 'chrome'
   },
 
-  baseUrl: 'http://localhost:' + (process.env.HTTP_PORT || '8000'),
+  baseUrl: 'http://' + (process.env.HTTP_HOST || 'localhost') + 
+    ':' + (process.env.HTTP_PORT || '8000'),
   
   onPrepare: 'onPrepare/startup.js'
 };

--- a/spec/suitesConf.js
+++ b/spec/suitesConf.js
@@ -20,7 +20,8 @@ exports.config = {
     'browserName': 'chrome'
   },
 
-  baseUrl: 'http://localhost:8000',
+  baseUrl: 'http://' + (process.env.HTTP_HOST || 'localhost') + 
+    ':' + (process.env.HTTP_PORT || '8000'),
 
   params: {
     login: {

--- a/spec/withLoginConf.js
+++ b/spec/withLoginConf.js
@@ -1,7 +1,8 @@
 // This is the configuration file showing how a suite of tests might
 // handle log-in using the onPrepare field.
 var port =  + (process.env.HTTP_PORT || '8000');
-var baseUrl = 'http://localhost:' + port;
+var host =  process.env.HTTP_HOST || 'localhost';
+var baseUrl = 'http://' + host + ':' + port;
 
 exports.config = {
   seleniumAddress: 'http://localhost:4444/wd/hub',


### PR DESCRIPTION
This change allows to run protractor's own tests using a network selenium grid.

You can now customize the `testapp/scripts/web-server.js` host name to other than _localhost_ in a similar way can customize the port number to be different from _8000_ e.g.

```
export HTTP_HOST=10.0.0.15
npm test
```

I need this testing feature so i can add IE to `multiConf.js` and `ciConf.js` on a future PR.
