### PR TITLE
fix(clientsidescripts): make findByCssContainingText tolerate elements...

### DIFF
--- a/lib/clientsidescripts.js
+++ b/lib/clientsidescripts.js
@@ -489,7 +489,7 @@ functions.findByCssContainingText = function(cssSelector, searchText, using) {
   var matches = [];
   for (var i = 0; i < elements.length; ++i) {
     var element = elements[i];
-    var elementText = element.textContent || element.innerText;
+    var elementText = element.textContent || element.innerText || '';
     if (elementText.indexOf(searchText) > -1) {
       matches.push(element);
     }


### PR DESCRIPTION
...with no textContent/innerText
