### PR TITLE
chore(tests): isPresent() shouldn't raise error on chained finders

### DIFF
--- a/spec/basic/elements_spec.js
+++ b/spec/basic/elements_spec.js
@@ -278,6 +278,13 @@ describe('ElementFinder', function() {
     expect(element(by.binding('nopenopenope')).isPresent()).toBe(false);
   });
 
+  it('isPresent() shouldn\'t raise error on chained finders', function() {
+    browser.get('index.html#/form');
+    var elmFinder = $('.nopenopenope').element(by.binding('greet'));
+
+    expect(elmFinder.isPresent()).toBe(false);
+  });
+
   it('should export an allowAnimations helper', function() {
     browser.get('index.html#/animation');
     var animationTop = element(by.id('animationTop'));


### PR DESCRIPTION
I tend to build page objects by taking advantage of ElementFinder chaining feature.

Problem is, when testing for absent chained elements, if some parent isn't present it fails with an exception instead of isPresent() resolving to false.

Attached the test case as a PR, the output is:

```
Failures:

  1) ElementFinder isPresent() shouldn't raise error on chained finders
   Message:
     Error: No element found using locator: By.cssSelector(".nopenopenope")
   Stacktrace:
     Error: No element found using locator: By.cssSelector(".nopenopenope")
==== async task ====
Asynchronous test function: it()
Error
    at null.<anonymous> (/home/user/oss/protractor/spec/basic/elements_spec.js:285:22)
Error
    at null.<anonymous> (/home/user/oss/protractor/spec/basic/elements_spec.js:281:3)
    at Object.<anonymous> (/home/user/oss/protractor/spec/basic/elements_spec.js:3:1)
```
