### PR TITLE
test(selenium): add a mock driver provider for integration testing

### DIFF
--- a/lib/driverProviders/mock.js
+++ b/lib/driverProviders/mock.js
@@ -1,0 +1,67 @@
+/*
+ * This is an mock implementation of the Driver Provider.
+ * It returns a fake webdriver and never actually contacts a selenium
+ * server.
+ */
+var webdriver = require('selenium-webdriver'),
+    q = require('q');
+/**
+ * @constructor
+ */
+var MockExecutor = function() {
+  this.driver_ = null;
+};
+
+/**
+ * @param {!webdriver.Command} command The command to execute.
+ * @param {function(Error, !bot.response.ResponseObject=)} callback the function
+ *     to invoke when the command response is ready.
+ */
+MockExecutor.prototype.execute = function(command, callback) {
+  callback(null, {
+    status: '0',
+    value: 'test_response'
+  });
+};
+
+var MockDriverProvider = function(config) {
+  this.config_ = config;
+};
+
+/**
+ * Configure and launch (if applicable) the object's environment.
+ * @public
+ * @return {q.promise} A promise which will resolve immediately.
+ */
+MockDriverProvider.prototype.setupEnv = function() {
+  return q.fcall(function() {});
+};
+
+/**
+ * Teardown and destroy the environment and do any associated cleanup.
+ *
+ * @public
+ * @return {q.promise} A promise which will resolve immediately.
+ */
+MockDriverProvider.prototype.teardownEnv = function() {
+  var deferred = q.defer();
+  this.driver_.quit().then(function() {
+    deferred.resolve();
+  });
+  return deferred.promise;
+};
+
+/**
+ * Retrieve the webdriver for the runner.
+ * @public
+ * @return webdriver instance
+ */
+MockDriverProvider.prototype.getDriver = function() {
+  this.driver_ = new webdriver.WebDriver('test_session_id', new MockExecutor());
+  return this.driver_;
+};
+
+// new instance w/ each include
+module.exports = function(config) {
+  return new MockDriverProvider(config);
+};

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -113,6 +113,8 @@ Runner.prototype.loadDriverProvider_ = function() {
     runnerPath = './driverProviders/sauce';
   } else if (this.config_.seleniumServerJar) {
     runnerPath = './driverProviders/local';
+  } else if (this.config_.mockSelenium) {
+    runnerPath = './driverProviders/mock';
   } else {
     runnerPath = './driverProviders/local';
   }

--- a/spec/unit/runner_test.js
+++ b/spec/unit/runner_test.js
@@ -2,35 +2,6 @@ var Runner = require('../../lib/runner');
 var q = require('q');
 
 describe('the Protractor runner', function() {
-  var mockDriverProvider;
-
-  beforeEach(function() {
-    mockDriverProvider = jasmine.createSpyObj(
-        'mockDriverProvider',
-        ['setupEnv', 'teardownEnv', 'getDriver']);
-
-    mockDriverProvider.setupEnv.andCallFake(function() {
-      return q.fcall(function() {});
-    });
-
-    mockDriverProvider.teardownEnv.andCallFake(function() {
-      return q.fcall(function() {});
-    });
-
-    mockDriverProvider.getDriver.andReturn({
-      // A fake driver.
-      manage: function() {
-        return {
-          timeouts: function() {
-            return {
-              setScriptTimeout: function() {}
-            };
-          }
-        };
-      }
-    });
-  });
-
   it('should export its config', function() {
     var config = {
       foo: 'bar',
@@ -43,21 +14,17 @@ describe('the Protractor runner', function() {
 
   it('should run', function(done) {
     var config = {
+      mockSelenium: true,
       specs: ['*.js'],
       framework: 'debugprint'
     };
     var exitCode;
-    Runner.prototype.loadDriverProvider_ = function() {
-      this.driverprovider_ = mockDriverProvider;
-    };
     Runner.prototype.exit_ = function(exit) {
       exitCode = exit;
     };
     var runner = new Runner(config);
 
     runner.run().then(function() {
-      expect(mockDriverProvider.setupEnv).toHaveBeenCalled();
-      expect(mockDriverProvider.teardownEnv).toHaveBeenCalled();
       expect(exitCode).toEqual(0);
       done();
     });
@@ -65,13 +32,11 @@ describe('the Protractor runner', function() {
 
   it('should fail with no specs', function() {
     var config = {
+      mockSelenium: true,
       specs: [],
       framework: 'simpleprint'
     };
     var exitCode;
-    Runner.prototype.loadDriverProvider_ = function() {
-      this.driverprovider_ = mockDriverProvider;
-    };
     Runner.prototype.exit_ = function(exit) {
       exitCode = exit;
     };


### PR DESCRIPTION
With `mockSelenium: true` in the config, an instance of WebDriver using a
fake executor will be used. This executor returns a successful test response
for any command, and never connects to a real browser.
