### PR TITLE
chore(clientSideScripts): fix typo in executeScript_ description

### DIFF
--- a/lib/protractor.js
+++ b/lib/protractor.js
@@ -1423,7 +1423,7 @@ Protractor.prototype.setLocation = function(url) {
 Protractor.prototype.getLocationAbsUrl = function() {
   this.waitForAngular();
   return this.executeScript_(clientSideScripts.getLocationAbsUrl,
-      'Protractor.getLocationBasUrl()', this.rootEl);
+      'Protractor.getLocationAbsUrl()', this.rootEl);
 };
 
 /**


### PR DESCRIPTION
Commit be236e7f4 improved stack traces by adding descriptions to
`executeScript`s, but one of the new descriptions had a typo.
