### PR TITLE
Promises link changed to WD instead of Q

### DIFF
--- a/docs/control-flow.md
+++ b/docs/control-flow.md
@@ -10,7 +10,7 @@ Promises and the Control Flow
 -----------------------------
 
 WebDriverJS (and thus, Protractor) APIs are entirely asynchronous. All functions
-return [promises](https://code.google.com/p/selenium/source/browse/javascript/webdriver/promise.js). 
+return [promises](https://code.google.com/p/selenium/wiki/WebDriverJs#Promises). 
 
 WebDriverJS maintains a queue of pending promises, called the control flow,
 to keep execution organized. For example, consider the test


### PR DESCRIPTION
If I understand correctly, Protractor functions returns promises in WebDriver meaning, not Q.
The Q is used internally for Protractor purposes, but WebDriver promises are exposed externally.
