### PR TITLE
Getting started documentation correction regarding spec file path

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -65,8 +65,9 @@ exports.config = {
     'browserName': 'chrome'
   },
 
-  // Spec patterns are relative to the location of the spec file. They may
-  // include glob patterns.
+  // Spec patterns are relative to the configuration file location passed
+  // to proractor (in this example conf.js).
+  // They may include glob patterns.
   specs: ['example-spec.js'],
 
   // Options to be passed to Jasmine-node.


### PR DESCRIPTION
Updated document to correctly state that spec paths are relative to the protractor config instead of the spec file.
