### PR TITLE
feat(jasmine2): add 'grep' option to jasmine2

### DIFF
--- a/docs/referenceConf.js
+++ b/docs/referenceConf.js
@@ -265,8 +265,13 @@ exports.config = {
     showColors: true,
     // Default time to wait in ms before a test fails.
     defaultTimeoutInterval: 30000,
-    // Function called to print jasmine results
+    // Function called to print jasmine results.
     print: function() {},
+    // If set, only execute specs whose names match the pattern, which is
+    // internally compiled to a RegExp.
+    grep: 'pattern',
+    // Inverts 'grep' matches
+    invertGrep: false
   },
 
   // Options to be passed to Mocha.

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -59,6 +59,8 @@ var optimist = require('optimist').
     alias('build', 'capabilities.build').
     alias('verbose', 'jasmineNodeOpts.isVerbose').
     alias('stackTrace', 'jasmineNodeOpts.includeStackTrace').
+    alias('grep', 'jasmineNodeOpts.grep').
+    alias('invert-grep', 'jasmineNodeOpts.invertGrep').
     string('capabilities.tunnel-identifier').
     check(function(arg) {
       if (arg._.length > 1) {

--- a/lib/frameworks/jasmine2.js
+++ b/lib/frameworks/jasmine2.js
@@ -54,6 +54,8 @@ exports.run = function(runner, specs) {
 
   require('jasminewd2');
 
+  var jasmineNodeOpts = runner.getConfig().jasmineNodeOpts;
+
   // On timeout, the flow should be reset. This will prevent webdriver tasks
   // from overflowing into the next test and causing it to fail or timeout
   // as well. This is done in the reporter instead of an afterEach block
@@ -62,10 +64,20 @@ exports.run = function(runner, specs) {
   var reporter = new RunnerReporter(runner); 
   jasmine.getEnv().addReporter(reporter);
 
+  // Filter specs to run based on jasmineNodeOpts.grep and jasmineNodeOpts.invert.
+  jasmine.getEnv().specFilter = function(spec) {
+    var grepMatch = !jasmineNodeOpts || 
+        !jasmineNodeOpts.grep || 
+        spec.getFullName().match(new RegExp(jasmineNodeOpts.grep)) != null;
+    var invertGrep = !!(jasmineNodeOpts && jasmineNodeOpts.invertGrep);
+    if (grepMatch == invertGrep) {
+      spec.pend();
+    }
+    return true;
+  }
+
   return runner.runTestPreparer().then(function() {
     return q.promise(function (resolve, reject) {
-      var jasmineNodeOpts = runner.getConfig().jasmineNodeOpts;
-
       if (jasmineNodeOpts && jasmineNodeOpts.defaultTimeoutInterval) {
         jasmine.DEFAULT_TIMEOUT_INTERVAL = jasmineNodeOpts.defaultTimeoutInterval;
       }


### PR DESCRIPTION
Allow users to filter the specs that they want to run using simple string match.
To use this feature, either:
1) specify jasmineNodeOpts.grep in your conf.js file
  or
2) via commandline like "protractor conf.js --jasmineNodeOpts.grep='string to match'"