### PR TITLE
fix(runner): prefer sauce to hosted driver when sauceKey is present

### DIFF
--- a/lib/driverProviders/sauce.js
+++ b/lib/driverProviders/sauce.js
@@ -55,8 +55,11 @@ SauceDriverProvider.prototype.setupEnv = function() {
   });
   this.config_.capabilities.username = this.config_.sauceUser;
   this.config_.capabilities.accessKey = this.config_.sauceKey;
-  this.config_.seleniumAddress = 'http://' + this.config_.sauceUser + ':' +
-      this.config_.sauceKey + '@ondemand.saucelabs.com:80/wd/hub';
+
+  if (!this.config_.seleniumAddress) {
+    this.config_.seleniumAddress = 'http://' + this.config_.sauceUser + ':' +
+        this.config_.sauceKey + '@ondemand.saucelabs.com:80/wd/hub';
+  }
   
   // Append filename to capabilities.name so that it's easier to identify tests
   if (this.config_.capabilities.name && this.config_.capabilities.shardTestFiles) {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -107,10 +107,10 @@ Runner.prototype.loadDriverProvider_ = function() {
   var runnerPath;
   if (this.config_.chromeOnly) {
     runnerPath = './driverProviders/chrome';
-  } else if (this.config_.seleniumAddress) {
-    runnerPath = './driverProviders/hosted';
   } else if (this.config_.sauceUser && this.config_.sauceKey) {
     runnerPath = './driverProviders/sauce';
+  } else if (this.config_.seleniumAddress) {
+    runnerPath = './driverProviders/hosted';
   } else if (this.config_.seleniumServerJar) {
     runnerPath = './driverProviders/local';
   } else if (this.config_.mockSelenium) {


### PR DESCRIPTION
Sauce Connect sets up a local Selenium relay at localhost:4445 by
default. Allow users to adjust the `seleniumAddress` to point at this
secure relay instead of the default `ondemand.saucelabs.com` host while
still using the `sauce` driver provider.

Previously, runner would load the `remote` driver provider if
`seleniumAddress` was configured, even if Sauce credentials were also
configured.

For reasons not clear to me, on Travis VMs, the Sauce Connect relay is 10x more reliable than `ondemand.saucelabs.com`. It might be worth testing whether this helps with protractor's test suite oddities (#1051 and #1052)
