### PR TITLE
feat(locators): remove deprecated locator APIs

### DIFF
--- a/bin/elementexplorer.js
+++ b/bin/elementexplorer.js
@@ -46,9 +46,6 @@ var INITIAL_SUGGESTIONS = [
   'element(by.css(\'\'))',
   'element(by.name(\'\'))',
   'element(by.binding(\'\'))',
-  'element(by.input(\'\'))',
-  'element(by.select(\'\'))',
-  'element(by.textarea(\'\'))',
   'element(by.xpath(\'\'))',
   'element(by.tagName(\'\'))',
   'element(by.className(\'\'))'

--- a/docs/api.md
+++ b/docs/api.md
@@ -48,13 +48,9 @@ Protractor API 0.22.0
 * [ProtractorBy.prototype.addLocator](#protractorbyprototypeaddlocator)
 * [ProtractorBy.prototype.binding](#protractorbyprototypebinding)
 * [ProtractorBy.prototype.exactBinding](#protractorbyprototypeexactbinding)
-* [ProtractorBy.prototype.select](#protractorbyprototypeselect)
-* [ProtractorBy.prototype.selectedOption](#protractorbyprototypeselectedoption)
-* [ProtractorBy.prototype.input](#protractorbyprototypeinput)
 * [ProtractorBy.prototype.model](#protractorbyprototypemodel)
 * [ProtractorBy.prototype.buttonText](#protractorbyprototypebuttontext)
 * [ProtractorBy.prototype.partialButtonText](#protractorbyprototypepartialbuttontext)
-* [ProtractorBy.prototype.textarea](#protractorbyprototypetextarea)
 * [ProtractorBy.prototype.repeater](#protractorbyprototyperepeater)
 * [ProtractorBy.prototype.cssContainingText](#protractorbyprototypecsscontainingtext)
 
@@ -1021,7 +1017,7 @@ While in the debugger, commands can be scheduled through webdriver by
 entering the repl:
   debug> repl
   Press Ctrl + C to leave rdebug repl
-  > ptor.findElement(protractor.By.input('user').sendKeys('Laura'));
+  > ptor.findElement(protractor.By.model('user').sendKeys('Laura'));
   > ptor.debugger();
   debug> c
 
@@ -1175,66 +1171,6 @@ Type | Description
 {findElementsOverride: findElementsOverride, message: string} | 
 
 
-##[ProtractorBy.prototype.select](https://github.com/angular/protractor/blob/master/lib/locators.js#L122)
-
-**DEPRECATED** Use 'model' instead.
-
-
-###Example
-
-```html
-<select ng-model="user" ng-options="user.name for user in users"></select>
-```
-
-```javascript
-element(by.select('user'));
-```
-
-
-
-
-
-
-##[ProtractorBy.prototype.selectedOption](https://github.com/angular/protractor/blob/master/lib/locators.js#L141)
-
-
-
-
-###Example
-
-```html
-<select ng-model="user" ng-options="user.name for user in users"></select>
-```
-
-```javascript
-element(by.selectedOption("user"));
-```
-
-
-
-
-
-
-##[ProtractorBy.prototype.input](https://github.com/angular/protractor/blob/master/lib/locators.js#L158)
-
-**DEPRECATED** Use 'model' instead.
-
-
-###Example
-
-```html
-<input ng-model="user" type="text"/>
-```
-
-```javascript
-element(by.input('user'));
-```
-
-
-
-
-
-
 ##[ProtractorBy.prototype.model](https://github.com/angular/protractor/blob/master/lib/locators.js#L176)
 #### Use as: by.model(modelName)
 Find an element by ng-model expression.
@@ -1330,27 +1266,10 @@ Type | Description
 {findElementsOverride: findElementsOverride, message: string} | 
 
 
-##[ProtractorBy.prototype.textarea](https://github.com/angular/protractor/blob/master/lib/locators.js#L247)
-
-**DEPRECATED** Use 'model' instead.
-
-
-###Example
-
-```html
-<textarea ng-model="user"></textarea>
-```
-
-```javascript
-element(by.textarea('user'));
-```
 
 
 
-
-
-
-##[ProtractorBy.prototype.repeater](https://github.com/angular/protractor/blob/master/lib/locators.js#L265)
+##[ProtractorBy.prototype.repeater](https://github.com/angular/protractor/blob/master/lib/locators.js#L245)
 
 Find elements inside an ng-repeat.
 

--- a/docs/control-flow.md
+++ b/docs/control-flow.md
@@ -19,7 +19,7 @@ to keep execution organized. For example, consider the test
   it('should find an element by text input model', function() {
     browser.get('app/index.html#/form');
 
-    var username = element(by.input('username'));
+    var username = element(by.model('username'));
     username.clear();
     username.sendKeys('Jane Doe');
 

--- a/lib/clientsidescripts.js
+++ b/lib/clientsidescripts.js
@@ -327,27 +327,6 @@ clientSideScripts.findRepeaterColumn = function(repeater, binding, using) {
 };
 
 /**
- * Find an input elements by model name.
- * DEPRECATED - use findByModel
- *
- * @param {string} model The model name.
- * @param {Element} using The scope of the search.  Defaults to 'document'.
- *
- * @return {Array.<Element>} The matching input elements.
- */
-clientSideScripts.findInputs = function(model, using) {
-  using = using || document;
-  var prefixes = ['ng-', 'ng_', 'data-ng-', 'x-ng-', 'ng\\:'];
-  for (var p = 0; p < prefixes.length; ++p) {
-    var selector = 'input[' + prefixes[p] + 'model="' + model + '"]';
-    var inputs = using.querySelectorAll(selector);
-    if (inputs.length) {
-      return inputs;
-    }
-  }
-};
-
-/**
  * Find elements by model name.
  *
  * @param {string} model The model name.

--- a/lib/locators.js
+++ b/lib/locators.js
@@ -120,60 +120,6 @@ ProtractorBy.prototype.exactBinding = function(bindingDescriptor) {
 };
 
 /**
- * @deprecated Use 'model' instead.
- *
- * @view
- * <select ng-model="user" ng-options="user.name for user in users"></select>
- *
- * @example
- * element(by.select('user'));
- */
-ProtractorBy.prototype.select = function(model) {
-  return {
-    findElementsOverride: function(driver, using) {
-      return driver.findElements(
-          webdriver.By.js(clientSideScripts.findSelects, model, using));
-    },
-    message: 'by.select("' + model + '")'
-  };
-};
-
-/**
- * @view
- * <select ng-model="user" ng-options="user.name for user in users"></select>
- *
- * @example
- * element(by.selectedOption("user"));
- */
-ProtractorBy.prototype.selectedOption = function(model) {
-  return {
-    findElementsOverride: function(driver, using) {
-      return driver.findElements(
-          webdriver.By.js(clientSideScripts.findSelectedOptions, model, using));
-    },
-    message: 'by.selectedOption("' + model + '")'
-  };
-};
-
-/**
- * @deprecated Use 'model' instead.
- * @view
- * <input ng-model="user" type="text"/>
- *
- * @example
- * element(by.input('user'));
- */
-ProtractorBy.prototype.input = function(model) {
-  return {
-    findElementsOverride: function(driver, using) {
-      return driver.findElements(
-          webdriver.By.js(clientSideScripts.findInputs, model, using));
-    },
-    message: 'by.input("' + model + '")'
-  };
-};
-
-/**
  * Find an element by ng-model expression.
  *
  * @alias by.model(modelName)
@@ -243,24 +189,6 @@ ProtractorBy.prototype.partialButtonText = function(searchText) {
   };
 };
 
-
-/**
- * @deprecated Use 'model' instead.
- * @view
- * <textarea ng-model="user"></textarea>
- *
- * @example
- * element(by.textarea('user'));
- */
-ProtractorBy.prototype.textarea = function(model) {
-  return {
-    findElementsOverride: function(driver, using) {
-      return driver.findElements(
-          webdriver.By.js(clientSideScripts.findTextareas, model, using));
-    },
-    message: 'by.textarea("' + model + '")'
-  };
-};
 
 /**
  * Find elements inside an ng-repeat.

--- a/spec/basic/locators_spec.js
+++ b/spec/basic/locators_spec.js
@@ -76,18 +76,6 @@ describe('locators', function() {
           toEqual('Something else to write about');
     });
 
-    it('should find an element by textarea model', function() {
-      // Note: deprecated API.
-      var about = element(by.textarea('aboutbox'));
-      expect(about.getAttribute('value')).toEqual('This is a text box');
-
-      about.clear();
-      about.sendKeys('Something else to write about');
-
-      expect(about.getAttribute('value')).
-          toEqual('Something else to write about');
-    });
-
     it('should find multiple selects by model', function() {
       var selects = element.all(by.model('dayColor.color'));
       expect(selects.count()).toEqual(3);
@@ -128,29 +116,6 @@ describe('locators', function() {
 
       username.clear();
       expect(name.getText()).toEqual('');
-    });
-  });
-
-  describe('by select', function() {
-    it('should find multiple selects', function() {
-      // Note: deprecated API.
-      element.all(by.select('dayColor.color')).then(function(arr) {
-        expect(arr.length).toEqual(3);
-      });
-    });
-
-    it('should find the selected option', function() {
-      expect(element(by.selectedOption('fruit')).getText()).toEqual('apple');
-    });
-
-    it('should find multiple selected options', function() {
-      element.all(
-          by.selectedOption('dayColor.color')).then(function(arr) {
-        expect(arr.length).toEqual(3);
-        expect(arr[0].getText()).toBe('red');
-        expect(arr[1].getText()).toBe('green');
-        expect(arr[2].getText()).toBe('blue');
-      });
     });
   });
 


### PR DESCRIPTION
This is a **breaking change**.  The following deprecated Locator APIs have been
removed.
- `by.input`
- `by.select`
- `by.selectedOption`
- `by.textarea`
- `by.input`
