### PR TITLE
feat(elementFinder): keep a reference to the original locator

### DIFF
--- a/lib/protractor.js
+++ b/lib/protractor.js
@@ -159,6 +159,15 @@ var buildElementHelper = function(ptor, opt_usingChain) {
     };
 
     /**
+     * Returns the originally specified locator.
+     *
+     * @return {webdriver.Locator} The element locator.
+     */
+    elementFinder.locator = function() {
+      return locator;
+    };
+
+    /**
      * Calls to element may be chained to find elements within a parent.
      *
      * @alias element(locator).element(locator)

--- a/spec/basic/findelements_spec.js
+++ b/spec/basic/findelements_spec.js
@@ -574,6 +574,13 @@ describe('global element function', function() {
     expect(element(by.binding('greet')).isPresent()).toBe(true);
     expect(element(by.binding('nopenopenope')).isPresent()).toBe(false);
   });
+
+  it('should keep a reference to the original locator', function() {
+    var byCss = by.css('body');
+    var byBinding = by.binding('greet');
+    expect(byCss).toEqual(element(byCss).locator());
+    expect(byBinding).toEqual(element(byBinding).locator());
+  });
 });
 
 describe('evaluating statements', function() {


### PR DESCRIPTION
There are some reasons to expose the reference to the original webdriver.Locator, @Droogans for example [shows one here](http://stackoverflow.com/a/23567136/511069)

I personally need this because sometimes i find myself using webdriver directly, i.e. `browser.driver.xxxx` and for that reason i'm unable to use certain shortcuts like `$('a.thing')` within my page objects, using `by.css('a.thing')` then wrapping the locator with `element()` when needed.

Being able to do `element(aThing).locator()` will give the flexibility back.
