### PR TITLE
fix(protractor): Fix typo in jsdoc that breaks doc generator

### DIFF
--- a/lib/protractor.js
+++ b/lib/protractor.js
@@ -255,7 +255,7 @@ Protractor.prototype.executeAsyncScript_ =
  * Instruct webdriver to wait until Angular has finished rendering and has
  * no outstanding $http calls before continuing.
  *
- * @param {=string} opt_description An optional description to be added
+ * @param {string=} opt_description An optional description to be added
  *     to webdriver logs.
  * @return {!webdriver.promise.Promise} A promise that will resolve to the
  *    scripts return value.


### PR DESCRIPTION
The doc generator doesn't work because the jsdoc for waitForAngular has an incorrect format.
