### PR TITLE
feat(debugging): use custom messages when executing scripts to improve s...

### DIFF
--- a/lib/protractor.js
+++ b/lib/protractor.js
@@ -1098,6 +1098,55 @@ var Protractor = function(webdriverInstance, opt_baseUrl, opt_rootElement) {
 };
 
 /**
+ * The same as {@code webdriver.WebDriver.prototype.executeScript},
+ * but with a customized description for debugging.
+ *
+ * @private
+ * @param {!(string|Function)} script The script to execute.
+ * @param {string} description A description of the command for debugging.
+ * @param {...*} var_args The arguments to pass to the script.
+ * @return {!webdriver.promise.Promise.<T>} A promise that will resolve to the
+ *    scripts return value.
+ * @template T
+ */
+Protractor.prototype.executeScript_ =
+    function(script, description) {
+      if (typeof script === 'function') {
+        script = 'return (' + script + ').apply(null, arguments);';
+      }
+
+      return this.driver.schedule(
+          new webdriver.Command(webdriver.CommandName.EXECUTE_SCRIPT).
+              setParameter('script', script).
+              setParameter('args', Array.prototype.slice.call(arguments, 2)),
+          description);
+    };
+
+/**
+ * The same as {@code webdriver.WebDriver.prototype.executeAsyncScript},
+ * but with a customized description for debugging.
+ *
+ * @private
+ * @param {!(string|Function)} script The script to execute.
+ * @param {string} description A description for debugging purposes.
+ * @param {...*} var_args The arguments to pass to the script.
+ * @return {!webdriver.promise.Promise.<T>} A promise that will resolve to the
+ *    scripts return value.
+ * @template T
+ */
+Protractor.prototype.executeAsyncScript_ =
+    function(script, description) {
+      if (typeof script === 'function') {
+        script = 'return (' + script + ').apply(null, arguments);';
+      }
+      return this.driver.schedule(
+          new webdriver.Command(webdriver.CommandName.EXECUTE_ASYNC_SCRIPT).
+              setParameter('script', script).
+              setParameter('args', Array.prototype.slice.call(arguments, 2)),
+          description);
+    };
+
+/**
  * Instruct webdriver to wait until Angular has finished rendering and has
  * no outstanding $http calls before continuing.
  *
@@ -1108,12 +1157,14 @@ Protractor.prototype.waitForAngular = function() {
   if (this.ignoreSynchronization) {
     return webdriver.promise.fulfilled();
   }
-  return this.driver.executeAsyncScript(
-    clientSideScripts.waitForAngular, this.rootEl).then(function(browserErr) {
-      if (browserErr) {
-        throw 'Error while waiting for Protractor to ' +
-              'sync with the page: ' + JSON.stringify(browserErr);
-      }
+  return this.executeAsyncScript_(
+      clientSideScripts.waitForAngular, 'Protractor.waitForAngular()',
+      this.rootEl).
+      then(function(browserErr) {
+        if (browserErr) {
+          throw 'Error while waiting for Protractor to ' +
+                'sync with the page: ' + JSON.stringify(browserErr);
+        }
     }).then(null, function(err) {
       var timeout;
       if (/asynchronous script timeout/.test(err.message)) {
@@ -1242,20 +1293,26 @@ Protractor.prototype.get = function(destination, opt_timeout) {
 
   destination = this.baseUrl.indexOf('file://') === 0 ?
     this.baseUrl + destination : url.resolve(this.baseUrl, destination);
+  var msg = function(str) {
+    return 'Protractor.get(' + destination + ') - ' + str;
+  };
 
   if (this.ignoreSynchronization) {
     return this.driver.get(destination);
   }
 
   this.driver.get(this.resetUrl);
-  this.driver.executeScript(
+  this.executeScript_(
       'window.name = "' + DEFER_LABEL + '" + window.name;' +
-      'window.location.replace("' + destination + '");');
+      'window.location.replace("' + destination + '");',
+      msg('reset url'));
 
   // We need to make sure the new url has loaded before
   // we try to execute any asynchronous scripts.
   this.driver.wait(function() {
-    return self.driver.executeScript('return window.location.href;').
+    return self.executeScript_(
+        'return window.location.href;',
+        msg('get url')).
         then(function(url) {
           return url !== self.resetUrl;
         }, function(err) {
@@ -1271,11 +1328,12 @@ Protractor.prototype.get = function(destination, opt_timeout) {
           }
         });
   }, timeout,
-  'Timed out waiting for page to load after ' + timeout + 'ms');
+  'waiting for page to load for ' + timeout + 'ms');
 
   // Make sure the page is an Angular page.
-  self.driver.executeAsyncScript(clientSideScripts.testForAngular,
-        Math.floor(timeout / 1000)).
+  self.executeAsyncScript_(clientSideScripts.testForAngular,
+      msg('test for angular'),
+      Math.floor(timeout / 1000)).
       then(function(angularTestResult) {
         var hasAngular = angularTestResult[0];
         if (!hasAngular) {
@@ -1294,16 +1352,18 @@ Protractor.prototype.get = function(destination, opt_timeout) {
     var mockModule = this.mockModules_[i];
     var name = mockModule.name;
     moduleNames.push(name);
-    var executeScriptArgs = [mockModule.script].concat(mockModule.args);
-    this.driver.executeScript.apply(this, executeScriptArgs).
+    var executeScriptArgs = [mockModule.script, msg('add mock module ' + name)].
+        concat(mockModule.args);
+    this.executeScript_.apply(this, executeScriptArgs).
         then(null, function(err) {
           throw 'Error while running module script ' + name +
               ': ' + err.message;
         });
   }
 
-  return this.driver.executeScript(
+  return this.executeScript_(
       'angular.resumeBootstrap(arguments[0]);',
+      msg('resume bootstrap'),
       moduleNames);
 };
 
@@ -1325,9 +1385,12 @@ Protractor.prototype.refresh = function(opt_timeout) {
     return self.driver.navigate().refresh();
   }
 
-  return self.driver.executeScript('return window.location.href').then(function(href) {
-    return self.get(href, timeout);
-  });
+  return self.executeScript_(
+      'return window.location.href',
+      'Protractor.refresh() - getUrl').
+      then(function(href) {
+        return self.get(href, timeout);
+      });
 };
 
 /**
@@ -1349,7 +1412,8 @@ Protractor.prototype.navigate = function() {
  */
 Protractor.prototype.setLocation = function(url) {
   this.waitForAngular();
-  return this.driver.executeScript(clientSideScripts.setLocation, this.rootEl, url)
+  return this.executeScript_(clientSideScripts.setLocation,
+    'Protractor.setLocation()', this.rootEl, url)
     .then(function(browserErr) {
       if (browserErr) {
         throw 'Error while navigating to \'' + url + '\' : ' +
@@ -1363,7 +1427,8 @@ Protractor.prototype.setLocation = function(url) {
  */
 Protractor.prototype.getLocationAbsUrl = function() {
   this.waitForAngular();
-  return this.driver.executeScript(clientSideScripts.getLocationAbsUrl, this.rootEl);
+  return this.executeScript_(clientSideScripts.getLocationAbsUrl,
+    'Protractor.getLocationBasUrl()', this.rootEl);
 };
 
 /**


### PR DESCRIPTION
...tack traces

Now, instead of asynchronous events during executeScript all being described as
`WebDriver.executeScript`, they have their own custom messages. The schedule
shown when debugging will be more informative, as in the example below:

```
-- WebDriver control flow schedule
 |- waiting for debugger to attach
 |---    at null.<anonymous> (/Users/ralphj/protractor/debugging/failure_spec.js:37:13)
 |- WebDriver.navigate().to(data:text/html,<html></html>)
 |---    at null.<anonymous> (/Users/ralphj/protractor/debugging/failure_spec.js:38:13)
 |- Protractor.get(http://localhost:8081/index.html#/form) - reset url
 |---    at null.<anonymous> (/Users/ralphj/protractor/debugging/failure_spec.js:38:13)
 |- Timed out waiting for page to load after 10000ms
 |---    at null.<anonymous> (/Users/ralphj/protractor/debugging/failure_spec.js:38:13)
 |- Protractor.get(http://localhost:8081/index.html#/form) - test for angular
 |---    at null.<anonymous> (/Users/ralphj/protractor/debugging/failure_spec.js:38:13)
 |- Protractor.get(http://localhost:8081/index.html#/form) - add mock module
 |---    at null.<anonymous> (/Users/ralphj/protractor/debugging/failure_spec.js:38:13)
 |- Protractor.get(http://localhost:8081/index.html#/form) - resume bootstrap
 |---    at null.<anonymous> (/Users/ralphj/protractor/debugging/failure_spec.js:38:13)
 |- Protractor.waitForAngular()
 |---    at null.<anonymous> (/Users/ralphj/protractor/debugging/failure_spec.js:42:21)
```
