### PR TITLE
feat(cucumber): Process the Cucumber 'coffee' param

### DIFF
--- a/lib/frameworks/cucumber.js
+++ b/lib/frameworks/cucumber.js
@@ -50,10 +50,10 @@ exports.run = function(runner, specs, done) {
       execOptions.push(runner.getConfig().cucumberOpts.format);
     }
 
-	  // Process Cucumber 'coffee' param
-	  if (runner.getConfig().cucumberOpts.coffee) {
-		  execOptions.push('--coffee');
-	  }
+    // Process Cucumber 'coffee' param
+    if (runner.getConfig().cucumberOpts.coffee) {
+      execOptions.push('--coffee');
+    }
   }
   global.cucumber = Cucumber.Cli(execOptions);
 


### PR DESCRIPTION
Usage:

``` javascript
// In the protractor config:
exports.config = {
  // don't forget your own config

  framework: "cucumber",
  // Options to be passed to Cucumber
  cucumberOpts: {
    coffee: true // display step definition snippets in CoffeeScript
  }
};
```

Assuming that you run a Cucumber feature with the step `I want to test something else` and do not define its implementation yet.

You will see that the step implementation is now in CoffeeScript instead of JavaScript after running protractor:

> You can implement step definitions for undefined steps with these snippets:
> 
> ``` coffeescript
>   @Then /^I want to test something else$/, (callback) ->
>     # Write code here that turns the phrase above into concrete actions
>     callback.pending()
> ```
