### PR TITLE
fix(protractor) fix stack traces for WebElement errors

### DIFF
--- a/lib/protractor.js
+++ b/lib/protractor.js
@@ -474,11 +474,15 @@ var buildElementHelper = function(ptor) {
     WEB_ELEMENT_FUNCTIONS.forEach(function(fnName) {
       if(!self[fnName]) {
         self[fnName] = function() {
+          var callerError = new Error();
           var args = arguments;
           var webElem = self.getWebElement();
           var actionResult = webElem.then(
               function(webElem_) {
-                return webElem_[fnName].apply(webElem_, args);
+                return webElem_[fnName].apply(webElem_, args).then(null, function(e) {
+                  e.stack = e.stack + '\n' + callerError.stack;
+                  throw e;
+                });
               });
 
           return new ElementFinder(
@@ -659,6 +663,7 @@ var buildElementHelper = function(ptor) {
    */
   ElementFinder.prototype.getWebElement = function() {
     var self = this; 
+    var callerError = new Error();
     var webElementsPromise = new ElementArrayFinder(
         this.locator_, this.parentElementFinder_).getWebElements();
 
@@ -686,6 +691,9 @@ var buildElementHelper = function(ptor) {
             arr.length + ' elements');
       }
       return arr[index];
+    }).then(null, function(e) {
+      e.stack = e.stack + '\n' + callerError.stack;
+      throw e;
     });
     return new webdriver.WebElement(ptor.driver, id);
   };


### PR DESCRIPTION
When angular/protractor@3c0e727136ab3d397c1a9a2bb02692d0aeb9be40
refactored `element()` into the ElementFinder object, the function lost
some of its error handling.  This removed references to frames inside
tests (`it()` blocks), making it hard to tell where the error was
actually occurring.

This commit fixes these problems, showing full stack traces for
WebElement errors.
