### PR TITLE
fix(element): Improve error reporting

### DIFF
--- a/lib/element.js
+++ b/lib/element.js
@@ -257,16 +257,10 @@ ElementArrayFinder.prototype.get = function(index) {
         i = parentWebElements.length + i;
       }
       if (i < 0 || i >= parentWebElements.length) {
-        if (parentWebElements.length == 0) {
-          throw new webdriver.error.Error(
-              webdriver.error.ErrorCode.NO_SUCH_ELEMENT,
-              'No element found using locator: ' +
-                  elementArrayFinder.locator_.toString());
-        } else {
         throw new Error('Index out of bound. Trying to access element at ' +
             'index: ' + index + ', but there are only ' +
-            parentWebElements.length + ' elements');
-        }
+            parentWebElements.length + ' elements that match locator ' +
+            elementArrayFinder.locator_.toString()));
       }
       return [parentWebElements[i]];
     });

--- a/lib/element.js
+++ b/lib/element.js
@@ -260,7 +260,7 @@ ElementArrayFinder.prototype.get = function(index) {
         throw new Error('Index out of bound. Trying to access element at ' +
             'index: ' + index + ', but there are only ' +
             parentWebElements.length + ' elements that match locator ' +
-            elementArrayFinder.locator_.toString()));
+            elementArrayFinder.locator_.toString());
       }
       return [parentWebElements[i]];
     });

--- a/lib/element.js
+++ b/lib/element.js
@@ -257,9 +257,16 @@ ElementArrayFinder.prototype.get = function(index) {
         i = parentWebElements.length + i;
       }
       if (i < 0 || i >= parentWebElements.length) {
+        if (parentWebElements.length == 0) {
+          throw new webdriver.error.Error(
+              webdriver.error.ErrorCode.NO_SUCH_ELEMENT,
+              'No element found using locator: ' +
+                  elementArrayFinder.locator_.toString());
+        } else {
         throw new Error('Index out of bound. Trying to access element at ' +
-            'index:' + index + ', but there are only ' +
+            'index: ' + index + ', but there are only ' +
             parentWebElements.length + ' elements');
+        }
       }
       return [parentWebElements[i]];
     });


### PR DESCRIPTION

I often get "Index out of bound" errors, explaining that there are 0 elements in an "element.all" array, when a more correct/consistent error would be "No element found using locator [Locator]". This is a quick fix. I may have a mis-scoped object or two in my "throw" statement. If so, I'd appreciate a push in the right direction.

Isaac Lyman