### PR TITLE
fix(runner): prevent source-map-support module from exiting process on `...

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -201,7 +201,30 @@ Runner.prototype.setupGlobals_ = function(driver) {
   global.by = global.By = protractor.By;
 
   // Enable sourcemap support for stack traces.
-  require('source-map-support').install();
+  var sourceMapSupport = require('source-map-support');
+
+  sourceMapSupport.install({
+    handleUncaughtExceptions: false
+  });
+
+  // @note The code below is directly inspired from the source-map-support's code.
+  // I'm using console.error because, well, it's an error...
+  // @see https://github.com/evanw/node-source-map-support/blob/636b1b28e42c7cd3aa7fdfd9949ecd5bb9aef701/source-map-support.js#L256
+  // Mimic node's stack trace printing when an exception escapes the process
+  process.on('uncaughtException', function (error) {
+    if (!error || !error.stack) {
+      console.error('Uncaught exception:', error);
+    } else {
+      var source = sourceMapSupport.getErrorSource(error);
+      if (source !== null) {
+        console.error(source);
+      }
+      console.error(error.stack);
+    }
+    // Do not exit the whole app,
+    //process.exit(1);
+  });
+
   // Required by dart2js machinery.
   // https://code.google.com/p/dart/source/browse/branches/bleeding_edge/dart/sdk/lib/js/dart2js/js_dart2js.dart?spec=svn32943&r=32943#487
   global.DartObject = function(o) { this.o = o; };

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -207,10 +207,8 @@ Runner.prototype.setupGlobals_ = function(driver) {
     handleUncaughtExceptions: false
   });
 
-  // @note The code below is directly inspired from the source-map-support's code.
-  // I'm using console.error because, well, it's an error...
-  // @see https://github.com/evanw/node-source-map-support/blob/636b1b28e42c7cd3aa7fdfd9949ecd5bb9aef701/source-map-support.js#L256
-  // Mimic node's stack trace printing when an exception escapes the process
+  // Instead of allowing source-map-support to handle exceptions and exit the process
+  // when they occur, give it an opportunity to modify and print the stack trace.
   process.on('uncaughtException', function (error) {
     if (!error || !error.stack) {
       console.error('Uncaught exception:', error);
@@ -221,8 +219,6 @@ Runner.prototype.setupGlobals_ = function(driver) {
       }
       console.error(error.stack);
     }
-    // Do not exit the whole app,
-    //process.exit(1);
   });
 
   // Required by dart2js machinery.


### PR DESCRIPTION
This is a quick patch for issue #876 which allows us to let Cucumber keep going even when a test step fails (the problem seems to mostly happen when it's a protractor promise that fails).

However, I can still see that the error stacks showing CoffeeScript source files are displayed with line numbers that actually match the js generated code, not the CoffeeScript code.
So I think that the source-map-support configuration is not correct when used with Cucumber js, but this should be fixed in another PR I reckon.
