### PR TITLE
refactor(clientSideScripts): reduce interval in testForAngular to 100ms

### DIFF
--- a/lib/clientsidescripts.js
+++ b/lib/clientsidescripts.js
@@ -474,7 +474,7 @@ functions.testForAngular = function(attempts, asyncCallback) {
           callback([false, 'retries looking for angular exceeded']);
         }
       } else {
-        window.setTimeout(function() {check(n - 1);}, 1000);
+        window.setTimeout(function() {check(n - 1);}, 100);
       }
     } catch (e) {
       callback([false, e]);


### PR DESCRIPTION
I noticed that the 1s interval in `testForAngular` was responsible for a significant part of my tests' duration. Shortening the timeout interval to 100ms from 1s reduced the length of my tests by up to 15s (60s to 45s).

It's not a huge change and I'm not familiar enough with the codebase to know if this wouldn't introduce changes elsewhere but I thought I'd send a PR in case the timeout interval's current length was an afterthought and not the result of a deliberate decision.
