### PR TITLE
Tutorial link to API for ElementArrayFinder is invalid

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -239,7 +239,7 @@ Since the Calculator reports the oldest result at the bottom, the oldest additio
 
 Fix the test so that it correctly expects the first history entry to contain the text "3 + 4".
 
-ElementArrayFinder also has methods `each`, `map`, `filter`, and `reduce` which are analogous to JavaScript Array methods. [Read the API for more details](#/api?view=ElementArrayFinder).
+ElementArrayFinder also has methods `each`, `map`, `filter`, and `reduce` which are analogous to JavaScript Array methods. [Read the API for more details](/docs/api.md#api-elementarrayfinder).
 
 Where to go next
 ----------------


### PR DESCRIPTION
The 'Read the API for more details' on the tutorial.md wasn't a valid API link.
