### PR TITLE
feat(webdriver-manager): changing chromedrive url to non-ssl

### DIFF
--- a/bin/webdriver-manager
+++ b/bin/webdriver-manager
@@ -43,7 +43,7 @@ var binaries = {
     prefix: 'chromedriver_',
     filename: 'chromedriver_' + versions.chromedriver + '.zip',
     url: function() {
-      var urlPrefix = 'https://chromedriver.storage.googleapis.com/' +
+      var urlPrefix = 'http://chromedriver.storage.googleapis.com/' +
           versions.chromedriver + '/chromedriver_';
       if (os.type() == 'Darwin') {
         return urlPrefix + 'mac32.zip';


### PR DESCRIPTION
Support to override the default request options would be ideal. However until then, the chromedriver url doesn't need to be requested via https.
