### PR TITLE
feat(protractor): add support for promises in configs

### DIFF
--- a/lib/driverProviders/hosted.js
+++ b/lib/driverProviders/hosted.js
@@ -8,7 +8,6 @@ var util = require('util'),
     webdriver = require('selenium-webdriver'),
     q = require('q');
 
-
 var HostedDriverProvider = function(config) {
   this.config_ = config;
   this.driver_ = null;
@@ -21,8 +20,18 @@ var HostedDriverProvider = function(config) {
  *     ready to test.
  */
 HostedDriverProvider.prototype.setupEnv = function() {
-  util.puts('Using the selenium server at ' + this.config_.seleniumAddress);
-  return q.fcall(function() {});
+  var config = this.config_,
+      seleniumAddress = config.seleniumAddress;
+
+  if (q.isPromiseAlike(seleniumAddress)) {
+    return q.when(seleniumAddress).then(function(resolvedAddress) {
+      config.seleniumAddress = resolvedAddress;
+      util.puts('Using the selenium server at ' + config.seleniumAddress);
+    });
+  } else {
+    util.puts('Using the selenium server at ' + this.config_.seleniumAddress);
+    return q.fcall(function() {});
+  }
 };
 
 /**

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -218,8 +218,19 @@ Runner.prototype.run = function() {
 
   // 1) Setup environment
   return this.driverprovider_.setupEnv().then(function() {
+    var config = self.config_,
+        caps = config.capabilites,
+        multiCaps = config.multiCapabilities;
+
     driver = self.driverprovider_.getDriver();
-    return q.fcall(function() {});
+    return q.allSettled([caps, multiCaps]).spread(function(capabilites, multiCapabilities) {
+      if (capabilites.state === 'fulfilled') {
+        config.capabilites = capabilites;
+      }    
+      if (multiCapabilities.state === 'fulfilled') {
+        config.multiCapabilities = multiCapabilities;
+      }    
+    });
 
     // 2) Execute test cases
   }).then(function() {

--- a/spec/driverprovider_test.js
+++ b/spec/driverprovider_test.js
@@ -64,6 +64,19 @@ testDriverProvider(require('../lib/driverProviders/hosted')(hostedConfig)).
       console.log('hosted.dp failed with ' + err);
     });
 
+var hostedPromisedConfig = {
+  sauceAddress: 'http://localhost:4444/wd/hub',
+  capabilities: q.when({
+    browserName: 'firefox'
+  })
+};
+testDriverProvider(require('../lib/driverProviders/hosted')(hostedPromisedConfig)).
+    then(function() {
+      console.log('hosted.dp with promises working!');
+    }, function(err) {
+      console.log('hosted.dp with promises failed with ' + err);
+    });
+
 var localConfig = {
   seleniumArgs: [],
   capabilities: {


### PR DESCRIPTION
Change driverProviders/hosted to resolve promise values
in configuration to allow async jobs in setup.  Primarily,
this would be for a network call to acquire a selenium host
or to start a proxy server.
