### PR TITLE
fix(element): isPresent should not throw on chained finders

### DIFF
--- a/lib/protractor.js
+++ b/lib/protractor.js
@@ -393,6 +393,12 @@ var buildElementHelper = function(ptor) {
   ElementArrayFinder.prototype.count = function() {
     return this.getWebElements().then(function(arr) {
       return arr.length;
+    }, function(err) {
+      if (err.code == webdriver.error.ErrorCode.NO_SUCH_ELEMENT) {
+        return 0;
+      } else {
+        throw err;
+      }
     });
   };
 
@@ -682,8 +688,10 @@ var buildElementHelper = function(ptor) {
     var getWebElements = function() {
       return elementArrayFinder.getWebElements().then(function(webElements) {
         if (webElements.length === 0) {
-          throw new Error('No element found using locator: ' +
-              elementArrayFinder.locator_.toString());
+          throw new webdriver.error.Error(
+              webdriver.error.ErrorCode.NO_SUCH_ELEMENT,
+              'No element found using locator: ' +
+                  elementArrayFinder.locator_.toString());
         } else {
           if (webElements.length > 1) {
             console.log('warning: more than one element found for locator ' +

--- a/spec/basic/elements_spec.js
+++ b/spec/basic/elements_spec.js
@@ -91,6 +91,34 @@ describe('ElementFinder', function() {
     expect(element(by.binding('nopenopenope')).isPresent()).toBe(false);
   });
 
+  it('should allow handling errors', function() {
+    browser.get('index.html#/form');
+    var elmFinder = $('.nopenopenope').getText().then(function(success) {
+      // This should throw an error. Fail.
+      expect(true).toEqual(false);
+    }, function(err) {
+      expect(true).toEqual(true);
+    });
+  });
+
+  it('should allow handling chained errors', function() {
+    browser.get('index.html#/form');
+    var elmFinder = $('.nopenopenope').$('furthernope').getText().then(
+      function(success) {
+        // This should throw an error. Fail.
+        expect(true).toEqual(false);
+      }, function(err) {
+        expect(true).toEqual(true);
+      });
+  });
+
+  it('isPresent() should not raise error on chained finders', function() {
+    browser.get('index.html#/form');
+    var elmFinder = $('.nopenopenope').element(by.binding('greet'));
+
+    expect(elmFinder.isPresent()).toBe(false);
+  });
+
   it('should export an allowAnimations helper', function() {
     browser.get('index.html#/animation');
     var animationTop = element(by.id('animationTop'));


### PR DESCRIPTION
Now, `$('nonexistant').$('foo').isPresent()` will return false instead
of throwing an error. This change also adds tests that ensure
that catching errors from promises works as expected.
