### PR TITLE
feat(locators): add toString() wrapper for this.message

### DIFF
--- a/lib/locators.js
+++ b/lib/locators.js
@@ -65,7 +65,10 @@ ProtractorBy.prototype.addLocator = function(name, script) {
         return driver.findElements(
             webdriver.By.js.apply(webdriver.By, findElementArguments));
       },
-      message: 'by.' + name + '("' + Array.prototype.join.call(locatorArguments, '", "') + '")'
+      toString: function toString() {
+        return 'by.' + name + '("' + Array.prototype.
+          join.call(locatorArguments, '", "') + '")';
+      }
     };
   };
 };
@@ -86,7 +89,7 @@ ProtractorBy.prototype.addLocator = function(name, script) {
  * expect(span2.getText()).toBe('foo@bar.com');
  *
  * @param {string} bindingDescriptor
- * @return {{findElementsOverride: findElementsOverride, message: string}}
+ * @return {{findElementsOverride: findElementsOverride, toString: Function|string}}
  */
 ProtractorBy.prototype.binding = function(bindingDescriptor) {
   return {
@@ -95,7 +98,9 @@ ProtractorBy.prototype.binding = function(bindingDescriptor) {
           webdriver.By.js(clientSideScripts.findBindings,
               bindingDescriptor, false, using));
     },
-    message: 'by.binding("' + bindingDescriptor + '")'
+    toString: function toString() {
+      return 'by.binding("' + bindingDescriptor + '")';
+    }
   };
 };
 
@@ -106,7 +111,7 @@ ProtractorBy.prototype.binding = function(bindingDescriptor) {
  * Same as by.binding() except this does not allow for partial matches
  *
  * @param {string} bindingDescriptor
- * @return {{findElementsOverride: findElementsOverride, message: string}}
+ * @return {{findElementsOverride: findElementsOverride, toString: Function|string}}
  */
 ProtractorBy.prototype.exactBinding = function(bindingDescriptor) {
   return {
@@ -115,7 +120,9 @@ ProtractorBy.prototype.exactBinding = function(bindingDescriptor) {
           webdriver.By.js(clientSideScripts.findBindings,
               bindingDescriptor, true, using));
     },
-    message: 'by.exactBinding("' + bindingDescriptor + '")'
+    toString: function toString() {
+      return 'by.exactBinding("' + bindingDescriptor + '")';
+    }
   };
 };
 
@@ -139,7 +146,9 @@ ProtractorBy.prototype.model = function(model) {
       return driver.findElements(
           webdriver.By.js(clientSideScripts.findByModel, model, using));
     },
-    message: 'by.model("' + model + '")'
+    toString: function toString() {
+      return 'by.model("' + model + '")';
+    }
   };
 };
 
@@ -153,7 +162,7 @@ ProtractorBy.prototype.model = function(model) {
  * element(by.buttonText('Save'));
  *
  * @param {string} searchText
- * @return {{findElementsOverride: findElementsOverride, message: string}}
+ * @return {{findElementsOverride: findElementsOverride, toString: Function|string}}
  */
 ProtractorBy.prototype.buttonText = function(searchText) {
   return {
@@ -162,7 +171,9 @@ ProtractorBy.prototype.buttonText = function(searchText) {
           webdriver.By.js(clientSideScripts.findByButtonText,
           searchText, using));
     },
-    message: 'by.buttonText("' + searchText + '")'
+    toString: function toString() {
+      return 'by.buttonText("' + searchText + '")';
+    }
   };
 };
 
@@ -176,7 +187,7 @@ ProtractorBy.prototype.buttonText = function(searchText) {
  * element(by.partialButtonText('Save'));
  *
  * @param {string} searchText
- * @return {{findElementsOverride: findElementsOverride, message: string}}
+ * @return {{findElementsOverride: findElementsOverride, toString: Function|string}}
  */
 ProtractorBy.prototype.partialButtonText = function(searchText) {
   return {
@@ -185,7 +196,9 @@ ProtractorBy.prototype.partialButtonText = function(searchText) {
           webdriver.By.js(clientSideScripts.findByPartialButtonText,
           searchText, using));
     },
-    message: 'by.partialButtonText("' + searchText + '")'
+    toString: function toString() {
+      return 'by.partialButtonText("' + searchText + '")';
+    }
   };
 };
 
@@ -248,7 +261,9 @@ ProtractorBy.prototype.repeater = function(repeatDescriptor) {
         webdriver.By.js(clientSideScripts.findAllRepeaterRows,
             repeatDescriptor, using));
     },
-    message: 'by.repeater("' + repeatDescriptor + '")',
+    toString: function toString() {
+      return 'by.repeater("' + repeatDescriptor + '")';
+    },
     row: function(index) {
       return {
         findElementsOverride: function(driver, using) {
@@ -256,7 +271,9 @@ ProtractorBy.prototype.repeater = function(repeatDescriptor) {
             webdriver.By.js(clientSideScripts.findRepeaterRows,
                 repeatDescriptor, index, using));
         },
-        message: 'by.repeater(' + repeatDescriptor + '").row("' + index + '")"',
+        toString: function toString() {
+          return 'by.repeater(' + repeatDescriptor + '").row("' + index + '")"';
+        },
         column: function(binding) {
           return {
             findElementsOverride: function(driver, using) {
@@ -264,8 +281,10 @@ ProtractorBy.prototype.repeater = function(repeatDescriptor) {
                   webdriver.By.js(clientSideScripts.findRepeaterElement,
                       repeatDescriptor, index, binding, using));
             },
-            message: 'by.repeater("' + repeatDescriptor + '").row("' + index +
-                '").column("' + binding + '")'
+            toString: function toString() {
+              return 'by.repeater("' + repeatDescriptor + '").row("' + index +
+                '").column("' + binding + '")';
+            }
           };
         }
       };
@@ -277,8 +296,10 @@ ProtractorBy.prototype.repeater = function(repeatDescriptor) {
               webdriver.By.js(clientSideScripts.findRepeaterColumn,
                   repeatDescriptor, binding, using));
         },
-        message: 'by.repeater("' + repeatDescriptor + '").column("' + binding +
-            '")',
+        toString: function toString() {
+          return 'by.repeater("' + repeatDescriptor + '").column("' + 
+            binding + '")';
+        },
         row: function(index) {
           return {
             findElementsOverride: function(driver, using) {
@@ -286,8 +307,10 @@ ProtractorBy.prototype.repeater = function(repeatDescriptor) {
                   webdriver.By.js(clientSideScripts.findRepeaterElement,
                       repeatDescriptor, index, binding, using));
             },
-            message: 'by.repeater("' + repeatDescriptor + '").column("' +
-                binding + '").row("' + index + '")'
+            toString: function toString() {
+              return 'by.repeater("' + repeatDescriptor + '").column("' +
+                binding + '").row("' + index + '")';
+            }
           };
         }
       };
@@ -315,7 +338,9 @@ ProtractorBy.prototype.cssContainingText = function(cssSelector, searchText) {
         webdriver.By.js(clientSideScripts.findByCssContainingText,
         cssSelector, searchText, using));
     },
-    message: 'by.cssContainingText("' + cssSelector + '", "' + searchText + '")'
+    toString: function toString() {
+      return 'by.cssContainingText("' + cssSelector + '", "' + searchText + '")';
+    }
   };
 };
 

--- a/lib/protractor.js
+++ b/lib/protractor.js
@@ -568,7 +568,7 @@ var buildElementHelper = function(ptor) {
         this.locator_, this.parentElementFinder_).getWebElements();
 
     var id = webElementsPromise.then(function(arr) {
-      var locatorMessage = (self.locator_.message || self.locator_.toString());
+      var locatorMessage = self.locator_.toString();
       if (!arr.length) {
         throw new Error('No element found using locator: ' + locatorMessage);
       }


### PR DESCRIPTION
Adding `toString()` on **webdriver.Locator** to be consistent with [webdriver's locators API](https://code.google.com/p/selenium/source/browse/javascript/webdriver/locators.js#249)

This is useful when writing custom matchers.

Other way around would be extending [webdriver's locators API](https://code.google.com/p/selenium/source/browse/javascript/webdriver/locators.js#249) with the `message` property.

In case you want to merge this idea it might be wise to avoid code repetition by creating a base object to extend from.
