### PR TITLE
fix(cli): removing object flattening as it breaks objects within capabilities object such as proxy

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -72,25 +72,6 @@ if (argv.version) {
   process.exit(0);
 }
 
-// WebDriver capabilities properties require dot notation, but optimist parses
-// that into an object. Re-flatten it.
-var flattenObject = function(obj) {
-  var prefix = arguments[1] || '';
-  var out = arguments[2] || {};
-    for (var prop in obj) {
-      if (obj.hasOwnProperty(prop)) {
-        typeof obj[prop] === 'object' ?
-            flattenObject(obj[prop], prefix + prop + '.', out) :
-            out[prefix + prop] = obj[prop];
-      }
-    }
-  return out;
-};
-
-if (argv.capabilities) {
-  argv.capabilities = flattenObject(argv.capabilities);
-}
-
 /**
  * Helper to resolve comma separated lists of file pattern strings relative to
  * the cwd.


### PR DESCRIPTION
As far as I could tell this object flattening is not necessary and it actually causes objects within the capabilities object (such as the proxy object) to not be formatted correctly and thus does not pass to protractor.

I tested a variety of capabilities and I'll list some of them below.  Everything works as intended.  Please let me know if there is another hidden use for this flattening as I can't seem to find it.

```
protractor ./spec/conf/protractor.config.js --seleniumAddress http://localhost:4444/wd/hub --suite smoke --capabilities.name E2E_Tests --capabilities.browserName chrome --capabilities.proxy.proxyType manual --capabilities.proxy.httpProxy http://myproxy.com:80

protractor ./spec/conf/protractor.config.js --sauceUser username --sauceKey 12345678-1234-1234-1234-123456789012 --suite smoke --capabilities.name E2E_Tests --capabilities.browserName firefox --capabilities.platform windows --capabilities.proxy.proxyType manual --capabilities.proxy.httpProxy http://myproxy.com:80

protractor ./spec/conf/protractor.config.js --sauceUser username --sauceKey 12345678-1234-1234-1234-123456789012 --suite smoke --capabilities.name E2E_Tests --capabilities.browserName firefox --capabilities.platform windows
```
