### PR TITLE
specs/cucumberConf.js require doesn't resolve

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -189,8 +189,8 @@ Runner.prototype.runCucumber_ = function(specs, done) {
 
     // Process Cucumber Require param
     if (self.config_.cucumberOpts.require) {
-      cucumberResolvedRequire =
-          ConfigParser.resolveFilePatterns(self.config_.cucumberOpts.require);
+      cucumberResolvedRequire = ConfigParser.resolveFilePatterns(
+          self.config_.cucumberOpts.require, false, self.config_.configDir);
       if (cucumberResolvedRequire && cucumberResolvedRequire.length) {
           execOptions.push('-r');
           execOptions = execOptions.concat(cucumberResolvedRequire);


### PR DESCRIPTION
When tests are run the `cucumberOpts.require` paths are defined relative to the conf file, but the config dir isn't used for relative path expansion like with the specs config key.

```
Warning: pattern cucumber/stepDefinitions.js did not match any files.
```
