### PR TITLE
fix(runner): add -r for each cucumber require

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -192,8 +192,9 @@ Runner.prototype.runCucumber_ = function(specs, done) {
       cucumberResolvedRequire =
           ConfigParser.resolveFilePatterns(self.config_.cucumberOpts.require);
       if (cucumberResolvedRequire && cucumberResolvedRequire.length) {
-          execOptions.push('-r');
-          execOptions = execOptions.concat(cucumberResolvedRequire);
+          execOptions = cucumberResolvedRequire.reduce(function(a, fn) {
+            return a.concat('-r', fn);
+          }, execOptions);
       }
     }
 


### PR DESCRIPTION
Currently a configuration where cucumberOpts.require expands to multiple files only passes the -r flag once.  Files after the first one get interpreted as feature files.

``` javascript
{
    cucumberOpts: {
        require: 'features/support/*.coffee'
    }
}
```
