### PR TITLE
fix(locators): Missing information in warning/error messages

### DIFF
--- a/lib/protractor.js
+++ b/lib/protractor.js
@@ -568,15 +568,16 @@ var buildElementHelper = function(ptor) {
         this.locator_, this.parentElementFinder_).getWebElements();
 
     var id = webElementsPromise.then(function(arr) {
+      var locatorMessage = (self.locator_.message || self.locator_.toString());
       if (!arr.length) {
-        throw new Error('No element found using locator: ' + self.locator_.message);
+        throw new Error('No element found using locator: ' + locatorMessage);
       }
       var index = self.opt_index_; 
       if (index == null) {
         // index null means we make sure there is only one element
         if (arr.length > 1) {
           console.log('warning: more than one element found for locator ' +
-              self.locator_.message + '- you may need to be more specific');
+              locatorMessage + ' - you may need to be more specific');
         }
         index = 0;
       } else if (index === -1) {


### PR DESCRIPTION
Webdriver's built-in locators (such as `by.css()`) appeared as
'undefined' in protractor's messages.

For instance, if a locator matched multiple elements, protractor
would print the following message: 'warning: more than one element
found for locator undefined- you may need to be more specific'.
