### PR TITLE
feat(cli): support for multiCapabilities in command line

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -91,6 +91,14 @@ if (argv.capabilities) {
   argv.capabilities = flattenObject(argv.capabilities);
 }
 
+if (argv.multiCapabilities) {
+    var multiCapabilitiesArray = [];
+    for (var i = 0; i < Object.keys(argv.multiCapabilities).length; i++) {
+        multiCapabilitiesArray[i] = flattenObject(argv.multiCapabilities[i]);
+    }
+    argv.multiCapabilities = multiCapabilitiesArray;
+}
+
 /**
  * Helper to resolve comma separated lists of file pattern strings relative to
  * the cwd.


### PR DESCRIPTION
For example, this command:

```
protractor protractor.config.js --multiCapabilities.0.browserName chrome --multiCapabilities.1.browserName firefox
```

is the equivalent of putting this in your config file:

```
multiCapabilities: [{
  'browserName': 'chrome'
}, {
  'browserName': 'firefox'
}],
```

or you can do this:

```
protractor protractor.config.js --multiCapabilities.0.browserName firefox --multiCapabilities.0.count 3
```

which is the equivalent of:

```
multiCapabilities: [{
  browserName: firefox,
  count: 3
}]
```
