### PR TITLE
feat(cli): Allow anonymous collection of metrics

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -50,6 +50,7 @@ var optimist = require('optimist').
     describe('stackTrace', 'Print stack trace on error').
     describe('params', 'Param object to be passed to the tests').
     describe('framework', 'Test framework to use: jasmine, cucumber or mocha').
+    describe('allowInsight', 'Allow protractor to collect anonymous usage data').
     alias('browser', 'capabilities.browserName').
     alias('name', 'capabilities.name').
     alias('platform', 'capabilities.platform').
@@ -67,8 +68,10 @@ var optimist = require('optimist').
 
 var argv = optimist.parse(args);
 
+var ptor_pkg = require(path.join(__dirname, '../package.json'));
+
 if (argv.version) {
-  util.puts('Version ' + require(path.join(__dirname, '../package.json')).version);
+  util.puts('Version ' + ptor_pkg.version);
   process.exit(0);
 }
 
@@ -125,5 +128,26 @@ if (!configFile && args.length < 3) {
   process.exit(1);
 }
 
-// Run the launcher
-require('./launcher').init(configFile, argv);
+// Use insight to acquire version-usage information
+var Insight = require('insight');
+var insight = new Insight({
+  trackingCode: 'UA-52886659-1',
+  packageName: ptor_pkg.name,
+  packageVersion: ptor_pkg.version
+});
+
+var trackStatsAndRun = function() {
+  if (insight.optOut === undefined) {
+    // ask for permission the first time
+    return insight.askPermission(null, trackStatsAndRun);
+  } else if (!insight.optOut) {
+    // recorded in Analytics as `/protractor`
+    insight.track('protractor');
+  }
+
+  // Run the launcher
+  require('./launcher').init(configFile, argv);
+};
+
+insight.optOut = (argv.allowInsight === undefined ? insight.optOut : !argv.allowInsight);
+trackStatsAndRun();

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "optimist": "~0.6.0",
     "q": "1.0.0",
     "lodash": "~2.4.1",
-    "source-map-support": "~0.2.6"
+    "source-map-support": "~0.2.6",
+    "insight": "0.3.1"
   },
   "devDependencies": {
     "expect.js": "~0.2.0",


### PR DESCRIPTION
- Allow anonymous collection of protractor version metrics to
  help development
- Protractor will prompt user once if they want to opt in
- Allow opt-in choice to be specified in command line for automation
