### PR TITLE
Fix typo in cli.js: seleium > selenium

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -39,7 +39,7 @@ var optimist = require('optimist').
     describe('help', 'Print Protractor help menu').
     describe('version', 'Print Protractor version').
     describe('browser', 'Browsername, e.g. chrome or firefox').
-    describe('seleniumAddress', 'A running seleium address to use').
+    describe('seleniumAddress', 'A running selenium address to use').
     describe('seleniumServerJar', 'Location of the standalone selenium jar file').
     describe('seleniumPort', 'Optional port for the selenium standalone server').
     describe('baseUrl', 'URL to prepend to all relative paths').


### PR DESCRIPTION
Fixed a typo in the cli.js where selenium was written as seleium.

Just noticed and thought I create a pull request.

Cheers
