### PR TITLE
docs(browser-setup): fix PhantomJS launch issue on Windows

### DIFF
--- a/docs/browser-setup.md
+++ b/docs/browser-setup.md
@@ -349,7 +349,7 @@ capabilities: {
    * Can be used to specify the phantomjs binary path.
    * This can generally be ommitted if you installed phantomjs globally.
    */
-  'phantomjs.binary.path': require('phantomjs').path
+  'phantomjs.binary.path': require('phantomjs').path,
   
   /*
    * Command line arugments to pass to phantomjs. 


### PR DESCRIPTION
I needed to run some tests on my Windows 8 test machine but they were all timing out. 

Using this config:

``` coffee
path = require 'path'
packageMeta = require './package.json'

exports.config =
  seleniumAddress: 'http://localhost:4444/wd/hub'

  allScriptsTimeout: 11000

  specs: [
    'e2e/*.coffee'
  ]

 capabilities:
    'browserName': 'phantomjs'
    'phantomjs.binary.path': './node_modules/phantomjs/bin/phantomjs'

  baseUrl: "http://localhost:#{packageMeta.panel.port}"

  framework: 'jasmine'

  jasmineNodeOpts:
    isVerbose: true
    defaultTimeoutInterval: 30000

  onPrepare: ->
    # Fixes https://github.com/angular/protractor/issues/585
    browser.driver.manage().window().setSize(1280, 1024)
    # Disable Angular check: http://ng-learn.org/2014/02/Protractor_Testing_With_Angular_And_Non_Angular_Sites/
    browser.ignoreSynchronization = true
```

After some investigation I discovered this error from Selenium:

```
22:01:05.606 ERROR - org.apache.commons.exec.ExecuteException: Execution failed (Exit value: -559038737. Caused by java.io.IOException: Cannot run program "C:\[redacted]\node_modules\phantomjs\bin\phantomjs" (in directory "."): CreateProcess error=193, %1 is not a valid Win32 application)
```

The problem is that the Selenium code uses `CreateProcess` function that expects an executable binary file which `./node_modules/phantomjs/bin/phantomjs` is not (just a simple node script).

There might be a better fix for it, but here is a quick workaround in the Protractor config:

```
'phantomjs.binary.path': require('phantomjs').path
```

Might be a good idea to update that in the docs, hence my PR.
