### PR TITLE
feat(runner): support sourcemaps in spec files

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -349,6 +349,9 @@ Runner.prototype.setupGlobals_ = function(driver) {
   global.$$ = browser.$$;
   global.element = browser.element;
   global.by = global.By = protractor.By;
+
+  // Enable sourcemap support for stack traces.
+  require('source-map-support').install();
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "adm-zip": "0.4.4",
     "optimist": "~0.6.0",
     "q": "1.0.0",
-    "lodash": "~2.4.1"
+    "lodash": "~2.4.1",
+    "source-map-support": "~0.2.6"
   },
   "devDependencies": {
     "expect.js": "~0.2.0",


### PR DESCRIPTION
This feature allows folks who are generating their spec files from a
different language to see stack traces that use the line numbers from
their sources before translation.

This commit introduces a dependency on the `source-map-support` library.

For general information about sourcemaps, refer:
-  http://www.html5rocks.com/en/tutorials/developertools/sourcemaps/
-  https://github.com/evanw/node-source-map-support
-  https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/view
