### PR TITLE
fix(config): Don't store webdriver versions in package.json

### DIFF
--- a/bin/webdriver-manager
+++ b/bin/webdriver-manager
@@ -15,7 +15,7 @@ var childProcess = require('child_process');
  */
 var SELENIUM_DIR = path.resolve(__dirname, '../selenium');
 
-var versions = require('../package.json').webdriverVersions;
+var versions = require('../config.json').webdriverVersions;
 
 /**
  * Get the major and minor version but ignore the patch (required for selenium

--- a/config.json
+++ b/config.json
@@ -1,0 +1,7 @@
+{
+  "webdriverVersions": {
+    "selenium": "2.43.1",
+    "chromedriver": "2.10",
+    "iedriver": "2.43.0"
+  }
+}

--- a/lib/driverProviders/local.js
+++ b/lib/driverProviders/local.js
@@ -28,7 +28,7 @@ LocalDriverProvider.prototype.addDefaultBinaryLocs_ = function() {
   if (!this.config_.seleniumServerJar) {
     this.config_.seleniumServerJar = path.resolve(__dirname,
         '../../selenium/selenium-server-standalone-' +
-        require('../../package.json').webdriverVersions.selenium + '.jar');
+        require('../../config.json').webdriverVersions.selenium + '.jar');
   }
   if (this.config_.capabilities.browserName === 'chrome') {
     this.config_.chromeDriver = this.config_.chromeDriver ||

--- a/package.json
+++ b/package.json
@@ -51,10 +51,5 @@
     "start": "testapp/scripts/web-server.js"
   },
   "license": "MIT",
-  "version": "1.3.1",
-  "webdriverVersions": {
-    "selenium": "2.43.1",
-    "chromedriver": "2.10",
-    "iedriver": "2.43.0"
-  }
+  "version": "1.3.1"
 }


### PR DESCRIPTION
Storing module configuration like webdriverVersions in package.json can cause issues with some third party registries/caching proxies like Artifactory that process the metadata, and package metadata seems like an odd place to put these values besides.
