### PR TITLE
feat(protractor): allow advanced features for ElementArrayFinder

### DIFF
--- a/lib/protractor.js
+++ b/lib/protractor.js
@@ -72,6 +72,30 @@ var buildElementHelper = function(ptor) {
    * ElementArrayFinder is used for operations on an array of elements (as opposed
    * to a single element).
    *
+   * The ElementArrayFinder is used to set up a chain of conditions that identify
+   * an array of elements. In particular, you can call all(locator) and
+   * filter(filterFn) to return a new ElementArrayFinder modified by the
+   * conditions, and you can call get(index) to return a single ElementFinder at
+   * position 'index'.
+   *
+   * Similar to jquery, ElementArrayFinder will search all branches of the DOM
+   * to find the elements that satify the conditions (i.e. all, filter, get).
+   * However, an ElementArrayFinder will not actually retrieve the elements until
+   * an action is called, which means it can be set up in helper files (i.e.
+   * page objects) before the page is available, and reused as the page changes.
+   *
+   * You can treat an ElementArrayFinder as an array of WebElements for most
+   * purposes, in particular, you may perform actions (i.e. click, getText) on
+   * them as you would an array of WebElements. The action will apply to
+   * every element identified by the ElementArrayFinder. ElementArrayFinder
+   * extends Promise, and once an action is performed on an ElementArrayFinder,
+   * the latest result can be accessed using then, and will be returned as an
+   * array of the results; the array has length equal to the length of the
+   * elements found by the ElementArrayFinder and each result represents the
+   * result of performing the action on the element. Unlike a WebElement, an
+   * ElementArrayFinder will wait for the angular app to settle before
+   * performing finds or actions.
+   *
    * @alias element.all(locator)
    * @view
    * <ul class="items">
@@ -87,54 +111,166 @@ var buildElementHelper = function(ptor) {
    * });
    *
    * @constructor
-   * @param {webdriver.Locator} locator An element locator.
-   * @param {ElementFinder=} opt_parentElementFinder The element finder previous to  
-   *     this. (i.e. opt_parentElementFinder.all(locator) => this)
+   * @param {function} getWebElements A function that returns a list of the
+   *    underlying Web Elements.
+   * @param {webdriver.Locator} locator The most relevant locator. It is only
+   *    used for error reporting and ElementArrayFinder.locator.
+   * @param {Array.<webdriver.promise.Promise>} opt_actionResults An array
+   *    of promises which will be retrieved with then. Resolves to the latest
+   *    action result, or null if no action has been called.
    * @return {ElementArrayFinder}
    */
-  var ElementArrayFinder = function(locator, opt_parentElementFinder) {
-    if (!locator) {
-      throw new Error('Locator cannot be empty');
-    }
+  var ElementArrayFinder = function(getWebElements, locator, opt_actionResults) {
+    this.getWebElements = getWebElements || null;
+    this.actionResults_ = opt_actionResults;
     this.locator_ = locator;
-    this.parentElementFinder_ = opt_parentElementFinder || null; 
+
+    var self = this;
+    WEB_ELEMENT_FUNCTIONS.forEach(function(fnName) {
+      self[fnName] = function() {
+        var callerError = new Error();
+        var args = arguments;
+        var actionFn = function(webElem) {
+          return webElem[fnName].apply(webElem, args).then(null, function(e) {
+            e.stack = e.stack + '\n' + callerError.stack;
+            throw e;
+          });
+        };
+        return self.applyAction_(actionFn);
+      };
+    });
   };
+  util.inherits(ElementArrayFinder, webdriver.promise.Promise);
 
   /**
-   * @return {webdriver.Locator}
-   */
-  ElementArrayFinder.prototype.locator = function() {
-    return this.locator_;
-  };
-
-  /**
-   * Returns the array of WebElements represented by this ElementArrayFinder. 
+   * Calls to ElementArrayFinder may be chained to find an array of elements
+   * using the current elements in this ElementArrayFinder as the starting point.
+   * This function returns a new ElementArrayFinder which would contain the
+   * children elements found (and could also be empty).
    *
-   * @alias element.all(locator).getWebElements()
-   * @return {Array.<webdriver.WebElement>}
+   * @alias element.all(locator).all(locator)
+   * @view
+   * <div id='id1' class="parent">
+   *   <ul>
+   *     <li class="foo">1a</li>
+   *     <li class="baz">1b</li>
+   *   </ul>
+   * </div>
+   * <div id='id2' class="parent">
+   *   <ul>
+   *     <li class="foo">2a</li>
+   *     <li class="bar">2b</li>
+   *   </ul>
+   * </div>
+   *
+   * @example
+   * var foo = element.all(by.css('.parent')).all(by.css('.foo'))
+   * expect(foo.getText()).toEqual(['1a', '2a'])
+   * var baz = element.all(by.css('.parent')).all(by.css('.baz'))
+   * expect(baz.getText()).toEqual(['1b'])
+   * var nonexistent = element.all(by.css('.parent')).all(by.css('.NONEXISTENT'))
+   * expect(nonexistent.getText()).toEqual([''])
+   *
+   * @param {webdriver.Locator} subLocator
+   * @return {ElementArrayFinder}
    */
-  ElementArrayFinder.prototype.getWebElements = function() {
-    if (this.parentElementFinder_) {
-      var parentWebElement = this.parentElementFinder_.getWebElement();
-      if (this.locator_.findElementsOverride) {
-        return this.locator_.findElementsOverride(ptor.driver, parentWebElement, ptor.rootEl);
+  ElementArrayFinder.prototype.all = function(locator) {
+    var self = this;
+    var getWebElements = function() {
+      if (self.getWebElements === null) {
+        // This is the first time we are looking for an element
+        return ptor.waitForAngular().then(function() {
+          if (locator.findElementsOverride) {
+            return locator.findElementsOverride(ptor.driver);
+          } else {
+            return ptor.driver.findElements(locator);
+          }
+        });
       } else {
-        return parentWebElement.findElements(this.locator_);
+        return self.getWebElements().then(function(parentWebElements) {
+          var childrenPromiseList = [];
+          // For each parent web element, find their children and construct a 
+          // list of Promise<List<child_web_element>>
+          parentWebElements.forEach(function(parentWebElement) {
+            var childrenPromise = locator.findElementsOverride ?
+                locator.findElementsOverride(ptor.driver, parentWebElement) :
+                parentWebElement.findElements(locator);
+            childrenPromiseList.push(childrenPromise);
+          });
+
+          // Resolve the list of Promise<List<child_web_elements>> and merge into
+          // a single list
+          return webdriver.promise.fullyResolved(childrenPromiseList).then(
+              function(resolved) {
+                var childrenList = [];
+                resolved.forEach(function(resolvedE) {
+                  childrenList = childrenList.concat(resolvedE);
+                });
+                return childrenList;
+              });
+        });
       }
-    } else {
-      var self = this; 
-      return ptor.waitForAngular().then(function() {
-        if (self.locator_.findElementsOverride) {
-          return self.locator_.findElementsOverride(ptor.driver, null, ptor.rootEl);
-        } else {
-          return ptor.driver.findElements(self.locator_);
-        }
-      });
-    }
+    };
+    return new ElementArrayFinder(getWebElements, locator);
   };
 
   /**
-   * Get an element found by the locator by index. The index starts at 0. 
+   * Apply a filter function to each element within the ElementArrayFinder. Returns
+   * a new ElementArrayFinder with all elements that pass the filter function. The
+   * filter function receives the ElementFinder as the first argument
+   * and the index as a second arg.
+   * This does not actually retrieve the underlying list of elements, so it can
+   * be used in page objects.
+   *
+   * @alias element.all(locator).filter(filterFn)
+   * @view
+   * <ul class="items">
+   *   <li class="one">First</li>
+   *   <li class="two">Second</li>
+   *   <li class="three">Third</li>
+   * </ul>
+   *
+   * @example
+   * element.all(by.css('.items li')).filter(function(elem, index) {
+   *   return elem.getText().then(function(text) {
+   *     return text === 'Third';
+   *   });
+   * }).then(function(filteredElements) {
+   *   filteredElements[0].click();
+   * });
+   *
+   * @param {function(ElementFinder, number): webdriver.WebElement.Promise} filterFn 
+   *     Filter function that will test if an element should be returned.
+   *     filterFn can either return a boolean or a promise that resolves to a boolean.
+   * @return {!ElementArrayFinder} A ElementArrayFinder that represents an array
+   *     of element that satisfy the filter function.
+   */
+  ElementArrayFinder.prototype.filter = function(filterFn) {
+    var self = this;
+    var getWebElements = function() {
+      return self.getWebElements().then(function(parentWebElements) {
+        var list = [];
+        parentWebElements.forEach(function(parentWebElement, index) {
+          var elementFinder = self.get(index); // Wrap in ElementFinder
+          var filterResults = filterFn(elementFinder, index);
+          if (filterResults instanceof webdriver.promise.Promise) {
+            filterResults.then(function(satisfies) {
+              if (satisfies) {
+                list.push(parentWebElements[index]);
+              }
+            });
+          } else if (filterResults) {
+            list.push(parentWebElements[index]);
+          }
+        });
+        return list;
+      });
+    };
+    return new ElementArrayFinder(getWebElements, this.locator_);
+  };
+
+  /**
+   * Get an element within the ElementArrayFinder by index. The index starts at 0.
    * This does not actually retrieve the underlying element.
    *
    * @alias element.all(locator).get(index)
@@ -154,12 +290,27 @@ var buildElementHelper = function(ptor) {
    * @return {ElementFinder} finder representing element at the given index.
    */ 
   ElementArrayFinder.prototype.get = function(index) {
-    return new ElementFinder(this.locator_, this.parentElementFinder_, null, index);
+    var self = this;
+    var getWebElements = function() {
+      return self.getWebElements().then(function(parentWebElements) {
+        if (index === -1) {
+          // -1 is special and means last
+          index = parentWebElements.length - 1;
+        }
+        if (index >= parentWebElements.length) {
+          throw new Error('Index out of bound. Trying to access element at ' +
+              'index:' + index + ', but there are only ' +
+              parentWebElements.length + ' elements');
+        }
+        return [parentWebElements[index]];
+      });
+    };
+    return new ElementArrayFinder(getWebElements, this.locator_).toElementFinder_();
   };
 
   /**
-   * Get the first matching element for the locator. This does not actually 
-   * retrieve the underlying element.
+   * Get the first matching element for the ElementArrayFinder. This does not
+   * actually retrieve the underlying element.
    *
    * @alias element.all(locator).first()
    * @view
@@ -180,8 +331,8 @@ var buildElementHelper = function(ptor) {
   };
 
   /**
-   * Get the last matching element for the locator. This does not actually 
-   * retrieve the underlying element.
+   * Get the last matching element for the ElementArrayFinder. This does not
+   * actually retrieve the underlying element.
    *
    * @alias element.all(locator).last()
    * @view
@@ -202,7 +353,26 @@ var buildElementHelper = function(ptor) {
   };
 
   /**
-   * Count the number of elements found by the locator.
+   * Shorthand function for finding arrays of elements by css.
+   *
+   * @type {function(string): ElementArrayFinder}
+   */
+  ElementArrayFinder.prototype.$$ = function(selector) {
+    return this.all(webdriver.By.css(selector));
+  };
+
+  /**
+   * Returns an ElementFinder representation of ElementArrayFinder. It ensures
+   * that the ElementArrayFinder resolves to one and only one underlying element.
+   *
+   * @return {ElementFinder} An ElementFinder representation
+   */
+  ElementArrayFinder.prototype.toElementFinder_ = function() {
+    return new ElementFinder(this);
+  };
+
+  /**
+   * Count the number of elements represented by the ElementArrayFinder.
    *
    * @alias element.all(locator).count()
    * @view
@@ -226,6 +396,37 @@ var buildElementHelper = function(ptor) {
   };
 
   /**
+   * Returns the most relevant locator.
+   * i.e.
+   *     $('#ID1').locator() returns by.css('#ID1')
+   *     $('#ID1').$('#ID2').locator() returns by.css('#ID2')
+   *     $$('#ID1').filter(filterFn).get(0).click().locator() returns by.css('#ID1')
+   * @return {webdriver.Locator}
+   */
+  ElementArrayFinder.prototype.locator = function() {
+    return this.locator_;
+  };
+
+  /**
+   * Apply an action function to every element in the ElementArrayFinder,
+   * and return a new ElementArrayFinder that contains the results of the actions.
+   *
+   * @param {function(ElementFinder)} actionFn
+   *
+   * @return {ElementArrayFinder}
+   */
+  ElementArrayFinder.prototype.applyAction_ = function(actionFn) {
+    var actionResults = this.getWebElements().then(function(arr) {
+      var list = [];
+      arr.forEach(function(webElem) {
+        list.push(actionFn(webElem));
+      });
+      return list;
+    });
+    return new ElementArrayFinder(this.getWebElements, this.locator_, actionResults);
+  };
+
+  /**
    * Represents the ElementArrayFinder as an array of ElementFinders.
    *
    * @return {Array.<ElementFinder>} Return a promise, which resolves to a list 
@@ -236,15 +437,16 @@ var buildElementHelper = function(ptor) {
     return this.getWebElements().then(function(arr) {
       var list = [];
       arr.forEach(function(webElem, index) {
-        list.push(new ElementFinder(self.locator_, self.parentElementFinder_, null, index));
+        list.push(self.get(index));
       });
       return list; 
     });
   };
 
   /**
-   * Find the elements specified by the locator. The input function is passed
-   * to the resulting promise, which resolves to an array of ElementFinders.
+   * Retrieve the elements represented by the ElementArrayFinder. The input
+   * function is passed to the resulting promise, which resolves to an
+   * array of ElementFinders.
    *
    * @alias element.all(locator).then(thenFunction)
    * @view
@@ -260,16 +462,21 @@ var buildElementHelper = function(ptor) {
    * });
    *
    * @param {function(Array.<ElementFinder>)} fn
+   * @param {function(Error)} errorFn
    *
    * @type {webdriver.promise.Promise} a promise which will resolve to
-   *     an array of ElementFinders matching the locator.
+   *     an array of ElementFinders represented by the ElementArrayFinder.
    */
-  ElementArrayFinder.prototype.then = function(fn) {
-    return this.asElementFinders_().then(fn);
+  ElementArrayFinder.prototype.then = function(fn, errorFn) {
+    if (this.actionResults_) {
+      return webdriver.promise.fullyResolved(this.actionResults_).then(fn, errorFn);
+    } else {
+      return this.asElementFinders_().then(fn, errorFn);
+    }
   };
 
   /**
-   * Calls the input function on each ElementFinder found by the locator.
+   * Calls the input function on each ElementFinder represented by the ElementArrayFinder.
    *
    * @alias element.all(locator).each(eachFunction)
    * @view
@@ -296,7 +503,7 @@ var buildElementHelper = function(ptor) {
   };
 
   /**
-   * Apply a map function to each element found using the locator. The
+   * Apply a map function to each element within the ElementArrayFinder. The
    * callback receives the ElementFinder as the first argument and the index as
    * a second arg.
    *
@@ -335,49 +542,6 @@ var buildElementHelper = function(ptor) {
         // All nested arrays and objects will also be fully resolved.
         webdriver.promise.fullyResolved(mapResult).then(function(resolved) {
           list.push(resolved);
-        });
-      });
-      return list;
-    });
-  };
-
-  /**
-   * Apply a filter function to each element found using the locator. Returns 
-   * promise of a new array with all elements that pass the filter function. The
-   * filter function receives the ElementFinder as the first argument 
-   * and the index as a second arg.
-   *
-   * @alias element.all(locator).filter(filterFn)
-   * @view
-   * <ul class="items">
-   *   <li class="one">First</li>
-   *   <li class="two">Second</li>
-   *   <li class="three">Third</li>
-   * </ul>
-   *
-   * @example
-   * element.all(by.css('.items li')).filter(function(elem, index) {
-   *   return elem.getText().then(function(text) {
-   *     return text === 'Third';
-   *   });
-   * }).then(function(filteredElements) {
-   *   filteredElements[0].click();
-   * });
-   *
-   * @param {function(ElementFinder, number): webdriver.WebElement.Promise} filterFn 
-   *     Filter function that will test if an element should be returned.
-   *     filterFn should return a promise that resolves to a boolean.
-   * @return {!webdriver.promise.Promise} A promise that resolves to an array
-   *     of ElementFinders that satisfy the filter function.
-   */
-  ElementArrayFinder.prototype.filter = function(filterFn) {
-    return this.asElementFinders_().then(function(arr) {
-      var list = [];
-      arr.forEach(function(elementFinder, index) {
-        filterFn(elementFinder, index).then(function(satisfies) {
-          if (satisfies) {
-            list.push(elementFinder);
-          }
         });
       });
       return list;
@@ -428,6 +592,45 @@ var buildElementHelper = function(ptor) {
   };
 
   /**
+   * Evaluates the input as if it were on the scope of the current underlying
+   * elements.
+   * @param {string} expression
+   *
+   * @return {ElementArrayFinder} which resolves to the
+   *     evaluated expression for each underlying element.
+   *     The result will be resolved as in
+   *     {@link webdriver.WebDriver.executeScript}. In summary - primitives will
+   *     be resolved as is, functions will be converted to string, and elements
+   *     will be returned as a WebElement.
+   */
+  ElementArrayFinder.prototype.evaluate = function(expression) {
+    var evaluationFn = function(webElem) {
+      return webElem.getDriver().executeScript(
+          clientSideScripts.evaluate, webElem, expression);
+    };
+    return this.applyAction_(evaluationFn);
+  };
+
+  /**
+   * Determine if animation is allowed on the current underlying elements.
+   * @param {string} value
+   *
+   * @return {ElementArrayFinder} which resolves to whether animation is allowed.
+   */
+  ElementArrayFinder.prototype.allowAnimations = function(value) {
+    var allowAnimationsTestFn = function(webElem) {
+      return webElem.getDriver().executeScript(
+          clientSideScripts.allowAnimations, webElem, value);
+    };
+    return this.applyAction_(allowAnimationsTestFn);
+  };
+
+  /**
+   * The ElementFinder simply represents a single element of an
+   * ElementArrayFinder (and is more like a convenience object). As a result,
+   * anything that can be done with an ElementFinder, can also be done using
+   * an ElementArrayFinder.
+   *
    * The ElementFinder can be treated as a WebElement for most purposes, in 
    * particular, you may perform actions (i.e. click, getText) on them as you
    * would a WebElement. ElementFinders extend Promise, and once an action 
@@ -461,48 +664,119 @@ var buildElementHelper = function(ptor) {
    * expect(input.getAttribute('value')).toBe('Foo123');
    *
    * @constructor
-   * @param {webdriver.Locator} locator An element locator.
-   * @param {ElementFinder=} opt_parentElementFinder The element finder previous 
-   *     to this. (i.e. opt_parentElementFinder.element(locator) => this)
-   * @param {webdriver.promise.Promise} opt_actionResult The promise which 
-   *     will be retrieved with then. Resolves to the latest action result, 
-   *     or null if no action has been called.
-   * @param {number=} opt_index The index of the element to retrieve. null means
-   *     retrieve the only element, while -1 means retrieve the last element
+   * @param {ElementArrayFinder} elementArrayFinder The ElementArrayFinder
+   *     that this is branched from.
    * @return {ElementFinder}
    */
-  var ElementFinder = function(locator, opt_parentElementFinder, opt_actionResult, opt_index) {
-    if (!locator) {
-      throw new Error ('Locator cannot be empty');
+  var ElementFinder = function(elementArrayFinder) {
+    if (!elementArrayFinder) {
+      throw new Error('BUG: elementArrayFinder cannot be empty');
     }
-    this.locator_ = locator;
-    this.parentElementFinder_ = opt_parentElementFinder || null;
-    this.opt_actionResult_ = opt_actionResult;
-    this.opt_index_ = opt_index; 
+    this.parentElementArrayFinder = elementArrayFinder;
 
-    var self = this; 
+    // This filter verifies that there is only 1 element returned by the 
+    // elementArrayFinder. It will warn if there are more than 1 element and
+    // throw an error if there are no elements.
+    var getWebElements = function() {
+      return elementArrayFinder.getWebElements().then(function(webElements) {
+        if (webElements.length === 0) {
+          throw new Error('No element found using locator: ' +
+              elementArrayFinder.locator_.toString());
+        } else {
+          if (webElements.length > 1) {
+            console.log('warning: more than one element found for locator ' +
+                elementArrayFinder.locator_.toString() +
+                ' - you may need to be more specific');
+          }
+          return [webElements[0]];
+        }
+      });
+    };
+
+    // Store a copy of the underlying elementArrayFinder, but with the more
+    // restrictive getWebElements (which checks that there is only 1 element).
+    this.elementArrayFinder_ = new ElementArrayFinder(
+        getWebElements, elementArrayFinder.locator_,
+        elementArrayFinder.actionResults_);
+
+    // Decorate ElementFinder with webdriver functions. Simply calls the
+    // underlying elementArrayFinder to perform these functions.
+    var self = this;
     WEB_ELEMENT_FUNCTIONS.forEach(function(fnName) {
-      if(!self[fnName]) {
-        self[fnName] = function() {
-          var callerError = new Error();
-          var args = arguments;
-          var webElem = self.getWebElement();
-          var actionResult = webElem.then(
-              function(webElem_) {
-                return webElem_[fnName].apply(webElem_, args).then(null, function(e) {
-                  e.stack = e.stack + '\n' + callerError.stack;
-                  throw e;
-                });
-              });
-
-          return new ElementFinder(
-              locator, opt_parentElementFinder, 
-              actionResult, opt_index);
-        };
-      }
+      self[fnName] = function() {
+        return self.elementArrayFinder_[fnName].
+            apply(self.elementArrayFinder_, arguments).toElementFinder_();
+      };
     });
   };
   util.inherits(ElementFinder, webdriver.promise.Promise);
+
+  /**
+   * See ElementArrayFinder.prototype.locator
+   * @return {webdriver.Locator}
+   */
+  ElementFinder.prototype.locator = function() {
+    return this.elementArrayFinder_.locator();
+  };
+
+  /**
+   * Returns the WebElement represented by this ElementFinder.
+   * Throws the WebDriver error if the element doesn't exist.
+   *
+   * @example
+   * The following three expressions are equivalent.
+   *  - element(by.css('.parent')).getWebElement();
+   *  - browser.waitForAngular(); browser.driver.findElement(by.css('.parent'));
+   *  - browser.findElement(by.css('.parent'))
+   *
+   * @alias element(locator).getWebElement()
+   * @return {webdriver.WebElement}
+   */
+  ElementFinder.prototype.getWebElement = function() {
+    var id = this.elementArrayFinder_.getWebElements().then(
+        function(parentWebElements) {
+          return parentWebElements[0];
+        });
+    return new webdriver.WebElement(ptor.driver, id);
+  };
+
+  /**
+   * Access the underlying actionResult of ElementFinder. Implementation allows
+   * ElementFinder to be used as a webdriver.promise.Promise
+   * @param {function(webdriver.promise.Promise)} fn Function which takes
+   *     the value of the underlying actionResult.
+   *
+   * @return {webdriver.promise.Promise} Promise which contains the results of 
+   *     evaluating fn.
+   */
+  ElementFinder.prototype.then = function(fn, errorFn) {
+    return this.elementArrayFinder_.then(function(actionResults) {
+      return fn(actionResults[0]);
+    }, errorFn);
+  };
+
+  /** 
+   * Calls to element may be chained to find an array of elements within a parent.
+   *
+   * @alias element(locator).all(locator)
+   * @view
+   * <div class="parent">
+   *   <ul>
+   *     <li class="one">First</li>
+   *     <li class="two">Second</li>
+   *     <li class="three">Third</li>
+   *   </ul>
+   * </div>
+   *
+   * @example
+   * var items = element(by.css('.parent')).all(by.tagName('li'))
+   *
+   * @param {webdriver.Locator} subLocator
+   * @return {ElementArrayFinder}
+   */
+  ElementFinder.prototype.all = function(subLocator) {
+    return this.elementArrayFinder_.all(subLocator);
+  };
 
   /**
    * Calls to element may be chained to find elements within a parent.
@@ -532,52 +806,7 @@ var buildElementHelper = function(ptor) {
    * @return {ElementFinder}
    */
   ElementFinder.prototype.element = function(subLocator) {
-    return new ElementFinder(subLocator, this);
-  };
-
-  /** 
-   * Calls to element may be chained to find an array of elements within a parent.
-   *
-   * @alias element(locator).all(locator)
-   * @view
-   * <div class="parent">
-   *   <ul>
-   *     <li class="one">First</li>
-   *     <li class="two">Second</li>
-   *     <li class="three">Third</li>
-   *   </ul>
-   * </div>
-   *
-   * @example
-   * var items = element(by.css('.parent')).all(by.tagName('li'))
-   *
-   * @param {webdriver.Locator} subLocator
-   * @return {ElementArrayFinder}
-   */
-  ElementFinder.prototype.all = function(subLocator) {
-    return new ElementArrayFinder(subLocator, this);
-  };
-
-  /**
-   * Shortcut for querying the document directly with css.
-   *
-   * @alias $(cssSelector)
-   * @view
-   * <div class="count">
-   *   <span class="one">First</span>
-   *   <span class="two">Second</span>
-   * </div>
-   *
-   * @example
-   * var item = $('.count .two');
-   * expect(item.getText()).toBe('Second');
-   *
-   * @param {string} selector A css selector
-   * @return {ElementFinder} which identifies the located 
-   *     {@link webdriver.WebElement}
-   */
-  ElementFinder.prototype.$ = function(selector) {
-    return new ElementFinder(webdriver.By.css(selector), this);
+    return this.all(subLocator).toElementFinder_();
   };
 
   /**
@@ -605,7 +834,29 @@ var buildElementHelper = function(ptor) {
    *     array of the located {@link webdriver.WebElement}s.
    */
   ElementFinder.prototype.$$ = function(selector) {
-    return new ElementArrayFinder(webdriver.By.css(selector), this);
+    return this.all(webdriver.By.css(selector));
+  };
+
+  /**
+   * Shortcut for querying the document directly with css.
+   *
+   * @alias $(cssSelector)
+   * @view
+   * <div class="count">
+   *   <span class="one">First</span>
+   *   <span class="two">Second</span>
+   * </div>
+   *
+   * @example
+   * var item = $('.count .two');
+   * expect(item.getText()).toBe('Second');
+   *
+   * @param {string} selector A css selector
+   * @return {ElementFinder} which identifies the located
+   *     {@link webdriver.WebElement}
+   */
+  ElementFinder.prototype.$ = function(selector) {
+    return this.element(webdriver.By.css(selector));
   };
 
   /**
@@ -625,12 +876,9 @@ var buildElementHelper = function(ptor) {
    *     the element is present on the page.
    */
   ElementFinder.prototype.isPresent = function() {
-    var isPresent = new ElementArrayFinder(
-        this.locator_, this.parentElementFinder_).count().then(function(count) {
+    return this.parentElementArrayFinder.count().then(function(count) {
       return !!count;
     });
-    return new ElementFinder(
-        this.locator_, this.parentElementFinder_, isPresent, this.opt_index_);
   };
 
   /**
@@ -648,117 +896,27 @@ var buildElementHelper = function(ptor) {
   };
 
   /**
-   * Get the element locator used to create this element finder.
-   * @return {webdriver.Locator} An element locator.
-   */
-  ElementFinder.prototype.locator = function() {
-    return this.locator_;
-  };
-
-  /**
-   * Returns the WebElement represented by this ElementFinder. 
-   * Throws the WebDriver error if the element doesn't exist.
-   * If index is null, it makes sure that there is only one underlying
-   * WebElement described by the chain of locators and issues a warning 
-   * otherwise. If index is not null, it retrieves the WebElement specified by 
-   * the index.
-   *
-   * @example
-   * The following three expressions are equivalent.
-   *  - element(by.css('.parent')).getWebElement();
-   *  - browser.waitForAngular(); browser.driver.findElement(by.css('.parent'));
-   *  - browser.findElement(by.css('.parent'))
-   *
-   * @return {webdriver.WebElement}
-   */
-  ElementFinder.prototype.getWebElement = function() {
-    var self = this; 
-    var callerError = new Error();
-    var webElementsPromise = new ElementArrayFinder(
-        this.locator_, this.parentElementFinder_).getWebElements();
-
-    var id = webElementsPromise.then(function(arr) {
-      var locatorMessage = self.locator_.toString();
-      if (!arr.length) {
-        throw new Error('No element found using locator: ' + locatorMessage);
-      }
-      var index = self.opt_index_; 
-      if (index == null) {
-        // index null means we make sure there is only one element
-        if (arr.length > 1) {
-          console.log('warning: more than one element found for locator ' +
-              locatorMessage + ' - you may need to be more specific');
-        }
-        index = 0;
-      } else if (index === -1) {
-        // -1 is special and means last
-        index = arr.length - 1;
-      }
-
-      if (index >= arr.length) {
-        throw new Error('Index out of bound. Trying to access index:' + index + 
-            ', but locator: ' + locatorMessage + ' only has ' + 
-            arr.length + ' elements');
-      }
-      return arr[index];
-    }).then(null, function(e) {
-      e.stack = e.stack + '\n' + callerError.stack;
-      throw e;
-    });
-    return new webdriver.WebElement(ptor.driver, id);
-  };
-
-  /**
    * Evaluates the input as if it were on the scope of the current element.
    * @param {string} expression
    *
-   * @return {ElementFinder} which resolves to the
-   *     evaluated expression. The result will be resolved as in
-   *     {@link webdriver.WebDriver.executeScript}. In summary - primitives will
-   *     be resolved as is, functions will be converted to string, and elements
-   *     will be returned as a WebElement.
+   * @return {ElementFinder} which resolves to the evaluated expression.
    */
   ElementFinder.prototype.evaluate = function(expression) {
-    var webElement = this.getWebElement();
-    var evaluatedResult = webElement.getDriver().executeScript(
-          clientSideScripts.evaluate, webElement, expression);
-    return new ElementFinder(this.locator_, this.parentElementFinder_, 
-      evaluatedResult, this.opt_index_);
+    return this.elementArrayFinder_.evaluate(expression).toElementFinder_();
   };
 
   /**
-   * Determine if animation is allowed on the current element.
+   * See ElementArrayFinder.prototype.allowAnimations.
    * @param {string} value
    *
    * @return {ElementFinder} which resolves to whether animation is allowed.
    */
   ElementFinder.prototype.allowAnimations = function(value) {
-    var webElement = this.getWebElement();
-    var allowAnimationsResult = webElement.getDriver().executeScript(
-          clientSideScripts.allowAnimations, webElement, value);
-    return new ElementFinder(this.locator_, this.parentElementFinder_, 
-      allowAnimationsResult, this.opt_index_);
+    return this.elementArrayFinder_.allowAnimations(value).toElementFinder_();
   };
 
   /**
-   * Access the underlying actionResult of ElementFinder. Implementation allows
-   * ElementFinder to be used as a webdriver.promise.Promise
-   * @param {function(webdriver.promise.Promise)} fn Function which takes 
-   *     the value of the underlying actionResult.
-   *
-   * @return {webdriver.promise.Promise} Promise which contains the results of 
-   *     evaluating fn.
-   */
-  ElementFinder.prototype.then = function(fn, errorFn) {
-    if (this.opt_actionResult_) {
-      return this.opt_actionResult_.then(fn, errorFn);
-    } else {
-      return webdriver.promise.fulfilled(fn(this));
-    }
-  };
-
-  /**
-   * Webdriver rely on this function to be present on Promises, so adding
+   * Webdriver relies on this function to be present on Promises, so adding
    * this dummy function as we inherited from webdriver.promise.Promise, but
    * this function is irrelevant to our usage
    *
@@ -769,11 +927,11 @@ var buildElementHelper = function(ptor) {
   };
 
   var element = function(locator) {
-    return new ElementFinder(locator);
+    return new ElementArrayFinder().all(locator).toElementFinder_();
   };
 
   element.all = function(locator) {
-    return new ElementArrayFinder(locator);
+    return new ElementArrayFinder().all(locator);
   };
 
   return element;

--- a/spec/basic/elements_spec.js
+++ b/spec/basic/elements_spec.js
@@ -73,6 +73,154 @@ describe('ElementFinder', function() {
     expect(reused.getText()).toEqual('Inner: inner');
   });
 
+  it('should determine element presence properly with chaining', function() {
+    browser.get('index.html#/conflict');
+    expect(element(by.id('baz')).
+        isElementPresent(by.binding('item.reusedBinding'))).
+        toBe(true);
+
+    expect(element(by.id('baz')).
+        isElementPresent(by.binding('nopenopenope'))).
+        toBe(false);
+  });
+
+  it('should export an isPresent helper', function() {
+    browser.get('index.html#/form');
+
+    expect(element(by.binding('greet')).isPresent()).toBe(true);
+    expect(element(by.binding('nopenopenope')).isPresent()).toBe(false);
+  });
+
+  it('should export an allowAnimations helper', function() {
+    browser.get('index.html#/animation');
+    var animationTop = element(by.id('animationTop'));
+    var toggledNode = element(by.id('toggledNode'));
+
+    expect(animationTop.allowAnimations()).toBe(true);
+    animationTop.allowAnimations(false);
+    expect(animationTop.allowAnimations()).toBe(false);
+
+    expect(toggledNode.isPresent()).toBe(true);
+    element(by.id('checkbox')).click();
+    expect(toggledNode.isPresent()).toBe(false);
+  });
+
+  it('should keep a reference to the original locator', function() {
+    browser.get('index.html#/form');
+
+    var byCss = by.css('body');
+    var byBinding = by.binding('greet');
+
+    expect(element(byCss).locator()).toEqual(byCss);
+    expect(element(byBinding).locator()).toEqual(byBinding);
+  });
+
+  it('should propagate exceptions', function() {
+    browser.get('index.html#/form');
+    var successful = protractor.promise.defer();
+
+    var invalidElement = element(by.binding('INVALID'));
+    invalidElement.getText().then(function(value) {
+      successful.fulfill(true);
+    }, function(err) {
+      successful.fulfill(false);
+    });
+    expect(successful).toEqual(false);
+  });
+});
+
+describe('ElementArrayFinder', function() {
+
+  it('action should act on all elements', function() {
+    browser.get('index.html#/conflict');
+
+    var multiElement = element.all(by.binding('item.reusedBinding'));
+    expect(multiElement.getText()).toEqual(['Outer: outer', 'Inner: inner']);
+  });
+
+  it('action should act on all elements selected by filter', function() {
+    browser.get('index.html');
+
+    var multiElement = $$('#checkboxes input').filter(function(elem, index) {
+      return index == 1 || index == 2;
+    });
+    multiElement.click();
+    expect($('#letterlist').getText()).toEqual('wx');
+  });
+
+  it('filter should chain with index correctly', function() {
+    browser.get('index.html');
+
+    var elem = $$('#checkboxes input').filter(function(elem, index) {
+      return index == 1 || index == 2;
+    }).last();
+    elem.click();
+    expect($('#letterlist').getText()).toEqual('x');
+  });
+
+  it('filter should work in page object', function() {
+    var elements = element.all(by.css('.menu li a')).filter(function(elem) {
+      return elem.getText().then(function(text) {
+        return text === 'bindings';
+      });
+    });
+
+    browser.get('index.html#/form');
+    expect(elements.count()).toEqual(1);
+  });
+
+  it('should be able to get ElementFinder from filtered ElementArrayFinder', function() {
+    var containsI = function(elem) {
+      return elem.getText().then(function(text) {
+        return text.indexOf("i") > -1;
+      });
+    };
+    var elements = element.all(by.css('.menu li a')).filter(containsI);
+
+    browser.get('index.html#/form');
+    expect(elements.count()).toEqual(4);
+    expect(elements.get(3).getText()).toEqual('animation');
+  });
+
+  it('filter should be compoundable', function() {
+    var containsA = function(elem) {
+      return elem.getText().then(function(text) {
+        return text.indexOf("a") > -1;
+      });
+    };
+    var containsI = function(elem) {
+      return elem.getText().then(function(text) {
+        return text.indexOf("i") > -1;
+      });
+    };
+    var elements = element.all(by.css('.menu li a')).filter(containsA).filter(containsI);
+
+    browser.get('index.html#/form');
+    expect(elements.count()).toEqual(1);
+    elements.then(function(arr) {
+      expect(arr[0].getText()).toEqual('animation');
+    });
+  });
+
+  it('filter should work with reduce', function() {
+    var containsA = function(elem) {
+      return elem.getText().then(function(text) {
+        return text.indexOf("a") > -1;
+      });
+    };
+    browser.get('index.html#/form');
+    var value = element.all(by.css('.menu li a')).filter(containsA).
+        reduce(function(currentValue, elem, index, elemArr) {
+          return elem.getText().then(function(text) {
+            return currentValue + index + '/' + elemArr.length + ': ' + text + '\n';
+          });
+        }, '');
+
+    expect(value).toEqual('0/3: repeater\n' +
+                          '1/3: async\n' +
+                          '2/3: animation\n');
+  });
+
   it('should find multiple elements scoped properly with chaining', function() {
     browser.get('index.html#/conflict');
 
@@ -109,17 +257,6 @@ describe('ElementFinder', function() {
     expect(first.getText()).toEqual('Inner: inner');
     expect(second.getText()).toEqual('Inner other: innerbarbaz');
     expect(last.getText()).toEqual('Inner other: innerbarbaz');
-  });
-
-  it('should determine element presence properly with chaining', function() {
-    browser.get('index.html#/conflict');
-    expect(element(by.id('baz')).
-        isElementPresent(by.binding('item.reusedBinding'))).
-        toBe(true);
-
-    expect(element(by.id('baz')).
-        isElementPresent(by.binding('nopenopenope'))).
-        toBe(false);
   });
 
   it('should count all elements', function() {
@@ -269,50 +406,6 @@ describe('ElementFinder', function() {
                           '4/7: conflict\n' +
                           '5/7: polling\n' +
                           '6/7: animation\n');
-  });
-
-  it('should export an isPresent helper', function() {
-    browser.get('index.html#/form');
-
-    expect(element(by.binding('greet')).isPresent()).toBe(true);
-    expect(element(by.binding('nopenopenope')).isPresent()).toBe(false);
-  });
-
-  it('should export an allowAnimations helper', function() {
-    browser.get('index.html#/animation');
-    var animationTop = element(by.id('animationTop'));
-    var toggledNode = element(by.id('toggledNode'));
-
-    expect(animationTop.allowAnimations()).toBe(true);
-    animationTop.allowAnimations(false);
-    expect(animationTop.allowAnimations()).toBe(false);
-
-    expect(toggledNode.isPresent()).toBe(true);
-    element(by.id('checkbox')).click();
-    expect(toggledNode.isPresent()).toBe(false);
-  });
-
-  it('should keep a reference to the original locator', function() {
-    browser.get('index.html#/form');
-
-    var byCss = by.css('body');
-    var byBinding = by.binding('greet');
-
-    expect(element(byCss).locator()).toEqual(byCss);
-    expect(element(byBinding).locator()).toEqual(byBinding);
-  });
-
-  it('should propagate exceptions', function() {
-    browser.get('index.html#/form');
-    var successful = protractor.promise.defer();
-
-    var invalidElement = element(by.binding('INVALID'));
-    invalidElement.getText().then(function(value) {
-      successful.fulfill(true);
-    }, function(err) {
-      successful.fulfill(false);
-    });
-    expect(successful).toEqual(false);
   });
 
   it('should always return a promise when calling then', function() {

--- a/spec/basic/locators_spec.js
+++ b/spec/basic/locators_spec.js
@@ -22,11 +22,11 @@ describe('locators', function() {
       expect(element(by.binding('greeting'))).toHaveText('Hiya');
     });
 
-    it('ElementFinder.then should resolve to itself', function() {
+    it('ElementFinder.then should be equivalent to itself', function() {
       var elem = element(by.binding('greeting'));
 
       elem.then(function(elem2) {
-        expect(elem).toEqual(elem2);
+        expect(elem.toWireValue()).toEqual(elem2.toWireValue());
       });
     });
 


### PR DESCRIPTION
changed ElementFinder as a subset of an ElementArrayFinder.

This enables actions on ElementArrayFinders, such as:
`element.all(by.css('.foo')).click()`

The function `filter` now returns an ElementArrayFinder, so you may also do:
`element.all(by.css('.foo')).filter(filterFn).click()`

or

`element.all(by.css('.foo')).filter(filterFn).last().click()`
