### PR TITLE
chore(minijasminenode): update minijasminenode dependency to v1.1.0

### DIFF
--- a/docs/referenceConf.js
+++ b/docs/referenceConf.js
@@ -150,7 +150,7 @@ exports.config = {
   
   // ----- Options to be passed to minijasminenode -----
   //
-  // See the full list at https://github.com/juliemr/minijasminenode
+  // See the full list at https://github.com/juliemr/minijasminenode/tree/jasmine1
   jasmineNodeOpts: {
     // If true, display spec names.
     isVerbose: false,

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "request": "~2.36.0",
     "selenium-webdriver": "2.42.1",
-    "minijasminenode": "1.0.0",
+    "minijasminenode": "1.1.0",
     "jasminewd": "1.0.1",
     "saucelabs": "~0.1.0",
     "glob": "~3.2",


### PR DESCRIPTION
This adds several options for the reporter, which can be included in protractor's
`config.jasmineNodeOpts`

``` js
// If true, output nothing to the terminal. Overrides other printing options.
silent: false,
// If true, print timestamps for failures
showTiming: true,
// Print failures in real time.
realtimeFailure: false
```
