### PR TITLE
feat(ElementArrayFinder): keep a reference to the original locator

### DIFF
--- a/lib/protractor.js
+++ b/lib/protractor.js
@@ -99,6 +99,13 @@ var buildElementHelper = function(ptor) {
   };
 
   /**
+   * @return {webdriver.Locator}
+   */
+  ElementArrayFinder.prototype.locator = function() {
+    return this.locator_;
+  };
+
+  /**
    * Returns the array of WebElements represented by this ElementArrayFinder. 
    *
    * @alias element.all(locator).getWebElements()

--- a/spec/basic/elements_spec.js
+++ b/spec/basic/elements_spec.js
@@ -172,6 +172,15 @@ describe('ElementFinder', function() {
     });
   });
 
+  it('should keep a reference to the array original locator', function() {
+    var byCss = by.css('.menu li a');
+    var byModel = by.model('color');
+    browser.get('index.html#/form');
+
+    expect(element.all(byCss).locator()).toEqual(byCss);
+    expect(element.all(byModel).locator()).toEqual(byModel);
+  });
+
   it('should map each element on array and with promises', function() {
     browser.get('index.html#/form');
     var labels = element.all(by.css('.menu li a')).map(function(elm, index) {


### PR DESCRIPTION
I found this one was missing while writing a custom matcher plus to be consistent with #800
