### PR TITLE
fix(ElementFinder): ElementFinder should allow null as succes handler.

### DIFF
--- a/lib/protractor.js
+++ b/lib/protractor.js
@@ -762,6 +762,9 @@ var buildElementHelper = function(ptor) {
    */
   ElementFinder.prototype.then = function(fn, errorFn) {
     return this.elementArrayFinder_.then(function(actionResults) {
+      if(!fn){
+        return actionResults[0];
+      }
       return fn(actionResults[0]);
     }, errorFn);
   };

--- a/spec/basic/elements_spec.js
+++ b/spec/basic/elements_spec.js
@@ -185,6 +185,19 @@ describe('ElementFinder', function() {
       expect(finalResult.getText()).toEqual('Hiya');
     });
   });
+  
+  it('should allow null as succeshandler', function() {
+    browser.get('index.html#/form');
+
+    var usernameInput = element(by.model('username'));
+    var name = element(by.binding('username'));
+
+    expect(name.getText()).toEqual('Anon');
+    expect(
+      name.getText().then(null, function(){})
+    ).toEqual('Anon');
+
+  });
 });
 
 describe('ElementArrayFinder', function() {


### PR DESCRIPTION
Passes the value to the next in the chain.
