### PR TITLE
fix(runner): setTestPreparer does not work

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -44,6 +44,7 @@ var Runner = function(config) {
   }
 
   this.loadDriverProvider_(config);
+  this.setTestPreparer(config.onPrepare);
 };
 
 util.inherits(Runner, EventEmitter);
@@ -197,8 +198,6 @@ Runner.prototype.run = function() {
   if (!specs.length) {
     throw new Error('Spec patterns did not match any files.');
   }
-
-  this.setTestPreparer(this.config_.onPrepare);
 
   var gracefulShutdown = function(driver) {
     if (driver) {


### PR DESCRIPTION
setTestPreparer would always set the testPrepare to config.onprepare during
`runner.run()`. This is breaking for code that relies on setTestPreparer
directly.
