### PR TITLE
feat(addMockModule): add third parameter to pass context

### DIFF
--- a/lib/protractor.js
+++ b/lib/protractor.js
@@ -839,13 +839,14 @@ Protractor.prototype.isElementPresent = function(locatorOrElement, varArgs) {
  *
  * @param {!string} name The name of the module to load or override.
  * @param {!string|Function} script The JavaScript to load the module.
- * @param {*=} argument The argument provided to the script as
- *     `arguments[0]`.
+ * @param {*=} var_args Any additional arguments will be provided to
+ *     the script and may be referenced using the `arguments` object.
  */
-Protractor.prototype.addMockModule = function(name, script, argument) {
+Protractor.prototype.addMockModule = function(name, script) {
   this.moduleNames_.push(name);
   this.moduleScripts_.push(script);
-  this.moduleArgs_.push(argument);
+  var moduleArgs = Array.prototype.slice.call(arguments, 2);
+  this.moduleArgs_.push(moduleArgs);
 };
 
 /**
@@ -922,7 +923,9 @@ Protractor.prototype.get = function(destination, opt_timeout) {
   // is called.
   for (var i = 0; i < this.moduleScripts_.length; ++i) {
     var name = this.moduleNames_[i];
-    this.driver.executeScript(this.moduleScripts_[i], this.moduleArgs_[i]).
+    var executeScriptArgs = [this.moduleScripts_[i]].
+      concat(this.moduleArgs_[i]);
+    this.driver.executeScript.apply(this, executeScriptArgs).
       then(null, function(err) {
         throw 'Error wile running module script ' + name +
             ': ' + err.message;

--- a/spec/basic/mockmodule_spec.js
+++ b/spec/basic/mockmodule_spec.js
@@ -17,10 +17,10 @@ describe('mock modules', function() {
   var mockModuleB = "angular.module('moduleB', []).value('version', '3');";
 
   // A third module overriding the 'version' service. This function
-  // references the third argument provided through addMockModule().
+  // references the fourth argument provided through addMockModule().
   var mockModuleC = function () {
     var newModule = angular.module('moduleC', []);
-    newModule.value('version', arguments[0]);
+    newModule.value('version', arguments[1]);
   };
 
   afterEach(function() {
@@ -55,12 +55,12 @@ describe('mock modules', function() {
     expect(element(by.css('[app-version]')).getText()).toEqual('2');
   });
 
-  it('should have the version provided as third parameter through the Module C', function() {
-    browser.addMockModule('moduleC', mockModuleC, '4');
+  it('should have the version provided as fourth parameter through the Module C', function() {
+    browser.addMockModule('moduleC', mockModuleC, 'foobar', '42');
 
     browser.get('index.html');
 
-    expect(element(by.css('[app-version]')).getText()).toEqual('4');
+    expect(element(by.css('[app-version]')).getText()).toEqual('42');
   });
 
   it('should load mock modules after refresh', function() {


### PR DESCRIPTION
Allow Protractor’s 'addMockModule' method to pass context to its mocks,
providing an argument to the script which overrides a module.
Rely on the WebDriver’s 'executeScript' method.

Closes #695
