### PR TITLE
fix(navigation): use empty html data urls for page resets instead of abo...

### DIFF
--- a/lib/protractor.js
+++ b/lib/protractor.js
@@ -23,6 +23,8 @@ var STACK_SUBSTRINGS_TO_FILTER = [
   'protractor/lib/'
 ];
 
+var DEFAULT_RESET_URL = 'data:text/html,<html></html>';
+
 /*
  * Mix in other webdriver functionality to be accessible via protractor.
  */
@@ -842,6 +844,11 @@ var Protractor = function(webdriverInstance, opt_baseUrl, opt_rootElement) {
   this.params = {};
 
   /**
+   * The reset URL to use between page loads.
+   */
+  this.resetUrl = DEFAULT_RESET_URL;
+
+  /**
    * Information about mock modules that will be installed during every
    * get().
    *
@@ -981,7 +988,7 @@ Protractor.prototype.get = function(destination, opt_timeout) {
     return this.driver.get(destination);
   }
 
-  this.driver.get('about:blank');
+  this.driver.get(this.resetUrl);
   this.driver.executeScript(
       'window.name = "' + DEFER_LABEL + '" + window.name;' +
       'window.location.replace("' + destination + '");');
@@ -991,7 +998,7 @@ Protractor.prototype.get = function(destination, opt_timeout) {
   this.driver.wait(function() {
     return self.driver.executeScript('return window.location.href;').
         then(function(url) {
-          return url !== 'about:blank';
+          return url !== self.resetUrl;
         }, function(err) {
           if (err.code == 13) {
             // Ignore the error, and continue trying. This is because IE

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -167,6 +167,14 @@ Runner.prototype.setupGlobals_ = function(driver) {
   browser.params = this.config_.params;
   protractor.setInstance(browser);
 
+  driver.getCapabilities().then(function(caps) {
+    // Internet Explorer does not accept data URLs, which are the default
+    // reset URL for Protractor.
+    if (caps.get('browserName') === 'internet explorer') {
+      browser.resetUrl = 'about:blank';
+    }
+  });
+
   // Export protractor to the global namespace to be used in tests.
   global.protractor = protractor;
   global.browser = browser;


### PR DESCRIPTION
...ut:blank

Except on internet explorer, which does not allow data urls.

Closes #1023.
