### PR TITLE
fix(cli): convert patterns from array to string

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -100,7 +100,7 @@ if (argv.capabilities) {
  * @param {Array} list
  */
 var processFilePatterns_ = function(list) {
-  var patterns = list.split(',');
+  var patterns = list.shift().split(',');
   patterns.forEach(function(spec, index, arr) {
     arr[index] = path.resolve(process.cwd(), spec);
   });


### PR DESCRIPTION
When specifying `specs` on the command line like this:
`protractor --specs e2e-tests/*.js`

Optimist automatically resolves these patterns and converts `argv.specs` into an array:

```
[ 'e2e-tests/**/*.js',
  '/Users/Robbin/Development/angular-seed/e2e-tests/scenarios.js' ]
```

The function `processFilePatterns_()` tries to split `argv.specs`, which doesn't work obviously as it's an array. This adjustment fixes this and allows Protractor to run without configuration file.
