### PR TITLE
tests(locators): add chaining on repeater returning a single column

### DIFF
--- a/spec/basic/locators_spec.js
+++ b/spec/basic/locators_spec.js
@@ -225,6 +225,12 @@ describe('locators', function() {
       });
     });
 
+    it('should allow chaining while returning a single column', function() {
+      var secondName = element(by.css('.allinfo')).element(
+        by.repeater('allinfo in days').column('name').row(2));
+      expect(secondName.getText()).toEqual('Wednesday');
+    });
+
     it('should return a single row', function() {
       var secondRow = element(
           by.repeater('allinfo in days').row(1));

--- a/testapp/repeater/repeater.html
+++ b/testapp/repeater/repeater.html
@@ -1,5 +1,5 @@
 <p>A series of repeaters used in tests.</p>
-<ul><li ng-repeat="allinfo in days">
+<ul class="allinfo"><li ng-repeat="allinfo in days">
   <span>{{allinfo.initial}}</span>
   <span>{{allinfo.name}}</span>
 </li></ul>


### PR DESCRIPTION
I'm trusting this particular use case, hopefully adding the extra tests doesn't hurt.
