### PR TITLE
fix(configParser): don't run suite if specs are supplied

### DIFF
--- a/lib/configParser.js
+++ b/lib/configParser.js
@@ -118,11 +118,14 @@ ConfigParser.getSpecs = function(config) {
     return config.suites[config.suite];
   }
 
-  var specs = config.specs || [];
+  if (config.specs.length > 0) {
+    return config.specs
+  }
+
+  var specs = [];
   _.forEach(config.suites, function(suite) {
     specs = _.union(specs, makeArray(suite));
   });
-
   return specs;
 };
 


### PR DESCRIPTION
Change the behavior of selecting tests to run:

Tests with suites in config file:

```
if --suite passed:
  run suite passed
elif --specs passed:
  run spec passed
elif specs from config file exists:
  run specs from config file
else
  run all suites
```

Tests without suites in config file:

```
if --suite passed:
  error (suite not found)
elif --specs passed:
  run spec passed
elif specs from config file exists:
  run specs from config file
else:
  error (no tests)
```
