### PR TITLE
docs(server-setup): Note tunnel-identifier and build requirements

### DIFF
--- a/docs/server-setup.md
+++ b/docs/server-setup.md
@@ -66,6 +66,7 @@ In your config file, set these options:
 
 Please note that if you set `sauceUser` and `sauceKey`, the settings for `seleniumServerJar`, `seleniumPort` and `seleniumArgs` will be ignored.
 
+You also need to set `tunnel-identifier` and `build` options to `process.env.TRAVIS_JOB_NUMBER` in order to connect to Sauce Labs.
 
 Selenium Server and the Chrome Browser
 --------------------------------------


### PR DESCRIPTION
Without setting tunnel-identifier and build options, Sauce Labs will not connect.
Add a note reminding that, those are required.
