### PR TITLE
feat(runner): support dart2js version 1.6.0-dev.0.0

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -180,6 +180,10 @@ Runner.prototype.setupGlobals_ = function(driver) {
   // Required by dart2js machinery.
   // https://code.google.com/p/dart/source/browse/branches/bleeding_edge/dart/sdk/lib/js/dart2js/js_dart2js.dart?spec=svn32943&r=32943#487
   global.DartObject = function(o) { this.o = o; };
+  // Dart 1.6.0-dev.0.0 needs the following:
+  // Ref: https://code.google.com/p/dart/source/browse/trunk/dart/sdk/lib/js/dart2js/js_dart2js.dart?r=37743
+  // Diff: https://code.google.com/p/dart/source/diff?spec=svn37743&r=37743&format=side&path=/trunk/dart/sdk/lib/js/dart2js/js_dart2js.dart&old_path=/trunk/dart/sdk/lib/js/dart2js/js_dart2js.dart&old=34920#sc_svn37743_100
+  global.self = global;
 };
 
 /**


### PR DESCRIPTION
This add to commit 876a3c04c07a9f8d97e1edca3ec1f76e51e1a310

dart2js now refers to the global object as "self" (as a step toward "use
strict" since Primitives.computeGlobalThis() wouldn't work in strict
mode.)  So we now publish "self" to the global namespace to support dart
version 1.6.0-dev.0.0.

Ref:  [js_dart2js.dart](https://code.google.com/p/dart/source/browse/branches/bleeding_edge/dart/sdk/lib/js/dart2js/js_dart2js.dart?r=37483#100) @ [r37483](https://code.google.com/p/dart/source/detail?r=37483)  ([diff](https://code.google.com/p/dart/source/diff?r=37483&format=side&path=/branches/bleeding_edge/dart/sdk/lib/js/dart2js/js_dart2js.dart#sc_svn37483_100))

``` diff
- final JsObject context = _wrapToDart(Primitives.computeGlobalThis());
+ final JsObject context = _wrapToDart(JS('', 'self'));
```
