### PR TITLE
Disable timeout by default for mocha 1.21.0 and above.

### DIFF
--- a/lib/configParser.js
+++ b/lib/configParser.js
@@ -39,7 +39,8 @@ var ConfigParser = function() {
     cucumberOpts: {},
     mochaOpts: {
       ui: 'bdd',
-      reporter: 'list'
+      reporter: 'list',
+      enableTimeouts: false
     },
     chromeDriver: null,
     configDir: './'


### PR DESCRIPTION
visionmedia/mocha@5dad9a34fe99fbfb4e3b72bfd6f780f4dcfed045 is included in 1.21.0.
On the commit, `lib/runnable.js` and `lib/suite.js` contains `this._enableTimeouts = true;` which breaks protractor, and it was reported on #1109.

If I add `enableTimeouts : false` to default mochaOpts, mocha no longer spits out "0s timeout" errors.
