### PR TITLE
chore(ci): mark smoke tests as allowed failures on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,19 @@ node_js:
   - "0.10"
 
 env:
-  matrix:
-    - JOB=smoke
-    - JOB=suite
   global:
     - SAUCE_USERNAME=angular-ci
     - SAUCE_ACCESS_KEY=9b988f434ff8-fbca-8aa4-4ae3-35442987
     - LOGS_DIR=/tmp/protractor-build/logs
     - BROWSER_PROVIDER_READY_FILE=/tmp/sauce-connect-ready
+  matrix:
+    - JOB=suite
+    - JOB=smoke
+
+matrix:
+  allow_failures:
+    - env: "JOB=smoke"
+
 
 before_script:
   - mkdir -p $LOGS_DIR


### PR DESCRIPTION
They fail due to IE flakiness most of the time, see #1052.
