### PR TITLE
feat(webdriver-manager): minor proxy enhancements

### DIFF
--- a/bin/webdriver-manager
+++ b/bin/webdriver-manager
@@ -111,9 +111,9 @@ var resolveProxy = function(fileUrl) {
   if (argv.proxy) {
     return argv.proxy;
   } else if (protocol === 'https:') {
-    return process.env.HTTPS_PROXY || process.env.HTTP_PROXY;
+    return process.env.HTTPS_PROXY || process.env.https_proxy || process.env.HTTP_PROXY || process.env.http_proxy;
   } else if (protocol === 'http:') {
-    return process.env.HTTP_PROXY;
+    return process.env.HTTP_PROXY || process.env.http_proxy;
   }
 };
 
@@ -132,8 +132,15 @@ var httpGetFile = function(fileUrl, fileName, outputDir, callback) {
     proxy: resolveProxy(fileUrl)
   }
   request(options, function (error, response) {
+    if (error) {
+      fs.unlink(filePath);
+      console.error('Error: Got error ' + error + ' from ' + fileUrl);
+      return;
+    }
     if (response.statusCode !== 200) {
-      throw new Error('Got code ' + response.statusCode + ' from ' + fileUrl);
+      fs.unlink(filePath);
+      console.error('Error: Got code ' + response.statusCode + ' from ' + fileUrl);
+      return;
     }
     console.log(fileName + ' downloaded to ' + filePath);
     if (callback) {


### PR DESCRIPTION
Added error handling for request - previously, any errors coming from the request module were silently swallowed.

Also evaluating both uppercase and lowercase proxy variables. Many tools use proxy variables in the form https_proxy, others use HTTPS_PROXY. I changed the code so both forms are evaluated. See the following links for more info on this practice:
- http://serverfault.com/q/571887/140074
- https://wiki.archlinux.org/index.php/proxy_settings#Environment_variables
