### PR TITLE
Add link to Protractor Tutorial that jump to Japanese version of tutorial

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -2,6 +2,7 @@ Tutorial
 ========
 
 This is a simple tutorial that shows you how to set up Protractor and start running tests.
+(Japanese version is [here](http://qiita.com/weed/items/30098f7be2f753580f63)
 
 Prerequisites
 -------------


### PR DESCRIPTION
At first I am going to email this, but I couldn't find the email address. I'm afraid that Pull Request isn't a proper method, but I cannot find the other way to inform the existence of Japanese version.
