### PR TITLE
webdriver-manager Selenium hub option and direct binary download URLs

### DIFF
--- a/bin/webdriver-manager
+++ b/bin/webdriver-manager
@@ -25,13 +25,6 @@ var shortVersion = function(version) {
   return version.slice(0, version.lastIndexOf('.'));
 }
 
-/**
- * Add string.endsWith method
- */
-String.prototype.endsWith = function(suffix) {
-    return this.indexOf(suffix, this.length - suffix.length) !== -1;
-};
-
 var binaries = {
   standalone: {
     name: 'selenium standalone',


### PR DESCRIPTION
This pull request adds a --hub option to webdriver-manager. This option runs Selenium Grid as a hub role, useful for running multiple browser tests at once, or using PhantomJS.

It also adds the ability to specify direct download URLs for webdriver binaries (selenium-standalone-server, chrome, iedriver) - this is useful to overcome specific bugs that have fixes that are not yet in the releases, but can be fixed by using a private build of the tip.

Direct download urls are optional, and specified in `package.json`, like so:

```
"webdriverVersions": {
    "selenium": "2.43-httpclient-fix",
    "seleniumDownloadUrl": "https://github.com/adamfeuer/selenium/releases/download/selenium-standalone-2.43-httpclient-fix/selenium-server-standalone-2.43-httpclient-fix.jar",
    "chromedriver": "2.10-fix-a",
    "chromedriverDownloadUrl": "https://github.com/adamfeuer/path/to/some/directory/chromedriver-2.10-fix-a.zip",
    "iedriver": "2.42.0-fix-b" ,
    "iedriverDownloadUrl": "https://github.com/adamfeuer/path/to/some/directory/iedriver-2.42.0-fix-b.zip"
}
```
