### PR TITLE
add locator test using by.cssContainingText with text-transform

### DIFF
--- a/spec/basic/locators_spec.js
+++ b/spec/basic/locators_spec.js
@@ -359,6 +359,11 @@ describe('locators', function() {
         expect(arr[1].getAttribute('id')).toBe('smalldog');
       });
     });
+    it('should find elements with text-transform style', function () {
+      expect(element(by.cssContainingText('#transformedtext div', 'Uppercase')).getAttribute('id')).toBe('textuppercase');
+      expect(element(by.cssContainingText('#transformedtext div', 'Lowercase')).getAttribute('id')).toBe('textlowercase');
+      expect(element(by.cssContainingText('#transformedtext div', 'capitalize')).getAttribute('id')).toBe('textcapitalize');
+    });
   });
 
   describe('by options', function() {

--- a/testapp/form/form.html
+++ b/testapp/form/form.html
@@ -82,3 +82,10 @@
     <li class="pet" id="cat">Cat</li>
   </ul>
 </div>
+
+<div id="transformedtext">
+  <h4>Transformed text</h4>
+  <div id="textuppercase" style="text-transform: uppercase;">Uppercase</div>
+  <div id="textlowercase" style="text-transform: lowercase;">Lowercase</div>
+  <div id="textcapitalize" style="text-transform: capitalize;">capitalize</div>
+</div>


### PR DESCRIPTION
Add locator test using by.cssContainingText on elements with text-transform style applied. Currently this locator matches differently on different browsers.
