### PR TITLE
fix(jasminewd): Use promise.all to combine promises and done

### DIFF
--- a/jasminewd/index.js
+++ b/jasminewd/index.js
@@ -90,7 +90,7 @@ function wrapInControlFlow(globalFn, fnName) {
           throw Error('Invalid # arguments (' + fn.length + ') within function "' + fnName +'"');
         }
 
-        flow.execute(function() {
+        var flowFinished = flow.execute(function() {
           fn.call(jasmine.getEnv().currentSpec, function(userError) {
             if (userError) {
               asyncFnDone.reject(new Error(userError));
@@ -98,8 +98,11 @@ function wrapInControlFlow(globalFn, fnName) {
               asyncFnDone.fulfill();
             }
           });
-          return asyncFnDone.promise;
-        }, desc_).then(seal(done), function(e) {
+        }, desc_);
+
+        webdriver.promise.all([asyncFnDone, flowFinished]).then(function() {
+          seal(done)();
+        }, function(e) {
           e.stack = e.stack + '==== async task ====\n' + driverError.stack;
           done(e);
         });


### PR DESCRIPTION
I tried the change for allowing done callbacks by @hankduan in #728 but my test case was getting stuck when I was doing `browser.get(url)`. I don't have proof of this but I suspect that this might be for cases that use both asynchronous functions as well as using the control flow promise manager. There were only separate test cases for asynchronous functionality and control flow, but no test case where both are used at the same time.

But instead of spending time figuring out where exactly the code goes wrong I tried my own version of solving the problem where I make the flowFinished promise explicit and then using `webdriver.promise.all` to call the done function when both promises are fulfilled. This solves my problem and makes my whole test suite pass so it seems I did something right.
