### PR TITLE
fix(testapp): fix missing npm-start and incorrect testapp path

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "bin": "bin/protractor",
   "main": "lib/protractor.js",
   "scripts": {
+    "start": "node testapp/scripts/web-server.js",
     "test": "node lib/cli.js spec/basicConf.js; node lib/cli.js spec/altRootConf.js; node lib/cli.js spec/onPrepareConf.js; node_modules/.bin/minijasminenode jasminewd/spec/adapterSpec.js"
   },
   "license" : "MIT",

--- a/testapp/scripts/web-server.js
+++ b/testapp/scripts/web-server.js
@@ -2,9 +2,10 @@
 
 var express = require('express');
 var util = require('util');
+var path = require('path');
 var testApp = express();
 var DEFAULT_PORT = 8000;
-var testAppDir = process.cwd();
+var testAppDir = path.join(process.cwd(), 'testapp');
 
 var main = function(argv) {
   var port = Number(argv[2]) || DEFAULT_PORT;


### PR DESCRIPTION
the documentation states you can run npm start, however this command
was missing form the package.json file. In addition the testapp script
was not looking into the testapp folder.
