### PR TITLE
chore(travis): fix platform and version numbers used for saucelabs

### DIFF
--- a/spec/ciConf.js
+++ b/spec/ciConf.js
@@ -17,12 +17,17 @@ exports.config = {
     'browserName': 'chrome',
     'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
     'build': process.env.TRAVIS_BUILD_NUMBER,
-    'name': 'Protractor smoke tests'
+    'name': 'Protractor smoke tests',
+    'version': '34',
+    'selenium-version': '2.41.0',
+    'platform': 'OS X 10.9'
   }, {
     'browserName': 'firefox',
     'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
     'build': process.env.TRAVIS_BUILD_NUMBER,
-    'name': 'Protractor smoke tests'
+    'name': 'Protractor smoke tests',
+    'version': '29',
+    'selenium-version': '2.41.0'
   }],
 
   baseUrl: 'http://localhost:' + (process.env.HTTP_PORT || '8000'),


### PR DESCRIPTION
Use mac for chrome because of errors with sending keys on Linux:
https://code.google.com/p/chromedriver/issues/detail?id=467
