### PR TITLE
fix(cli): enhancing object flattening as it breaks objects within capabilities object such as proxy

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -72,14 +72,16 @@ if (argv.version) {
   process.exit(0);
 }
 
-// WebDriver capabilities properties require dot notation, but optimist parses
-// that into an object. Re-flatten it.
+// Webdriver capabilities properties (specifically PhantomJS) require dot notation, 
+// but proxy capabilities properties require an object.  There's no simple way to process this.
+// Because optimist parses the entirety of the args into an object, 
+// we need to re-flatten everything EXCEPT proxy objects.
 var flattenObject = function(obj) {
   var prefix = arguments[1] || '';
   var out = arguments[2] || {};
     for (var prop in obj) {
       if (obj.hasOwnProperty(prop)) {
-        if (prop.toString() != "proxy") {
+        if (prop.toString() != 'proxy') {
           typeof obj[prop] === 'object' ?
               flattenObject(obj[prop], prefix + prop + '.', out) :
               out[prefix + prop] = obj[prop];


### PR DESCRIPTION
Tackled this problem after #1029 was closed.  Instead of removing object flattening completely, I've set it up so that it will ignore flattening proxy objects.  This will leave the proxy object intact. 
