### PR TITLE
Unbreak mocha.js

### DIFF
--- a/lib/frameworks/mocha.js
+++ b/lib/frameworks/mocha.js
@@ -75,14 +75,14 @@ exports.run = function(runner, specs) {
       });
     });
 
-    mochaRunner.on('fail', function(test) {
+    mochaRunner.on('fail', function(test, err) {
       runner.emit('testFail');
       testResult.push({
         description: test.title,
         assertions: [{
           passed: false,
-          errorMsg: test.err.message,
-          stackTrace: test.err.stack 
+          errorMsg: err.message,
+          stackTrace: err.stack 
         }],
         duration: test.duration
       });


### PR DESCRIPTION
Changes introduced in 55a91ea cause failing tests in Mocha to crash the runner with the following error:

```
node_modules/protractor/lib/frameworks/mocha.js:85
          errorMsg: test.err.message,
                            ^
TypeError: Cannot read property 'message' of undefined
```

This is because you are erroneously attempting to retrieve the error from the `test` object in Mocha's `fail` event. The `fail` event actually delivers two separate arguments, the test that failed and the error with which the test failed. This corrects the error.
