### PR TITLE
Add ptor.waitForAny to wait on multiple possible outcomes.

### DIFF
--- a/lib/protractor.js
+++ b/lib/protractor.js
@@ -1,6 +1,8 @@
 var url = require('url');
 var util = require('util');
 var webdriver = require('selenium-webdriver');
+var _ = require('lodash');
+var q = require('q');
 
 var clientSideScripts = require('./clientsidescripts.js');
 var ProtractorBy = require('./locators.js').ProtractorBy;
@@ -83,7 +85,7 @@ var buildElementHelper = function(ptor) {
    *
    * @constructor
    * @param {webdriver.Locator} locator An element locator.
-   * @param {ElementFinder=} opt_parentElementFinder The element finder previous to  
+   * @param {ElementFinder=} opt_parentElementFinder The element finder previous to
    *     this. (i.e. opt_parentElementFinder.all(locator) => this)
    * @return {ElementArrayFinder}
    */
@@ -92,11 +94,11 @@ var buildElementHelper = function(ptor) {
       throw new Error('Locator cannot be empty');
     }
     this.locator_ = locator;
-    this.parentElementFinder_ = opt_parentElementFinder || null; 
+    this.parentElementFinder_ = opt_parentElementFinder || null;
   };
 
   /**
-   * Returns the array of WebElements represented by this ElementArrayFinder. 
+   * Returns the array of WebElements represented by this ElementArrayFinder.
    *
    * @alias element.all(locator).getWebElements()
    * @return {Array.<webdriver.WebElement>}
@@ -110,7 +112,7 @@ var buildElementHelper = function(ptor) {
         return parentWebElement.findElements(this.locator_);
       }
     } else {
-      var self = this; 
+      var self = this;
       return ptor.waitForAngular().then(function() {
         if (self.locator_.findElementsOverride) {
           return self.locator_.findElementsOverride(ptor.driver);
@@ -122,7 +124,7 @@ var buildElementHelper = function(ptor) {
   };
 
   /**
-   * Get an element found by the locator by index. The index starts at 0. 
+   * Get an element found by the locator by index. The index starts at 0.
    * This does not actually retrieve the underlying element.
    *
    * @alias element.all(locator).get(index)
@@ -140,13 +142,13 @@ var buildElementHelper = function(ptor) {
    *
    * @param {number} index Element index.
    * @return {ElementFinder} finder representing element at the given index.
-   */ 
+   */
   ElementArrayFinder.prototype.get = function(index) {
     return new ElementFinder(this.locator_, this.parentElementFinder_, null, index);
   };
 
   /**
-   * Get the first matching element for the locator. This does not actually 
+   * Get the first matching element for the locator. This does not actually
    * retrieve the underlying element.
    *
    * @alias element.all(locator).first()
@@ -168,7 +170,7 @@ var buildElementHelper = function(ptor) {
   };
 
   /**
-   * Get the last matching element for the locator. This does not actually 
+   * Get the last matching element for the locator. This does not actually
    * retrieve the underlying element.
    *
    * @alias element.all(locator).last()
@@ -216,17 +218,17 @@ var buildElementHelper = function(ptor) {
   /**
    * Represents the ElementArrayFinder as an array of ElementFinders.
    *
-   * @return {Array.<ElementFinder>} Return a promise, which resolves to a list 
+   * @return {Array.<ElementFinder>} Return a promise, which resolves to a list
    *     of ElementFinders specified by the locator.
    */
   ElementArrayFinder.prototype.asElementFinders_ = function() {
-    var self = this; 
+    var self = this;
     return this.getWebElements().then(function(arr) {
       var list = [];
       arr.forEach(function(webElem, index) {
         list.push(new ElementFinder(self.locator_, self.parentElementFinder_, null, index));
       });
-      return list; 
+      return list;
     });
   };
 
@@ -330,9 +332,9 @@ var buildElementHelper = function(ptor) {
   };
 
   /**
-   * Apply a filter function to each element found using the locator. Returns 
+   * Apply a filter function to each element found using the locator. Returns
    * promise of a new array with all elements that pass the filter function. The
-   * filter function receives the ElementFinder as the first argument 
+   * filter function receives the ElementFinder as the first argument
    * and the index as a second arg.
    *
    * @alias element.all(locator).filter(filterFn)
@@ -352,7 +354,7 @@ var buildElementHelper = function(ptor) {
    *   filteredElements[0].click();
    * });
    *
-   * @param {function(ElementFinder, number): webdriver.WebElement.Promise} filterFn 
+   * @param {function(ElementFinder, number): webdriver.WebElement.Promise} filterFn
    *     Filter function that will test if an element should be returned.
    *     filterFn should return a promise that resolves to a boolean.
    * @return {!webdriver.promise.Promise} A promise that resolves to an array
@@ -373,11 +375,11 @@ var buildElementHelper = function(ptor) {
   };
 
   /**
-   * Apply a reduce function against an accumulator and every element found 
+   * Apply a reduce function against an accumulator and every element found
    * using the locator (from left-to-right). The reduce function has to reduce
-   * every element into a single value (the accumulator). Returns promise of 
-   * the accumulator. The reduce function receives the accumulator, current 
-   * ElementFinder, the index, and the entire array of ElementFinders, 
+   * every element into a single value (the accumulator). Returns promise of
+   * the accumulator. The reduce function receives the accumulator, current
+   * ElementFinder, the index, and the entire array of ElementFinders,
    * respectively.
    *
    * @alias element.all(locator).reduce(reduceFn)
@@ -397,11 +399,11 @@ var buildElementHelper = function(ptor) {
    *
    * expect(value).toEqual('First Second Third ');
    *
-   * @param {function(number, ElementFinder, number, Array.<ElementFinder>)} 
+   * @param {function(number, ElementFinder, number, Array.<ElementFinder>)}
    *     reduceFn Reduce function that reduces every element into a single value.
-   * @param {*} initialValue Initial value of the accumulator. 
+   * @param {*} initialValue Initial value of the accumulator.
    * @return {!webdriver.promise.Promise} A promise that resolves to the final
-   *     value of the accumulator. 
+   *     value of the accumulator.
    */
   ElementArrayFinder.prototype.reduce = function(reduceFn, initialValue) {
     var valuePromise = webdriver.promise.fulfilled(initialValue);
@@ -416,17 +418,17 @@ var buildElementHelper = function(ptor) {
   };
 
   /**
-   * The ElementFinder can be treated as a WebElement for most purposes, in 
+   * The ElementFinder can be treated as a WebElement for most purposes, in
    * particular, you may perform actions (i.e. click, getText) on them as you
-   * would a WebElement. ElementFinders extend Promise, and once an action 
-   * is performed on an ElementFinder, the latest result from the chain can be 
+   * would a WebElement. ElementFinders extend Promise, and once an action
+   * is performed on an ElementFinder, the latest result from the chain can be
    * accessed using then. Unlike a WebElement, an ElementFinder will wait for
    * angular to settle before performing finds or actions.
    *
    * ElementFinder can be used to build a chain of locators that is used to find
-   * an element. An ElementFinder does not actually attempt to find the element 
-   * until an action is called, which means they can be set up in helper files 
-   * before the page is available. 
+   * an element. An ElementFinder does not actually attempt to find the element
+   * until an action is called, which means they can be set up in helper files
+   * before the page is available.
    *
    * @alias element(locator)
    * @view
@@ -450,10 +452,10 @@ var buildElementHelper = function(ptor) {
    *
    * @constructor
    * @param {webdriver.Locator} locator An element locator.
-   * @param {ElementFinder=} opt_parentElementFinder The element finder previous 
+   * @param {ElementFinder=} opt_parentElementFinder The element finder previous
    *     to this. (i.e. opt_parentElementFinder.element(locator) => this)
-   * @param {webdriver.promise.Promise} opt_actionResult The promise which 
-   *     will be retrieved with then. Resolves to the latest action result, 
+   * @param {webdriver.promise.Promise} opt_actionResult The promise which
+   *     will be retrieved with then. Resolves to the latest action result,
    *     or null if no action has been called.
    * @param {number=} opt_index The index of the element to retrieve. null means
    *     retrieve the only element, while -1 means retrieve the last element
@@ -466,9 +468,9 @@ var buildElementHelper = function(ptor) {
     this.locator_ = locator;
     this.parentElementFinder_ = opt_parentElementFinder || null;
     this.opt_actionResult_ = opt_actionResult;
-    this.opt_index_ = opt_index; 
+    this.opt_index_ = opt_index;
 
-    var self = this; 
+    var self = this;
     WEB_ELEMENT_FUNCTIONS.forEach(function(fnName) {
       if(!self[fnName]) {
         self[fnName] = function() {
@@ -480,7 +482,7 @@ var buildElementHelper = function(ptor) {
               });
 
           return new ElementFinder(
-              locator, opt_parentElementFinder, 
+              locator, opt_parentElementFinder,
               actionResult, opt_index);
         };
       }
@@ -519,7 +521,7 @@ var buildElementHelper = function(ptor) {
     return new ElementFinder(subLocator, this);
   };
 
-  /** 
+  /**
    * Calls to element may be chained to find an array of elements within a parent.
    *
    * @alias element(locator).all(locator)
@@ -557,7 +559,7 @@ var buildElementHelper = function(ptor) {
    * expect(item.getText()).toBe('Second');
    *
    * @param {string} selector A css selector
-   * @return {ElementFinder} which identifies the located 
+   * @return {ElementFinder} which identifies the located
    *     {@link webdriver.WebElement}
    */
   ElementFinder.prototype.$ = function(selector) {
@@ -622,7 +624,7 @@ var buildElementHelper = function(ptor) {
   /**
    * Override for WebElement.prototype.isElementPresent so that protractor waits
    * for Angular to settle before making the check.
-   * 
+   *
    * @see ElementFinder.isPresent
    * @return {ElementFinder} which resolves to whether
    *     the element is present on the page.
@@ -639,11 +641,11 @@ var buildElementHelper = function(ptor) {
   };
 
   /**
-   * Returns the WebElement represented by this ElementFinder. 
+   * Returns the WebElement represented by this ElementFinder.
    * Throws the WebDriver error if the element doesn't exist.
    * If index is null, it makes sure that there is only one underlying
-   * WebElement described by the chain of locators and issues a warning 
-   * otherwise. If index is not null, it retrieves the WebElement specified by 
+   * WebElement described by the chain of locators and issues a warning
+   * otherwise. If index is not null, it retrieves the WebElement specified by
    * the index.
    *
    * @example
@@ -656,7 +658,7 @@ var buildElementHelper = function(ptor) {
    * @return {webdriver.WebElement}
    */
   ElementFinder.prototype.getWebElement = function() {
-    var self = this; 
+    var self = this;
     var webElementsPromise = new ElementArrayFinder(
         this.locator_, this.parentElementFinder_).getWebElements();
 
@@ -665,7 +667,7 @@ var buildElementHelper = function(ptor) {
       if (!arr.length) {
         throw new Error('No element found using locator: ' + locatorMessage);
       }
-      var index = self.opt_index_; 
+      var index = self.opt_index_;
       if (index == null) {
         // index null means we make sure there is only one element
         if (arr.length > 1) {
@@ -679,8 +681,8 @@ var buildElementHelper = function(ptor) {
       }
 
       if (index >= arr.length) {
-        throw new Error('Index out of bound. Trying to access index:' + index + 
-            ', but locator: ' + locatorMessage + ' only has ' + 
+        throw new Error('Index out of bound. Trying to access index:' + index +
+            ', but locator: ' + locatorMessage + ' only has ' +
             arr.length + ' elements');
       }
       return arr[index];
@@ -702,7 +704,7 @@ var buildElementHelper = function(ptor) {
     var webElement = this.getWebElement();
     var evaluatedResult = webElement.getDriver().executeScript(
           clientSideScripts.evaluate, webElement, expression);
-    return new ElementFinder(this.locator_, this.parentElementFinder_, 
+    return new ElementFinder(this.locator_, this.parentElementFinder_,
       evaluatedResult, this.opt_index_);
   };
 
@@ -716,17 +718,17 @@ var buildElementHelper = function(ptor) {
     var webElement = this.getWebElement();
     var allowAnimationsResult = webElement.getDriver().executeScript(
           clientSideScripts.allowAnimations, webElement, value);
-    return new ElementFinder(this.locator_, this.parentElementFinder_, 
+    return new ElementFinder(this.locator_, this.parentElementFinder_,
       allowAnimationsResult, this.opt_index_);
   };
 
   /**
    * Access the underlying actionResult of ElementFinder. Implementation allows
    * ElementFinder to be used as a webdriver.promise.Promise
-   * @param {function(webdriver.promise.Promise)} fn Function which takes 
+   * @param {function(webdriver.promise.Promise)} fn Function which takes
    *     the value of the underlying actionResult.
    *
-   * @return {webdriver.promise.Promise} Promise which contains the results of 
+   * @return {webdriver.promise.Promise} Promise which contains the results of
    *     evaluating fn.
    */
   ElementFinder.prototype.then = function(fn, errorFn) {
@@ -915,7 +917,7 @@ Protractor.prototype.findElements = function(locator) {
  *     the element is present on the page.
  */
 Protractor.prototype.isElementPresent = function(locatorOrElement) {
-  var element = (locatorOrElement instanceof webdriver.promise.Promise) ? 
+  var element = (locatorOrElement instanceof webdriver.promise.Promise) ?
       locatorOrElement : this.element(locatorOrElement);
   return element.isPresent();
 };
@@ -1091,6 +1093,37 @@ Protractor.prototype.setLocation = function(url) {
             JSON.stringify(browserErr);
       }
     });
+};
+
+/**
+ * Similar to ptor.wait but takes an array of promises or many promises as arguments.
+ * Whenever one of the promises completes, the wait stops.
+ * @param  {[promise]} promises
+ * @return {promise}
+ */
+Protractor.prototype.waitForAny = function(promises) {
+    if (!_.isArray(promises)) {
+        promises = _.toArray(arguments);
+    }
+
+    function waitFor() {
+      var d = q.defer();
+
+      var proms = _.map(promises, function(promise) {
+        return q.when(promise());
+      });
+      q.allSettled(proms).then(function(results){
+        var status = _.reduce(results, function(accumulator, result){
+            return accumulator || result.value;
+        }, false);
+
+        d.resolve(status);
+      });
+
+      return d.promise;
+    }
+
+    return this.wait(waitFor);
 };
 
 /**

--- a/spec/basic/synchronize_spec.js
+++ b/spec/basic/synchronize_spec.js
@@ -94,4 +94,23 @@ describe('synchronizing with slow pages', function() {
 
     expect(status.getText()).toEqual('slow template contents');
   });
+
+  it('can wait for multiple outcomes', function(){
+    element(by.css('[ng-click="randomTimeouts()"]')).click();
+    var ptor = protractor.getInstance();
+    ptor.waitForAny(
+      function(){
+        return element(by.css('.timeout.success')).getText().then(function(text){
+          return text === 'Success!!';
+        });
+      },
+      function(){
+        return element(by.css('.timeout.failure')).getText().then(function(text){
+          return text === 'Success!!';
+        });
+      }
+    );
+
+    expect(element(by.css('.timeout.finished')).isDisplayed()).toBe(true);
+  });
 });

--- a/testapp/async/async.html
+++ b/testapp/async/async.html
@@ -32,4 +32,10 @@ Slow things that can happen:
     <button ng-click="changeTemplateUrl()">ng-include URL change</button>
     <div class="included" ng-include="templateUrl"></div>
   </li>
+  <li>
+    <button ng-click="randomTimeouts()">Two possible resutls</button>
+    <span class="timeout success">{{timeoutSuccess}}</span>
+    <span class="timeout failure">{{timeoutFailure}}</span>
+    <span class="timeout finished" ng-show="timeoutSuccess || timeoutFailure">Finished</span>
+  </li>
 </ul>

--- a/testapp/async/async.js
+++ b/testapp/async/async.js
@@ -32,6 +32,18 @@ function AsyncCtrl($scope, $http, $timeout, $location) {
     }, 5000);
   };
 
+  $scope.randomTimeouts = function() {
+    var result = ['timeoutSuccess', 'timeoutFailure'];
+    $scope.timeoutSuccess = '';
+    $scope.timeoutFailure = '';
+    var i = Math.floor(Math.random() * 2);
+    result = result[i];
+
+    $timeout(function(){
+      $scope[result] = 'Success!!';
+    }, 500);
+  }
+
   $scope.slowAngularTimeout = function() {
     $scope.slowAngularTimeoutStatus = 'pending...';
     $timeout(function() {


### PR DESCRIPTION
Many times there can be more than one possible result for `ptor.wait`. If I'm performing a search through a form for example, depending on the presence or absence of search results, what I am able to test on my page is very different:
- Presence of one or more search results
- Presence of a message letting me know there is no results

If this is not exactly the function under test but only one step in the test process, it is only important to know that this async loading of information is now finished. This allows to wait on multiple possible outcome:

``` js
ptor.waitForAny(
      function(){
        return element(by.css('.success')).isDisplayed();
      },
      function(){
        return element(by.css('.failure')).isDisplayed();
      }
);
```
