### PR TITLE
feat(config): Option to exclude test for specific capability

### DIFF
--- a/docs/referenceConf.js
+++ b/docs/referenceConf.js
@@ -109,7 +109,11 @@ exports.config = {
     maxInstances: 1,
 
     // Additional spec files to be run on this capability only.
-    specs: ['spec/chromeOnlySpec.js']
+    specs: ['spec/chromeOnlySpec.js'],
+
+    // Spec files to be excluded on this capability only.
+    exclude: ['spec/doNotRunInChromeSpec.js']
+
   },
 
   // If you would like to run more than one instance of WebDriver on the same

--- a/lib/taskScheduler.js
+++ b/lib/taskScheduler.js
@@ -55,6 +55,15 @@ var TaskScheduler = function(config) {
       capabilitySpecs = capabilitySpecs.concat(capabilitySpecificSpecs);
     }
 
+    if (capability.exclude) {
+      var capabilitySpecExcludes = ConfigParser.resolveFilePatterns(
+          capability.exclude, true, config.configDir);
+      capabilitySpecs = ConfigParser.resolveFilePatterns(
+          capabilitySpecs).filter(function(path) {
+              return capabilitySpecExcludes.indexOf(path) < 0;
+          });
+    }
+
     var specLists = [];
     // If we shard, we return an array of one element arrays, each containing 
     // the spec file. If we don't shard, we return an one element array 

--- a/spec/unit/taskScheduler_test.js
+++ b/spec/unit/taskScheduler_test.js
@@ -221,4 +221,26 @@ describe('the task scheduler', function() {
 
     expect(scheduler.numTasksRemaining()).toEqual(0);
   });
+
+  it('should exclude capability-specific specs', function() {
+    var toAdd = {
+        specs: [
+            'spec/unit/data/fakespecA.js',
+            'spec/unit/data/fakespecB.js'
+        ],
+        multiCapabilities: [{
+            'browserName': 'chrome',
+            exclude: 'spec/unit/data/fakespecB.js'
+        }]
+    };
+    var config = new ConfigParser().addConfig(toAdd).getConfig();
+    var scheduler = new TaskScheduler(config);
+
+    var task = scheduler.nextTask();
+    expect(task.capability.browserName).toEqual('chrome');
+    expect(task.specs.length).toEqual(1);
+
+    expect(scheduler.numTasksRemaining()).toEqual(0);
+  });
+
 });


### PR DESCRIPTION
Add the option to exclude spec files for a specific capability.
This way you can ignore spec files for one capability only.
For example if the test is known to fail in the capability.

Closes #1230
