### PR TITLE
feat(selectors): Add $x shorthand for by.xpath

### DIFF
--- a/bin/elementexplorer.js
+++ b/bin/elementexplorer.js
@@ -129,6 +129,7 @@ var startUp = function() {
     global.browser = browser;
     global.$ = browser.$;
     global.$$ = browser.$$;
+    global.$x = browser.$x;
     global.element = browser.element;
     global.by = global.By = protractor.By;
     global.list = list;

--- a/docs/api.md
+++ b/docs/api.md
@@ -18,6 +18,7 @@ Protractor API 0.24.1
 * [ElementFinder.prototype.all](#api-elementfinder-prototype-all)
 * [ElementFinder.prototype.$](#api-elementfinder-prototype-$)
 * [ElementFinder.prototype.$$](#api-elementfinder-prototype-$$)
+* [ElementFinder.prototype.$x](#api-elementfinder-prototype-$x)
 * [ElementFinder.prototype.isPresent](#api-elementfinder-prototype-ispresent)
 * [ElementFinder.prototype.isElementPresent](#api-elementfinder-prototype-iselementpresent)
 * [ElementFinder.prototype.locator](#api-elementfinder-prototype-locator)
@@ -648,6 +649,47 @@ selector | string | a css selector
 Type | Description
 --- | ---
 [ElementArrayFinder](#elementarrayfinder) | which identifies the array of the located [webdriver.WebElement](#webdriverwebelement)s.
+
+
+##<a name="api-elementfinder-prototype-$x"></a>[ElementFinder.prototype.$x](https://github.com/angular/protractor/blob/master/lib/protractor.js#L474)
+#### Use as: $x(cssSelector)
+Shortcut for querying the document directly with xpath.
+
+
+###Example
+
+```html
+<div class="count">
+  <span class="one">First</span>
+  <span class="two">Second</span>
+</div>
+```
+
+```javascript
+// The following protractor expressions are equivalent.
+var second = element(by.xpath('/html/body/div[1]/div/div/div[1]'));
+expect(second.getText()).toBe('Second');
+
+second = $x('/html/body/div[1]/div/div/div[1]');
+expect(second.getText()).toBe('Second');
+```
+
+
+
+###Params
+
+Param | Type | Description
+--- | --- | ---
+selector | string | a css selector
+
+
+
+
+###Returns
+
+Type | Description
+--- | ---
+[ElementFinder](#elementfinder) | which identifies the located  [webdriver.WebElement](#webdriverwebelement)
 
 
 ##<a name="api-elementfinder-prototype-ispresent"></a>[ElementFinder.prototype.isPresent](https://github.com/angular/protractor/blob/master/lib/protractor.js#L502)

--- a/lib/protractor.js
+++ b/lib/protractor.js
@@ -500,6 +500,32 @@ var buildElementHelper = function(ptor) {
   };
 
   /**
+   * Shortcut for querying the document directly with xpath.
+   *
+   * @alias $x(xpathSelector)
+   * @view
+   * <div class="count">
+   *   <span class="one">First</span>
+   *   <span class="two">Second</span>
+   * </div>
+   *
+   * @example
+   * // The following protractor expressions are equivalent.
+   * var second = element(by.xpath('/html/body/div/span[2]'));
+   * expect(second.getText()).toBe('Second');
+   *
+   * second = $x('/html/body/div/span[2]');
+   * expect(second.getText()).toBe('Second');
+   *
+   * @param {string} selector a xpath selector
+   * @return {ElementArrayFinder} which identifies the
+   *     array of the located {@link webdriver.WebElement}s.
+   */
+  ElementFinder.prototype.$x = function(selector) {
+    return new ElementArrayFinder(webdriver.By.xpath(selector), this);
+  };
+
+  /**
    * Determine whether the element is present on the page.
    *
    * @alias element(locator).isPresent()
@@ -703,6 +729,15 @@ var Protractor = function(webdriverInstance, opt_baseUrl, opt_rootElement) {
    */
   this.$$ = function(selector) {
     return self.element.all(webdriver.By.css(selector));
+  };
+
+  /**
+   * Shorthand function for finding arrays of elements by xpath.
+   *
+   * @type {function(string): ElementArrayFinder}
+   */
+  this.$x = function(selector) {
+    return self.element(webdriver.By.xpath(selector));
   };
 
   /**

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -172,6 +172,7 @@ Runner.prototype.setupGlobals_ = function(driver) {
   global.browser = browser;
   global.$ = browser.$;
   global.$$ = browser.$$;
+  global.$x = browser.$x;
   global.element = browser.element;
   global.by = global.By = protractor.By;
 

--- a/spec/basic/elements_spec.js
+++ b/spec/basic/elements_spec.js
@@ -285,6 +285,11 @@ describe('shortcut css notation', function() {
     expect($$('option').count()).toEqual(element.all(by.css('option')).count());
   });
   
+  it('should grab by xpath', function () {
+    expect($x('/html/body/div[1]/div/div/div[1]').getText()).
+        toEqual(element(by.xpath('/html/body/div[1]/div/div/div[1]')).getText());
+  });
+
   it('should chain $$ with $', function() {
     var withoutShortcutCount =
         element(by.css('select')).all(by.css('option')).then(function(options) {


### PR DESCRIPTION
Similiar to Chrome console, $x can be a shorthand for selecting by xpath
