### PR TITLE
feat(scripts): add framework to test protractor

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "main": "lib/protractor.js",
   "scripts": {
-    "pretest": "node_modules/.bin/jshint lib spec",
+    "pretest": "node_modules/.bin/jshint lib spec scripts",
     "test": "scripts/test.js",
     "start": "testapp/scripts/web-server.js"
   },

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
+var Executor = require('./test/test_util').Executor;
 var glob = require('glob').sync;
-var spawn = require('child_process').spawn;
 
-var scripts = [
+var passingTests = [
   'node lib/cli.js spec/basicConf.js',
   'node lib/cli.js spec/multiConf.js',
   'node lib/cli.js spec/altRootConf.js',
@@ -22,29 +22,68 @@ var scripts = [
   'node lib/cli.js spec/suitesConf.js --suite okmany,okspec'
 ];
 
-scripts.push(
+passingTests.push(
     'node node_modules/.bin/minijasminenode ' +
     glob('spec/unit/*.js').join(' ') + ' ' +
     glob('docgen/spec/*.js').join(' '));
 
-var failed = false;
+var executor = new Executor();
 
-(function runTests(i) {
-  if (i < scripts.length) {
-    console.log('node ' + scripts[i]);
-    var args = scripts[i].split(/\s/);
+passingTests.forEach(function(passing_test) {
+  executor.addCommandlineTest(passing_test)
+      .assertExitCodeOnly();
+});
 
-    var test = spawn(args[0], args.slice(1), {stdio: 'inherit'});
-    test.on('error', function(err) {
-      throw err;
+/*************************
+ *Below are failure tests*
+ *************************/
+
+// assert stacktrace shows line of failure
+executor.addCommandlineTest('node lib/cli.js spec/errorTest/singleFailureConf.js')
+    .expectExitCode(1)
+    .expectErrors({
+      stackTrace: 'single_failure_spec1.js:5:32'
     });
-    test.on('exit', function(code) {
-      if (code != 0) {
-        failed = true;
-      }
-      runTests(i + 1);
+
+// assert timeout works 
+executor.addCommandlineTest('node lib/cli.js spec/errorTest/timeoutConf.js')
+    .expectExitCode(1)
+    .expectErrors({
+      message: 'timeout: timed out after 1 msec waiting for spec to complete'
+    })
+    .expectTestDuration(0, 100);
+
+executor.addCommandlineTest('node lib/cli.js spec/errorTest/afterLaunchChangesExitCodeConf.js')
+    .expectExitCode(11)
+    .expectErrors({
+      message: 'Expected \'Hiya\' to equal \'INTENTIONALLY INCORRECT\'.'
     });
-  } else {
-    process.exit(failed ? 1 : 0);
-  }
-}(0));
+
+executor.addCommandlineTest('node lib/cli.js spec/errorTest/multiFailureConf.js')
+    .expectExitCode(1)
+    .expectErrors([{
+      message: 'Expected \'Hiya\' to equal \'INTENTIONALLY INCORRECT\'.',
+      stacktrace: 'single_failure_spec1.js:5:32'
+    }, {
+      message: 'Expected \'Hiya\' to equal \'INTENTIONALLY INCORRECT\'.',
+      stacktrace: 'single_failure_spec2.js:5:32'
+    }]);
+
+executor.addCommandlineTest('node lib/cli.js spec/errorTest/shardedFailureConf.js')
+    .expectExitCode(1)
+    .expectErrors([{
+      message: 'Expected \'Hiya\' to equal \'INTENTIONALLY INCORRECT\'.',
+      stacktrace: 'single_failure_spec1.js:5:32'
+    }, {
+      message: 'Expected \'Hiya\' to equal \'INTENTIONALLY INCORRECT\'.',
+      stacktrace: 'single_failure_spec2.js:5:32'
+    }]);
+
+executor.addCommandlineTest('node lib/cli.js spec/errorTest/mochaFailureConf.js')
+    .expectExitCode(1)
+    .expectErrors([{
+      message: 'expected \'My AngularJS App\' to equal \'INTENTIONALLY INCORRECT\'',
+      stacktrace: 'mocha_failure_spec.js:11:20'
+    }]);
+
+executor.execute();

--- a/scripts/test/test_util.js
+++ b/scripts/test/test_util.js
@@ -1,0 +1,225 @@
+#!/usr/bin/env node
+
+var child_process = require('child_process'),
+    q = require('q'),
+    fs = require('fs');
+
+var CommandlineTest = function(command) {
+  var self = this; 
+  this.command_ = command;
+  this.expectedExitCode_ = 0;
+  this.stdioOnlyOnFailures_ = true;
+  this.expectedErrors_ = [];
+  this.assertExitCodeOnly_ = false;
+
+  // If stdioOnlyOnFailures_ is true, do not stream stdio unless test failed.
+  // This is to prevent tests with expected failures from polluting the output.
+  this.alwaysEnableStdio = function() {
+    self.stdioOnlyOnFailures_ = false;
+    return self;
+  };
+
+  // Only assert the exit code and not failures.
+  // This must be true if the command you're running does not support
+  //   the flag '--resultJsonOutputFile'.
+  this.assertExitCodeOnly = function() {
+    self.assertExitCodeOnly_ = true;
+    return self;
+  };
+
+  // Set the expected exit code for the test command. 
+  this.expectExitCode = function(exitCode) {
+    self.expectedExitCode_ = exitCode;
+    return self;
+  };
+
+  // Set the expected total test duration in milliseconds.
+  this.expectTestDuration = function(min, max) {
+    self.expectedMinTestDuration_ = min;
+    self.expectedMaxTestDuration_ = max;
+    return self;
+  };
+
+  /**
+   * Add expected error(s) for the test command. 
+   * Input is an object or list of objects of the following form:
+   * {
+   *   message: string, // optional regex
+   *   stackTrace: string, //optional regex
+   * }
+   */
+  this.expectErrors = function(expectedErrors) {
+    if (expectedErrors instanceof Array) {
+      self.expectedErrors_ = self.expectedErrors_.concat(expectedErrors);
+    } else {
+      self.expectedErrors_.push(expectedErrors);
+    }
+    return self;
+  };
+
+  this.run = function() {
+    var start = new Date().getTime();
+    var testOutputPath = 'test_output_' + start + '.tmp';
+    var output = '';
+
+    var flushAndFail = function(errorMsg) {
+      process.stdout.write(output);
+      throw new Error(errorMsg);
+    };
+
+    return q.promise(function(resolve, reject) {
+      if (!self.assertExitCodeOnly_) {
+        self.command_ = self.command_ + ' --resultJsonOutputFile ' + testOutputPath;
+      }
+      var args = self.command_.split(/\s/);
+
+      var test_process;
+
+      if (self.stdioOnlyOnFailures_) {
+        test_process = child_process.spawn(args[0], args.slice(1));
+
+        test_process.stdout.on('data', function(data) {
+          output += data;
+        });
+
+        test_process.stderr.on('data', function(data) {
+          output += data;
+        });
+      } else {
+        test_process = child_process.spawn(args[0], args.slice(1), {stdio:'inherit'});
+      }
+      
+      test_process.on('error', function(err) {
+        reject(err);
+      });
+      
+      test_process.on('exit', function(exitCode) {
+        resolve(exitCode);
+      });
+    }).then(function(exitCode) {
+      if (self.expectedExitCode_ !== exitCode) {
+        flushAndFail('expecting exit code: ' + self.expectedExitCode_ +
+              ', actual: ' + exitCode);
+      }
+
+      // Skip the rest if we are only verify exit code.
+      // Note: we're expecting a file populated by '--resultJsonOutputFile' after
+      //   this point.
+      if (self.assertExitCodeOnly_) {
+        return;
+      }
+
+      var raw_data = fs.readFileSync(testOutputPath);
+      var testOutput = JSON.parse(raw_data);
+
+      var actualErrors = [];
+      var duration = 0;
+      testOutput.forEach(function(specResult) {
+        duration += specResult.duration;
+        specResult.assertions.forEach(function(assertion) {
+          if (!assertion.passed) {
+            actualErrors.push(assertion);
+          }
+        });
+      });
+
+      self.expectedErrors_.forEach(function(expectedError) {
+        var found = false;
+        for (var i = 0; i < actualErrors.length; ++i) {
+          var actualError = actualErrors[i];
+
+          // if expected message is defined and messages don't match
+          if (expectedError.message) {
+            if (!actualError.errorMsg || 
+                !actualError.errorMsg.match(new RegExp(expectedError.message))) {
+                  continue;
+                }
+          }
+          // if expected stackTrace is defined and stackTraces don't match
+          if (expectedError.stackTrace) {
+            if (!actualError.stackTrace ||
+                !actualError.stackTrace.match(new RegExp(expectedError.stackTrace))) {
+                  continue;
+                }
+          }
+          found = true;
+          break;
+        }
+
+        if (!found) {
+          if (expectedError.message && expectedError.stackTrace) {
+            flushAndFail('did not fail with expected error with message: [' + 
+              expectedError.message + '] and stackTrace: [' + 
+              expectedError.stackTrace + ']');
+          } else if (expectedError.message) {
+            flushAndFail('did not fail with expected error with message: [' + 
+              expectedError.message + ']');
+          } else if (expectedError.stackTrace) {
+            flushAndFail('did not fail with expected error with stackTrace: [' + 
+              expectedError.stackTrace + ']');
+          }
+        } else {
+          actualErrors.splice(i, 1);
+        }
+      });
+
+      if (actualErrors.length > 0) {
+        flushAndFail('failed with ' + actualErrors.length + ' unexpected failures');
+      }
+
+      if (self.expectedMinTestDuration_
+          && duration < self.expectedMinTestDuration_) {
+            flushAndFail('expecting test min duration: ' + 
+                self.expectedMinTestDuration_ + ', actual: ' + duration);
+      }
+      if (self.expectedMaxTestDuration_ 
+          && duration > self.expectedMaxTestDuration_) {
+            flushAndFail('expecting test max duration: ' + 
+                self.expectedMaxTestDuration_ + ', actual: ' + duration);
+      }
+    }).fin(function() {
+      try {
+        fs.unlinkSync(testOutputPath);
+      } catch (err) {
+        // don't do anything
+      }
+    });
+  };
+};
+
+/**
+ * Util for running tests and testing functionalities including:
+ *   exitCode, test durations, expected errors, and expected stackTrace
+ * Note, this will work with any commandline tests, but only if it supports
+ *   the flag '--resultJsonOutputFile', unless only exitCode is being tested.
+ *   For now, this means protractor tests (jasmine/mocha/cucumber).
+ */
+exports.Executor = function() {
+  var tests = [];
+  this.addCommandlineTest = function(command) {
+    var test = new CommandlineTest(command);
+    tests.push(test);
+    return test; 
+  };
+
+  this.execute = function() {
+    var failed = false;
+
+    (function runTests(i) {
+      if (i < tests.length) {
+        console.log('running: ' + tests[i].command_);
+        tests[i].run().then(function() {
+          console.log('>>> \033[1;32mpass\033[0m');
+        }, function(err) {
+          failed = true;
+          console.log('>>> \033[1;31mfail: ' + err.toString() + '\033[0m');
+        }).fin(function() {
+          runTests(i + 1);
+        }).done();
+      } else {
+        console.log('Summary: ' + (failed ? 'fail' : 'pass'));
+        process.exit(failed ? 1 : 0);
+      }
+    }(0));
+  };
+};

--- a/spec/errorTest/afterLaunchChangesExitCodeConf.js
+++ b/spec/errorTest/afterLaunchChangesExitCodeConf.js
@@ -1,0 +1,26 @@
+var env = require('../environment.js');
+
+exports.config = {
+  seleniumAddress: env.seleniumAddress,
+
+  specs: [
+    'baseCase/single_failure_spec1.js'
+  ],
+
+  multiCapabilities: [{
+    'browserName': 'chrome'
+  }],
+
+  baseUrl: env.baseUrl,
+
+  jasmineNodeOpts: {
+    isVerbose: true,
+    showTiming: true,
+    defaultTimeoutInterval: 90000
+  },
+
+  afterLaunch: function(exitCode) {
+    return exitCode + 10;
+  },
+
+};

--- a/spec/errorTest/baseCase/error_spec.js
+++ b/spec/errorTest/baseCase/error_spec.js
@@ -1,0 +1,6 @@
+describe('finding an element that does not exist', function() {
+  it('should throw an error', function() {
+    browser.get('index.html');
+    var greeting = element(by.binding('INVALID'));
+  });
+});

--- a/spec/errorTest/baseCase/mocha_failure_spec.js
+++ b/spec/errorTest/baseCase/mocha_failure_spec.js
@@ -1,0 +1,13 @@
+// Use the external Chai As Promised to deal with resolving promises in
+// expectations.
+var chai = require('chai');
+var chaiAsPromised = require('chai-as-promised');
+chai.use(chaiAsPromised);
+var expect = chai.expect;
+
+describe('protractor library', function() {
+  it('should fail', function() {
+    browser.get('index.html');
+    expect(browser.getTitle()).to.eventually.equal('INTENTIONALLY INCORRECT');
+  });
+});

--- a/spec/errorTest/baseCase/single_failure_spec1.js
+++ b/spec/errorTest/baseCase/single_failure_spec1.js
@@ -1,0 +1,7 @@
+describe('single failure spec1', function() {
+  it('should fail expectation', function() {
+    browser.get('index.html');
+    var greeting = element(by.binding('greeting'));
+    expect(greeting.getText()).toEqual('INTENTIONALLY INCORRECT');
+  });
+});

--- a/spec/errorTest/baseCase/single_failure_spec2.js
+++ b/spec/errorTest/baseCase/single_failure_spec2.js
@@ -1,0 +1,7 @@
+describe('single failure spec2', function() {
+  it('should fail expectation', function() {
+    browser.get('index.html');
+    var greeting = element(by.binding('greeting'));
+    expect(greeting.getText()).toEqual('INTENTIONALLY INCORRECT');
+  });
+});

--- a/spec/errorTest/baseCase/success_spec.js
+++ b/spec/errorTest/baseCase/success_spec.js
@@ -1,0 +1,7 @@
+describe('success spec', function() {
+  it('should pass', function() {
+    browser.get('index.html');
+    var greeting = element(by.binding('greeting'));
+    expect(greeting.getText()).toEqual('Hiya');
+  });
+});

--- a/spec/errorTest/baseCase/timeout_spec.js
+++ b/spec/errorTest/baseCase/timeout_spec.js
@@ -1,0 +1,5 @@
+describe('timeout spec', function() {
+  it('should timeout due to jasmine spec limit', function() {
+    browser.get('index.html#/form');
+  }, 1);
+});

--- a/spec/errorTest/mochaFailureConf.js
+++ b/spec/errorTest/mochaFailureConf.js
@@ -1,0 +1,22 @@
+var env = require('../environment.js');
+
+exports.config = {
+  seleniumAddress: env.seleniumAddress,
+
+  specs: [
+    'baseCase/mocha_failure_spec.js'
+  ],
+
+  multiCapabilities: [{
+    'browserName': 'chrome'
+  }],
+
+  baseUrl: env.baseUrl,
+
+  mochaOpts: {
+    reporter: 'spec',
+    timeout: 4000
+  },
+
+  framework: 'mocha',
+};

--- a/spec/errorTest/multiFailureConf.js
+++ b/spec/errorTest/multiFailureConf.js
@@ -1,0 +1,23 @@
+var env = require('../environment.js');
+
+exports.config = {
+  seleniumAddress: env.seleniumAddress,
+
+  specs: [
+    'baseCase/single_failure_spec1.js',
+    'baseCase/single_failure_spec2.js'
+  ],
+
+  multiCapabilities: [{
+    'browserName': 'chrome'
+  }],
+
+  baseUrl: env.baseUrl,
+
+  jasmineNodeOpts: {
+    isVerbose: true,
+    showTiming: true,
+    defaultTimeoutInterval: 90000
+  },
+
+};

--- a/spec/errorTest/shardedFailureConf.js
+++ b/spec/errorTest/shardedFailureConf.js
@@ -1,0 +1,25 @@
+var env = require('../environment.js');
+
+exports.config = {
+  seleniumAddress: env.seleniumAddress,
+
+  specs: [
+    'baseCase/single_failure_spec1.js',
+    'baseCase/single_failure_spec2.js'
+  ],
+
+  multiCapabilities: [{
+    'browserName': 'chrome',
+    maxInstances: 2,
+    shardTestFiles: true
+  }],
+
+  baseUrl: env.baseUrl,
+
+  jasmineNodeOpts: {
+    isVerbose: true,
+    showTiming: true,
+    defaultTimeoutInterval: 90000
+  },
+
+};

--- a/spec/errorTest/singleFailureConf.js
+++ b/spec/errorTest/singleFailureConf.js
@@ -1,0 +1,22 @@
+var env = require('../environment.js');
+
+exports.config = {
+  seleniumAddress: env.seleniumAddress,
+
+  specs: [
+    'baseCase/single_failure_spec1.js'
+  ],
+
+  multiCapabilities: [{
+    'browserName': 'chrome'
+  }],
+
+  baseUrl: env.baseUrl,
+
+  jasmineNodeOpts: {
+    isVerbose: true,
+    showTiming: true,
+    defaultTimeoutInterval: 90000
+  },
+
+};

--- a/spec/errorTest/timeoutConf.js
+++ b/spec/errorTest/timeoutConf.js
@@ -1,0 +1,22 @@
+var env = require('../environment.js');
+
+exports.config = {
+  seleniumAddress: env.seleniumAddress,
+
+  specs: [
+    'baseCase/timeout_spec.js'
+  ],
+
+  multiCapabilities: [{
+    'browserName': 'chrome'
+  }],
+
+  baseUrl: env.baseUrl,
+
+  jasmineNodeOpts: {
+    isVerbose: true,
+    showTiming: true,
+    defaultTimeoutInterval: 90000
+  },
+
+};


### PR DESCRIPTION
basic framework for testing protractor exitcode, before/after scripts, stacktrace, error messages

will be able to cover the following cases:
- expected failures still fail
- timeouts time out at the right time
- test output is sane (good stack traces + error messages)
- correct exit code

will not be able to cover the following cases:
- debugger
