### PR TITLE
feat(runner): support running dart2js spec files

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -352,6 +352,10 @@ Runner.prototype.setupGlobals_ = function(driver) {
 
   // Enable sourcemap support for stack traces.
   require('source-map-support').install();
+
+  // Required by dart2js machinery.
+  // https://code.google.com/p/dart/source/browse/branches/bleeding_edge/dart/sdk/lib/js/dart2js/js_dart2js.dart?spec=svn32943&r=32943#487
+  global.DartObject = function(o) { this.o = o; };
 };
 
 /**

--- a/spec/basic/lib_spec.js
+++ b/spec/basic/lib_spec.js
@@ -14,6 +14,10 @@ describe('protractor library', function() {
     expect(By).toBeDefined();
     expect(element).toBeDefined();
     expect($).toBeDefined();
+    expect(DartObject).toBeDefined();
+    var obj = {};
+    var dartProxy = new DartObject(obj);
+    expect(dartProxy.o === obj).toBe(true);
   });
 
   it('should export other webdriver classes onto the global protractor',


### PR DESCRIPTION
This commit supports running Dart2JS output in NodeJS.  Officially,
Dart2JS in supposed to only generate code for running in a real
webbrowser.  With this patch, the dart2js code can also be executed in
NodeJS.

Ref: https://code.google.com/p/dart/source/browse/branches/bleeding_edge/dart/sdk/lib/js/dart2js/js_dart2js.dart?spec=svn32943&r=32943#487
