### PR TITLE
Modified protractor to support testing node-webkit by using string conca...

### DIFF
--- a/lib/protractor.js
+++ b/lib/protractor.js
@@ -1042,7 +1042,7 @@ Protractor.prototype.get = function(destination, opt_timeout) {
   var timeout = opt_timeout ? opt_timeout : this.getPageTimeout;
   var self = this;
 
-  destination = this.baseUrl.indexOf('file://') === 0 ? ?
+  destination = this.baseUrl.indexOf('file://') === 0 ?
     this.baseUrl + destination : url.resolve(this.baseUrl, destination);
 
   if (this.ignoreSynchronization) {


### PR DESCRIPTION
I wanted to create a pull request for #1266 in case there was a chance it would be accepted.

When using AngularJS in https://github.com/rogerwang/node-webkit, the browser uses `file://` based urls.

The `baseUrl` in the protractor config is stripped when it begins with `file://` because it is run through `url.resolve`.

This commit simply concatenates `baseUrl` and `destination` when the `baseUrl` begins with `file://`, otherwise it joins the variables with `url.resolve()` as normal.

This is the only issue that prevents us from running tests with protractor in a node-webkit project.
