### PR TITLE
ng-repeat-start should not return extra null element

### DIFF
--- a/lib/clientsidescripts.js
+++ b/lib/clientsidescripts.js
@@ -127,7 +127,8 @@ functions.findBindings = function(binding, exactMatch, using, rootSelector) {
       }
     }
   }
-  return [rows[index]].concat(multiRows[index]);
+  var row=rows[index]||[], multiRow=multiRows[index]||[];
+  return [].concat(row,multiRow); 
  };
 
  /**


### PR DESCRIPTION
if use findRepeaterRows to find web elements inside ng-repeat-start and ng-repeat-end,  an additional null element will be returned. sample webdriver response result like

{"sessionId":"ceaa220df6d1aea288c80924820c066b","status":0,"value":[null,{"ELEMENT":"0.2879988788627088-17"},{"ELEMENT":"0.2879988788627088-18"},{"ELEMENT":"0.2879988788627088-19"},{"ELEMENT":"0.2879988788627088-20"}]}

the 1st element in the result is null
