### PR TITLE
chore(docs): Remove outdated API document and point to the website.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,4 +1,4 @@
 Protractor API
 ==============
 
-The API documentation moved to: [http://angular.github.io/protractor/#/api]
+The API documentation was moved to: http://angular.github.io/protractor/#/api


### PR DESCRIPTION
Remove outdated api doc.
