### PR TITLE
Allow for custom server addresses when running against SauceLabs.

### DIFF
--- a/lib/driverProviders/sauce.js
+++ b/lib/driverProviders/sauce.js
@@ -55,8 +55,15 @@ SauceDriverProvider.prototype.setupEnv = function() {
   });
   this.config_.capabilities.username = this.config_.sauceUser;
   this.config_.capabilities.accessKey = this.config_.sauceKey;
-  this.config_.seleniumAddress = 'http://' + this.config_.sauceUser + ':' +
-      this.config_.sauceKey + '@ondemand.saucelabs.com:80/wd/hub';
+  var auth = 'http://' + this.config_.sauceUser + ':' +
+    this.config_.sauceKey + '@';
+
+  if (this.config_.seleniumAddress) {
+    this.config_.seleniumAddress = auth + this.config_.seleniumAddress;
+  } else {
+    this.config_.seleniumAddress = auth + 'ondemand.saucelabs.com:80/wd/hub';
+  }
+  this.config_.seleniumAddress = this.config_.seleniumAddress;
   
   // Append filename to capabilities.name so that it's easier to identify tests
   if (this.config_.capabilities.name && this.config_.capabilities.shardTestFiles) {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -98,8 +98,8 @@ Runner.prototype.runTestPreparers = function() {
  *
  * Priority
  * 1) if chromeOnly, use that
- * 2) if seleniumAddress is given, use that
- * 3) if a sauceAccount is given, use that.
+ * 2) if a sauceAccount is given, use that
+ * 3) if seleniumAddress is given, use that
  * 4) if a seleniumServerJar is specified, use that
  * 5) try to find the seleniumServerJar in protractor/selenium
  */
@@ -107,10 +107,10 @@ Runner.prototype.loadDriverProvider_ = function() {
   var runnerPath;
   if (this.config_.chromeOnly) {
     runnerPath = './driverProviders/chrome';
-  } else if (this.config_.seleniumAddress) {
-    runnerPath = './driverProviders/hosted';
   } else if (this.config_.sauceUser && this.config_.sauceKey) {
     runnerPath = './driverProviders/sauce';
+  } else if (this.config_.seleniumAddress) {
+    runnerPath = './driverProviders/hosted';
   } else if (this.config_.seleniumServerJar) {
     runnerPath = './driverProviders/local';
   } else if (this.config_.mockSelenium) {


### PR DESCRIPTION
Sauce Connect can tunnel Selenium traffic, not just Browser traffic.  This is often used in restricted networking environments.

This is supported by running Sauce Connect, then pointing your remote WebDriver to the Sauce Connect machine rather then `ondemand.saucelabs.com`.

This PR lets you specify a seleniumAddress as well as a sauceUser and sauceKey, and still use Sauce with job status updating et al.
