### PR TITLE
test(travis): added travis_retry for testonsauce.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ before_script:
 
 script:
   - ./scripts/testserver.sh
-  - ./scripts/testonsauce.sh
+  - travis_retry ./scripts/testonsauce.sh


### PR DESCRIPTION
`travis_retry` checks the return code of a command, in this case **testonsauce.sh**, retrying up to 3 times if the return code is non-zero.

This will help avoid false positives errored builds due to unrelated timing issues with Sauce Labs.
