### PR TITLE
fix(elementexplorer): element.all hangs in interactive mode

### DIFF
--- a/bin/elementexplorer.js
+++ b/bin/elementexplorer.js
@@ -80,7 +80,7 @@ var flowEval = function(code, context, file, callback) {
       process.domain.emit('error', vmErr);
       process.domain.exit();
     }
-    return result;
+    return webdriver.promise.fulfilled(result);
   }).then(function(res) {
     if (!vmErr) {
       callback(null, res);


### PR DESCRIPTION
I think it's a webdriver problem. Root cause described here: https://code.google.com/p/selenium/issues/detail?id=7537&thanks=7537&ts=1403632668
