### PR TITLE
chore(release): add a travis job to run smoke tests on more browsers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ node_js:
   - "0.10"
 
 env:
+  matrix:
+    - JOB=smoke
+    - JOB=suite
   global:
     - SAUCE_USERNAME=angular-ci
     - SAUCE_ACCESS_KEY=9b988f434ff8-fbca-8aa4-4ae3-35442987

--- a/scripts/testonsauce.sh
+++ b/scripts/testonsauce.sh
@@ -1,3 +1,9 @@
 SAUCE_ACCESS_KEY=`echo $SAUCE_ACCESS_KEY | rev`
 
-node bin/protractor spec/ciConf.js
+if [ $JOB = "smoke" ]; then
+  node bin/protractor spec/smokeConf.js
+elif [ $JOB = "suite" ]; then
+  node bin/protractor spec/ciConf.js
+else
+  echo "Unknown job type. Please set JOB=smoke or JOB=suite"
+fi

--- a/spec/ciConf.js
+++ b/spec/ciConf.js
@@ -17,7 +17,7 @@ exports.config = {
     'browserName': 'chrome',
     'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
     'build': process.env.TRAVIS_BUILD_NUMBER,
-    'name': 'Protractor smoke tests',
+    'name': 'Protractor suite tests',
     'version': '34',
     'selenium-version': '2.41.0',
     'platform': 'OS X 10.9'
@@ -25,7 +25,7 @@ exports.config = {
     'browserName': 'firefox',
     'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
     'build': process.env.TRAVIS_BUILD_NUMBER,
-    'name': 'Protractor smoke tests',
+    'name': 'Protractor suite tests',
     'version': '29',
     'selenium-version': '2.41.0'
   }],

--- a/spec/smokeConf.js
+++ b/spec/smokeConf.js
@@ -1,0 +1,56 @@
+// Smoke tests to be run on CI servers - covers more browsers than
+// ciConf.js, but does not run all tests.
+exports.config = {
+  sauceUser: process.env.SAUCE_USERNAME,
+  sauceKey: process.env.SAUCE_ACCESS_KEY,
+
+  specs: [
+    'basic/locators_spec.js',
+    'basic/mockmodule_spec.js',
+    'basic/synchronize_spec.js'
+  ],
+
+  // Two latest versions of Chrome, Firefox, IE.
+  // TODO - add mobile.
+  multiCapabilities: [{
+    'browserName': 'chrome',
+    'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
+    'build': process.env.TRAVIS_BUILD_NUMBER,
+    'name': 'Protractor smoke tests',
+    'version': '33',
+    'selenium-version': '2.41.0',
+    'platform': 'OS X 10.9'
+  }, {
+    'browserName': 'firefox',
+    'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
+    'build': process.env.TRAVIS_BUILD_NUMBER,
+    'name': 'Protractor smoke tests',
+    'version': '28',
+    'selenium-version': '2.41.0'
+  }, {
+    'browserName': 'internet explorer',
+    'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
+    'build': process.env.TRAVIS_BUILD_NUMBER,
+    'name': 'Protractor smoke tests',
+    'version': '11',
+    'selenium-version': '2.41.0',
+    'platform': 'Windows 7'
+  }, {
+    'browserName': 'internet explorer',
+    'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
+    'build': process.env.TRAVIS_BUILD_NUMBER,
+    'name': 'Protractor smoke tests',
+    'version': '10',
+    'selenium-version': '2.41.0',
+    'platform': 'Windows 7'
+  }],
+
+  baseUrl: 'http://localhost:' + (process.env.HTTP_PORT || '8000'),
+
+  params: {
+    login: {
+      user: 'Jane',
+      password: '1234'
+    }
+  }
+};


### PR DESCRIPTION
Adds smoke tests (not the full suite) that run on the latest 2 versions of
chrome, firefox, and IE.
