### PR TITLE
tests(protractor): advanced features for ElementArrayFinder

### DIFF
--- a/spec/basic/elements_spec.js
+++ b/spec/basic/elements_spec.js
@@ -196,6 +196,15 @@ describe('ElementArrayFinder', function() {
     expect(multiElement.getText()).toEqual(['Outer: outer', 'Inner: inner']);
   });
 
+  it('action should act on all input elements', function() {
+    var checkboxesElms = $$('#checkboxes input');
+    browser.get('index.html');
+
+    expect(checkboxesElms.isSelected()).toEqual([true, false, false]);
+    checkboxesElms.click();
+    expect(checkboxesElms.isSelected()).toEqual([false, true, true]);
+  });
+
   it('action should act on all elements selected by filter', function() {
     browser.get('index.html');
 


### PR DESCRIPTION
User in StackOverflow reports `$$('i.icon-trash').click();` isn't [working for him](http://stackoverflow.com/questions/25896061/protractor-how-to-click-all-delete-buttons-in-a-page-object/25985521?noredirect=1#comment40757134_25985521)

Works for me and tried to find a clear test case to prove him wrong but could only found `selected by filter` examples so adding this one.
