### PR TITLE
Add iteration index to each function

### DIFF
--- a/lib/protractor.js
+++ b/lib/protractor.js
@@ -277,8 +277,8 @@ var buildElementHelper = function(ptor) {
    */
   ElementArrayFinder.prototype.each = function(fn) {
     return this.asElementFinders_().then(function(arr) {
-      arr.forEach(function(elementFinder) {
-        fn(elementFinder);
+      arr.forEach(function(elementFinder, i) {
+        fn(elementFinder, i);
       });
     });
   };


### PR DESCRIPTION
It is useful, in many cases, to have the index of the current iteration.

overcome this doing this manually but again this is very useful.

ref: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach

Thanks!
