### PR TITLE
Added new question to faq

### DIFF
--- a/partials/faq.html
+++ b/partials/faq.html
@@ -77,3 +77,5 @@ jasmine.Spec.prototype.addMatcherResult = function() {
 <h2 id="how-can-i-catch-errors-such-as-elementnotfound-">How can I catch errors such as ElementNotFound?</h2>
 <p>WebDriver throws errors when commands cannot be completed - e.g. not being able to click on an element which is obscured by another element. If you need to retry these actions, try using <a href="https://github.com/juliemr/webdriverjs-retry">webdriverjs-retry</a>. If you would just like to catch the error, do so like this</p>
 <pre><code class="lang-javascript">elm.click().then(function() { /* passing case */}, function(err) { /* error handling here */})</code></pre>
+<h2 id="why-is-browser-debugger-not-pausing">Why is browser.debugger(); not pausing the test?</h2>
+<p>The most likely reason is that you are not running the test in debug mode. To do this you run: <code ng-non-bindable>protractor debug</code> followed by the path to your protractor configuration file.</p>


### PR DESCRIPTION
I just spend some time now having an issue where the browser.debugger did not work. It turns out that you need to run protractor in debug mode for this. I believe that in the past when I used browser.pause I did not need to run protractor in debug mode so I was not expecting this now. When searching for it there is a popular topic of browser.debugger not working on windows (I'm on a MAC, but if I were on a windows machine I would just assume the issue was related). I also found others talking about this issue on a mailing list https://groups.google.com/forum/#!topic/angular/n7FADYnWFYU and they did not come up with any answer.

I finally found the information I needed on a commented from Julie Ralph that I read on a non related issue. I then read the testing documentation more carefully and saw that the information is actually there. For someone that has worked with protractor before, this information is easy to miss since we are unlikely to look at the documentation so closely this second time.

Thank you for your great work on this amazing tool!
