### PR TITLE
chore(http): fix httpGetFile to handle redirects

### DIFF
--- a/bin/webdriver-manager
+++ b/bin/webdriver-manager
@@ -119,7 +119,11 @@ var httpGetFile = function(fileUrl, fileName, outputDir, callback) {
   };
 
   http.get(options, function(res) {
-    if (res.statusCode !== 200) {
+    // Handle redirects recursively
+    if ([301, 302].indexOf(res.statusCode) > -1) {
+      httpGetFile(res.headers.location, fileName, outputDir, callback);
+      return;
+    } else if (res.statusCode !== 200) {
       throw new Error('Got code ' + res.statusCode + ' from ' + fileUrl);
     }
     var filePath = path.join(outputDir, fileName);


### PR DESCRIPTION
Google changed selenium-server-standalone.jar's location and is returning 302, http module does not follow redirects by default.

Closes https://github.com/angular/protractor/issues/826
