### PR TITLE
fix(page get): Make protractor return destination when using file://

### DIFF
--- a/lib/protractor.js
+++ b/lib/protractor.js
@@ -1211,12 +1211,12 @@ Protractor.prototype.get = function(destination, opt_timeout) {
   var timeout = opt_timeout ? opt_timeout : this.getPageTimeout;
   var self = this;
 
-  destination = this.baseUrl.indexOf('file://') === 0 ?
-    this.baseUrl + destination : url.resolve(this.baseUrl, destination);
-
-  if (this.ignoreSynchronization) {
+  if (this.ignoreSynchronization || this.baseUrl.indexOf('file://') === 0) {
+    destination = this.baseUrl + destination;
     return this.driver.get(destination);
   }
+
+  destination = url.resolve(this.baseUrl, destination);
 
   this.driver.get(this.resetUrl);
   this.driver.executeScript(


### PR DESCRIPTION
To allow protractor to use file:// for running tests, it is not possible to force setting window location via JavaScript.

This will close #1390 
