### PR TITLE
Add bower install directory

### DIFF
--- a/website/.bowerrc
+++ b/website/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "directory":"bower_components"
+}


### PR DESCRIPTION
I had to add an install directory for bower to be able to generate documents correctly. Using a .bowerrc file with a directory property is the only way I know how to tell bower where to install stuff.
