### PR TITLE
add jasmine2 framework

### DIFF
--- a/docs/referenceConf.js
+++ b/docs/referenceConf.js
@@ -236,7 +236,7 @@ exports.config = {
   // ----- The test framework --------------------------------------------------
   // ---------------------------------------------------------------------------
 
-  // Test framework to use. This may be jasmine, cucumber, or mocha.
+  // Test framework to use. This may be jasmine, jasmine2, cucumber, or mocha.
   //
   // Jasmine is fully supported as a test and assertion framework.
   // Mocha and Cucumber have limited beta support. You will need to include your
@@ -255,6 +255,18 @@ exports.config = {
     includeStackTrace: true,
     // Default time to wait in ms before a test fails.
     defaultTimeoutInterval: 30000
+  },
+
+  // Options to be passed to jasmine2.
+  //
+  // See the full list at https://github.com/jasmine/jasmine-npm
+  jasmineNodeOpts: {
+    // If true, print colors to the terminal.
+    showColors: true,
+    // Default time to wait in ms before a test fails.
+    defaultTimeoutInterval: 30000,
+    // Function called to print jasmine results
+    print: function() {},
   },
 
   // Options to be passed to Mocha.

--- a/lib/frameworks/jasmine2.js
+++ b/lib/frameworks/jasmine2.js
@@ -1,0 +1,95 @@
+var q = require('q');
+
+var RunnerReporter = function(emitter) {
+  this.emitter = emitter;
+  this.testResult = [],
+  this.failedCount = 0;
+};
+
+RunnerReporter.prototype.jasmineStarted = function() {
+  // Need to initiate startTime here, in case reportSpecStarting is not
+  // called (e.g. when fit is used)
+  this.startTime = new Date();
+};
+
+RunnerReporter.prototype.specStarted = function() {
+  this.startTime = new Date();
+};
+
+RunnerReporter.prototype.specDone = function(result) {
+  if (result.status == 'passed') {
+    this.emitter.emit('testPass');
+  } else if (result.status == 'failed') {
+    this.emitter.emit('testFail');
+    this.failedCount++;
+  }
+
+  var entry = {
+    description: result.description,
+    assertions: [],
+    duration: new Date().getTime() - this.startTime.getTime()
+  };
+  
+  result.failedExpectations.forEach(function(item) {
+    entry.assertions.push({
+      passed: item.passed,
+      errorMsg: item.passed ? undefined : item.message,
+      stackTrace: item.passed ? undefined : item.stack
+    });
+  });
+  this.testResult.push(entry);
+};
+
+/**
+ * Execute the Runner's test cases through Jasmine.
+ *
+ * @param {Runner} runner The current Protractor Runner.
+ * @param {Array} specs Array of Directory Path Strings.
+ * @return {q.Promise} Promise resolved with the test results
+ */
+exports.run = function(runner, specs) {
+  var JasmineRunner = require('jasmine');
+  var jrunner = new JasmineRunner();
+  /* global jasmine */
+
+  require('jasminewd2');
+
+  // On timeout, the flow should be reset. This will prevent webdriver tasks
+  // from overflowing into the next test and causing it to fail or timeout
+  // as well. This is done in the reporter instead of an afterEach block
+  // to ensure that it runs after any afterEach() blocks with webdriver tasks
+  // get to complete first.
+  var reporter = new RunnerReporter(runner); 
+  jasmine.getEnv().addReporter(reporter);
+
+  return runner.runTestPreparer().then(function() {
+    return q.promise(function (resolve, reject) {
+      var jasmineNodeOpts = runner.getConfig().jasmineNodeOpts;
+
+      if (jasmineNodeOpts && jasmineNodeOpts.defaultTimeoutInterval) {
+        jasmine.DEFAULT_TIMEOUT_INTERVAL = jasmineNodeOpts.defaultTimeoutInterval;
+      }
+
+      var originalOnComplete = runner.getConfig().onComplete;
+      jasmineNodeOpts.onComplete = function(passed) {
+        try {
+          if (originalOnComplete) {
+            originalOnComplete(passed);
+          }
+          resolve({
+            failedCount: reporter.failedCount,
+            specResults: reporter.testResult
+          });
+        } catch(err) {
+          reject(err);
+        }
+      };
+
+      jrunner.configureDefaultReporter(jasmineNodeOpts);
+      jrunner.projectBaseDir = '';
+      jrunner.specDir = '';
+      jrunner.addSpecFiles(specs);
+      jrunner.execute();
+    });
+  });
+};

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -263,6 +263,8 @@ Runner.prototype.run = function() {
     var frameworkPath = '';
     if (self.config_.framework === 'jasmine') {
       frameworkPath = './frameworks/jasmine.js';
+    } else if (self.config_.framework === 'jasmine2') {
+      frameworkPath = './frameworks/jasmine2.js';
     } else if (self.config_.framework === 'mocha') {
       frameworkPath = './frameworks/mocha.js';
     } else if (self.config_.framework === 'cucumber') {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "selenium-webdriver": "2.44.0",
     "minijasminenode": "1.1.1",
     "jasminewd": "1.1.0",
+    "jasminewd2": "0.0.2",
+    "jasmine": "2.1.1",
     "saucelabs": "~0.1.0",
     "glob": "~3.2",
     "adm-zip": "0.4.4",

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
 var Executor = require('./test/test_util').Executor;
-var glob = require('glob').sync;
 
 var passingTests = [
   'node lib/cli.js spec/basicConf.js',
@@ -26,13 +25,9 @@ var passingTests = [
   'node lib/cli.js spec/interactionConf.js',
   'node lib/cli.js spec/directConnectConf.js',
   'node lib/cli.js spec/restartBrowserBetweenTestsConf.js',
-  'node lib/cli.js spec/getCapabilitiesConf.js'
+  'node lib/cli.js spec/getCapabilitiesConf.js',
+  'node node_modules/.bin/jasmine JASMINE_CONFIG_PATH=scripts/unit_test.json'
 ];
-
-passingTests.push(
-  'node node_modules/minijasminenode/bin/minijn ' +
-  glob('spec/unit/*.js').join(' ') + ' ' +
-  glob('website/docgen/spec/*.js').join(' '));
 
 var executor = new Executor();
 
@@ -56,7 +51,8 @@ executor.addCommandlineTest('node lib/cli.js spec/errorTest/singleFailureConf.js
 executor.addCommandlineTest('node lib/cli.js spec/errorTest/timeoutConf.js')
     .expectExitCode(1)
     .expectErrors({
-      message: 'timeout: timed out after 1 msec waiting for spec to complete'
+      message: 'Timeout - Async callback was not invoked within timeout ' +
+          'specified by jasmine.DEFAULT_TIMEOUT_INTERVAL.'
     })
     .expectTestDuration(0, 100);
 

--- a/scripts/unit_test.json
+++ b/scripts/unit_test.json
@@ -1,0 +1,7 @@
+{
+  "spec_dir": "",
+  "spec_files": [
+    "spec/unit/*.js",
+    "website/docgen/spec/*.js"
+  ]
+}

--- a/spec/altRootConf.js
+++ b/spec/altRootConf.js
@@ -4,6 +4,8 @@ var env = require('./environment.js');
 exports.config = {
   seleniumAddress: env.seleniumAddress,
 
+  framework: 'jasmine2',
+
   // Spec patterns are relative to this config.
   specs: [
     'altRoot/*_spec.js',

--- a/spec/basic/locators_spec.js
+++ b/spec/basic/locators_spec.js
@@ -12,10 +12,16 @@ describe('locators', function() {
 
     it('should allow custom expectations to expect an element', function() {
       this.addMatchers({
-        toHaveText: function(actualText) {
-          return this.actual.getText().then(function(expectedText) {
-            return expectedText === actualText;
-          });
+        toHaveText: function() {
+          return {
+            compare: function(actual, expected) {
+              return {
+                pass: actual.getText().then(function(actual) {
+                  return actual === expected;
+                })
+              };
+            }
+          };
         }
       });
 

--- a/spec/basicConf.js
+++ b/spec/basicConf.js
@@ -4,6 +4,8 @@ var env = require('./environment.js');
 exports.config = {
   seleniumAddress: env.seleniumAddress,
 
+  framework: 'jasmine2',
+
   // Spec patterns are relative to this directory.
   specs: [
     'basic/*_spec.js'

--- a/spec/ciConf.js
+++ b/spec/ciConf.js
@@ -5,6 +5,8 @@ exports.config = {
   sauceUser: process.env.SAUCE_USERNAME,
   sauceKey: process.env.SAUCE_ACCESS_KEY,
 
+  framework: 'jasmine2',
+
   // Spec patterns are relative to this directory.
   specs: [
     'basic/*_spec.js'

--- a/spec/directConnectConf.js
+++ b/spec/directConnectConf.js
@@ -4,6 +4,8 @@ var env = require('./environment.js');
 exports.config = {
   directConnect: true,
 
+  framework: 'jasmine2',
+
   capabilities: {
     'browserName': 'chrome'
   },

--- a/spec/errorTest/afterLaunchChangesExitCodeConf.js
+++ b/spec/errorTest/afterLaunchChangesExitCodeConf.js
@@ -3,6 +3,8 @@ var env = require('../environment.js');
 exports.config = {
   seleniumAddress: env.seleniumAddress,
 
+  framework: 'jasmine2',
+
   specs: [
     'baseCase/single_failure_spec1.js'
   ],

--- a/spec/errorTest/multiFailureConf.js
+++ b/spec/errorTest/multiFailureConf.js
@@ -3,6 +3,8 @@ var env = require('../environment.js');
 exports.config = {
   seleniumAddress: env.seleniumAddress,
 
+  framework: 'jasmine2',
+
   specs: [
     'baseCase/single_failure_spec1.js',
     'baseCase/single_failure_spec2.js'

--- a/spec/errorTest/shardedFailureConf.js
+++ b/spec/errorTest/shardedFailureConf.js
@@ -3,6 +3,8 @@ var env = require('../environment.js');
 exports.config = {
   seleniumAddress: env.seleniumAddress,
 
+  framework: 'jasmine2',
+
   specs: [
     'baseCase/single_failure_spec1.js',
     'baseCase/single_failure_spec2.js'

--- a/spec/errorTest/singleFailureConf.js
+++ b/spec/errorTest/singleFailureConf.js
@@ -3,6 +3,8 @@ var env = require('../environment.js');
 exports.config = {
   seleniumAddress: env.seleniumAddress,
 
+  framework: 'jasmine2',
+
   specs: [
     'baseCase/single_failure_spec1.js'
   ],

--- a/spec/errorTest/timeoutConf.js
+++ b/spec/errorTest/timeoutConf.js
@@ -3,6 +3,8 @@ var env = require('../environment.js');
 exports.config = {
   seleniumAddress: env.seleniumAddress,
 
+  framework: 'jasmine2',
+
   specs: [
     'baseCase/timeout_spec.js'
   ],

--- a/spec/interactionConf.js
+++ b/spec/interactionConf.js
@@ -4,6 +4,8 @@ var env = require('./environment.js');
 exports.config = {
   seleniumAddress: env.seleniumAddress,
 
+  framework: 'jasmine2',
+
   // Spec patterns are relative to this directory.
   specs: [
     'interaction/*_spec.js'

--- a/spec/junitOutputConf.js
+++ b/spec/junitOutputConf.js
@@ -8,6 +8,8 @@ var env = require('./environment.js');
 exports.config = {
   seleniumAddress: env.seleniumAddress,
 
+  framework: 'jasmine2',
+
   specs: [
     'basic/*_spec.js'
   ],

--- a/spec/multiConf.js
+++ b/spec/multiConf.js
@@ -4,6 +4,8 @@ var env = require('./environment.js');
 exports.config = {
   seleniumAddress: env.seleniumAddress,
 
+  framework: 'jasmine2',
+
   // Spec patterns are relative to this directory.
   specs: [
     'basic/lib_spec.js'

--- a/spec/ngHintFailConfig.js
+++ b/spec/ngHintFailConfig.js
@@ -2,6 +2,7 @@ var env = require('./environment.js');
 
 exports.config = {
   seleniumAddress: env.seleniumAddress,
+  framework: 'jasmine2',
   specs: ['ngHint/fail_spec.js'],
   baseUrl: env.baseUrl,
   plugins: [{

--- a/spec/ngHintSuccessConfig.js
+++ b/spec/ngHintSuccessConfig.js
@@ -2,6 +2,7 @@ var env = require('./environment.js');
 
 exports.config = {
   seleniumAddress: env.seleniumAddress,
+  framework: 'jasmine2',
   specs: ['ngHint/success_spec.js'],
   baseUrl: env.baseUrl,
   plugins: [{

--- a/spec/onCleanUpAsyncReturnValueConf.js
+++ b/spec/onCleanUpAsyncReturnValueConf.js
@@ -5,6 +5,8 @@ var q = require('q');
 exports.config = {
   seleniumAddress: env.seleniumAddress,
 
+  framework: 'jasmine2',
+
   specs: [
     'onCleanUp/*_spec.js'
   ],

--- a/spec/onCleanUpNoReturnValueConf.js
+++ b/spec/onCleanUpNoReturnValueConf.js
@@ -4,6 +4,8 @@ var env = require('./environment.js');
 exports.config = {
   seleniumAddress: env.seleniumAddress,
 
+  framework: 'jasmine2',
+
   specs: [
     'onCleanUp/*_spec.js'
   ],

--- a/spec/onCleanUpSyncReturnValueConf.js
+++ b/spec/onCleanUpSyncReturnValueConf.js
@@ -4,6 +4,8 @@ var env = require('./environment.js');
 exports.config = {
   seleniumAddress: env.seleniumAddress,
 
+  framework: 'jasmine2',
+
   specs: [
     'onCleanUp/*_spec.js'
   ],

--- a/spec/onPrepareConf.js
+++ b/spec/onPrepareConf.js
@@ -6,6 +6,8 @@ var env = require('./environment.js');
 exports.config = {
   seleniumAddress: env.seleniumAddress,
 
+  framework: 'jasmine2',
+
   specs: [
     'onPrepare/*_spec.js'
   ],

--- a/spec/onPrepareFileConf.js
+++ b/spec/onPrepareFileConf.js
@@ -5,6 +5,8 @@ var env = require('./environment.js');
 exports.config = {
   seleniumAddress: env.seleniumAddress,
 
+  framework: 'jasmine2',
+
   // Spec patterns are relative to this directory.
   specs: [
     'onPrepare/*_spec.js'

--- a/spec/onPreparePromiseConf.js
+++ b/spec/onPreparePromiseConf.js
@@ -7,6 +7,8 @@ var q = require('q');
 exports.config = {
   seleniumAddress: env.seleniumAddress,
 
+  framework: 'jasmine2',
+
   specs: [
     'onPrepare/*_spec.js'
   ],

--- a/spec/onPreparePromiseFileConf.js
+++ b/spec/onPreparePromiseFileConf.js
@@ -5,6 +5,8 @@ var env = require('./environment.js');
 exports.config = {
   seleniumAddress: env.seleniumAddress,
 
+  framework: 'jasmine2',
+
   // Spec patterns are relative to this directory.
   specs: [
     'onPrepare/*_spec.js'

--- a/spec/pluginsBasicConf.js
+++ b/spec/pluginsBasicConf.js
@@ -5,6 +5,8 @@ var env = require('./environment.js');
 exports.config = {
   seleniumAddress: env.seleniumAddress,
 
+  framework: 'jasmine2',
+
   // Spec patterns are relative to this directory.
   specs: [
     'plugins/basic_spec.js'

--- a/spec/pluginsFullConf.js
+++ b/spec/pluginsFullConf.js
@@ -4,6 +4,8 @@ var env = require('./environment.js');
 exports.config = {
   seleniumAddress: env.seleniumAddress,
 
+  framework: 'jasmine2',
+
   // Spec patterns are relative to this directory.
   specs: [
     'plugins/basic_spec.js'

--- a/spec/restartBrowserBetweenTestsConf.js
+++ b/spec/restartBrowserBetweenTestsConf.js
@@ -4,6 +4,8 @@ var env = require('./environment.js');
 exports.config = {
   seleniumAddress: env.seleniumAddress,
 
+  framework: 'jasmine2',
+
   // Spec patterns are relative to this directory.
   specs: [
     'restartBrowserBetweenTests/*_spec.js'

--- a/spec/smokeConf.js
+++ b/spec/smokeConf.js
@@ -6,6 +6,8 @@ exports.config = {
   sauceUser: process.env.SAUCE_USERNAME,
   sauceKey: process.env.SAUCE_ACCESS_KEY,
 
+  framework: 'jasmine2',
+
   specs: [
     'basic/locators_spec.js',
     'basic/mockmodule_spec.js',

--- a/spec/suitesConf.js
+++ b/spec/suitesConf.js
@@ -3,6 +3,8 @@ var env = require('./environment.js');
 exports.config = {
   seleniumAddress: env.seleniumAddress,
 
+  framework: 'jasmine2',
+
   // Spec patterns are relative to this directory.
   suites: {
     okspec: 'suites/ok_spec.js',

--- a/spec/unit/config_test.js
+++ b/spec/unit/config_test.js
@@ -41,7 +41,7 @@ describe('the config parser', function() {
 
   describe('resolving globs', function() {
     it('should resolve relative to the cwd', function() {
-      spyOn(process, 'cwd').andReturn(__dirname + '/');
+      spyOn(process, 'cwd').and.returnValue(__dirname + '/');
       var toAdd = {
         specs: 'data/*spec[AB].js'
       };

--- a/spec/withLoginConf.js
+++ b/spec/withLoginConf.js
@@ -5,6 +5,8 @@ var env = require('./environment.js');
 exports.config = {
   seleniumAddress: env.seleniumAddress,
 
+  framework: 'jasmine2',
+
   specs: [
     'login/login_spec.js'
   ],


### PR DESCRIPTION
This PR enables protractor to work with jasmine2.0 (see https://github.com/angular/protractor/issues/362)

Pending https://github.com/angular/jasminewd/pull/13 for the release of jasminewd2

Note, passing timeout as part of `it`, `fit`, etc does not work yet. Pending https://github.com/jasmine/jasmine/commit/a4faa80be464b1054293ac3179eb21b2ccc8c472

Also, stacktrace is messed up when calling `done.fail('xyz')` because jasmine2 does not allow custom stacktrace. Filed an issue at https://github.com/jasmine/jasmine/issues/734
