### PR TITLE
fix(taskScheduler) Do not run other browsers then Chrome when ChromeOnly...

### DIFF
--- a/lib/taskScheduler.js
+++ b/lib/taskScheduler.js
@@ -31,22 +31,30 @@ var TaskScheduler = function(config) {
         return excludes.indexOf(path) < 0;
       });
 
-  if (config.capabilities) {
-    if (config.multiCapabilities.length) {
-      console.log('Running using config.multiCapabilities - ' +
-        'config.capabilities will be ignored');
-    } else {
-      // Use capabilities if multiCapabilities is empty.
-      config.multiCapabilities = [config.capabilities];
+  if (config.chromeOnly) {
+      console.log('Running using config.chromeOnly - ' +
+          'ignoring capabilities, using Chrome instead.');
+      config.multiCapabilities = [{
+             browserName: 'chrome'
+          }];
+  } else {
+    if (config.capabilities) {
+        if (config.multiCapabilities.length) {
+            console.log('Running using config.multiCapabilities - ' +
+              'config.capabilities will be ignored');
+        } else {
+            // Use capabilities if multiCapabilities is empty.
+            config.multiCapabilities = [config.capabilities];
+        }
+    } else if (!config.multiCapabilities.length) {
+        // Default to chrome if no capability given
+        config.multiCapabilities = [{
+            browserName: 'chrome'
+        }];
     }
-  } else if (!config.multiCapabilities.length) {
-    // Default to chrome if no capability given
-    config.multiCapabilities = [{
-      browserName: 'chrome'
-    }];
   }
 
-  var taskQueues = [];
+    var taskQueues = [];
   config.multiCapabilities.forEach(function(capability) {
     var capabilitySpecs = allSpecs;
     if (capability.specs) {


### PR DESCRIPTION
... is true

Previously when ChromeOnly was true it would report running other browsers as well.
Stating the spec was runned and succesful using the ChromeDriver directly.
They are not executed, so we shouldn't report them as executed.

Closes: #1364
