### PR TITLE
Pass the current runner config into the onPrepare hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 1.6.1
+
+## Bug Fixes
+
+- ([92c5d17](https://github.com/angular/protractor/commit/92c5d17844a2b4dc56c483ab4a65e2bf631175f9)) 
+  fix(element): test crashes when using certain locators with `fromWebElement_`
+
+  Protractor crashes when one uses locators with findElementsOverride (i.e. any custom protractor
+  locator like by.binding/repeater/etc) in map/filter/then/each/reduce
+
 # 1.6.0
 
 ## Features

--- a/docs/frameworks.md
+++ b/docs/frameworks.md
@@ -13,7 +13,7 @@ Currently, Jasmine Versions 1.3 and 2.0 are supported. Jasmine 1.3 is the defaul
 Using Mocha
 -----------
 
-_Note: Limited support for Mocha is available as of December 2013. For more information, see the [Mocha GitHub site](http://visionmedia.github.io/mocha/)._
+_Note: Limited support for Mocha is available as of December 2013. For more information, see the [Mocha documentation site](http://mochajs.org/)._
 
 If you would like to use the Mocha test framework, you'll need to use the BDD interface and Chai assertions with [Chai As Promised](http://chaijs.com/plugins/chai-as-promised).
 

--- a/docs/jasmine-upgrade.md
+++ b/docs/jasmine-upgrade.md
@@ -1,4 +1,5 @@
-## Upgrading from Jasmine 1.3 to 2.x
+Upgrading from Jasmine 1.3 to 2.x
+=================================
 
 First, please read [Jasmine's official upgrade documentation](http://jasmine.github.io/2.0/upgrading.html).
 

--- a/docs/jasmine-upgrade.md
+++ b/docs/jasmine-upgrade.md
@@ -14,6 +14,26 @@ exports.config = {
 
 ```
 
+Similar to jasmine 1.3, you may include `jasmineNodeOpts` in the config file. However, because we changed the runner from "https://github.com/juliemr/minijasminenode" to "https://github.com/jasmine/jasmine-npm", the options have changed slightly. In particular, we will only support the options in the official "jasmine-npm":
+
+```javascript
+jasmineNodeOpts: {
+  // If true, print colors to the terminal.
+  showColors: true,
+  // Default time to wait in ms before a test fails.
+  defaultTimeoutInterval: 30000,
+  // Function called to print jasmine results.
+  print: function() {},
+  // If set, only execute specs whose names match the pattern, which is
+  // internally compiled to a RegExp.
+  grep: 'pattern',
+  // Inverts 'grep' matches
+  invertGrep: false
+}
+```
+
+Notably options `print` and `grep` are new, but we will no longer support options `isVerbose` and `includeStackTrace` (unless, of course, "jasmine-npm" introduces these options).
+
 ### In your specs
 
 #### Focused specs

--- a/docs/referenceConf.js
+++ b/docs/referenceConf.js
@@ -276,7 +276,7 @@ exports.config = {
 
   // Options to be passed to Mocha.
   //
-  // See the full list at http://visionmedia.github.io/mocha/
+  // See the full list at http://mochajs.org/
   mochaOpts: {
     ui: 'bdd',
     reporter: 'list'

--- a/docs/referenceConf.js
+++ b/docs/referenceConf.js
@@ -193,6 +193,14 @@ exports.config = {
     // are using Jasmine, you can add a reporter with:
     //     jasmine.getEnv().addReporter(new jasmine.JUnitXmlReporter(
     //         'outputdir/', true, true));
+    //
+    // As a convenience, if you need access back to the current configuration
+    // object, you may use a pattern like the following:
+    //     browser.getProcessedConfig().then(function(config) {
+    //       // config.capabilities is the CURRENT capability being run, if
+    //       // you are using multiCapabilities.
+    //       console.log('Executing capability', config.capabilities);
+    //     });
   },
 
   // A callback function called once tests are finished.

--- a/lib/element.js
+++ b/lib/element.js
@@ -258,8 +258,9 @@ ElementArrayFinder.prototype.get = function(index) {
       }
       if (i < 0 || i >= parentWebElements.length) {
         throw new Error('Index out of bound. Trying to access element at ' +
-            'index:' + index + ', but there are only ' +
-            parentWebElements.length + ' elements');
+            'index: ' + index + ', but there are only ' +
+            parentWebElements.length + ' elements that match locator ' +
+            elementArrayFinder.locator_.toString());
       }
       return [parentWebElements[i]];
     });

--- a/lib/element.js
+++ b/lib/element.js
@@ -207,7 +207,7 @@ ElementArrayFinder.prototype.filter = function(filterFn) {
       var list = [];
       parentWebElements.forEach(function(parentWebElement, index) {
         var elementFinder = 
-            ElementFinder.fromWebElement_(parentWebElement, self.locator_);
+            ElementFinder.fromWebElement_(self.ptor_, parentWebElement, self.locator_);
 
         var filterResults = filterFn(elementFinder, index);
         if (filterResults instanceof webdriver.promise.Promise) {
@@ -412,7 +412,7 @@ ElementArrayFinder.prototype.asElementFinders_ = function() {
   return this.getWebElements().then(function(arr) {
     var list = [];
     arr.forEach(function(webElem) {
-      list.push(ElementFinder.fromWebElement_(webElem, self.locator_));
+      list.push(ElementFinder.fromWebElement_(self.ptor_, webElem, self.locator_));
     });
     return list; 
   });
@@ -703,11 +703,11 @@ util.inherits(ElementFinder, webdriver.promise.Promise);
 
 exports.ElementFinder = ElementFinder;
 
-ElementFinder.fromWebElement_ = function(webElem, locator) {
+ElementFinder.fromWebElement_ = function(ptor, webElem, locator) {
   var getWebElements = function() {
     return webdriver.promise.fulfilled([webElem]);
   };
-  return new ElementArrayFinder(this.ptor_, getWebElements, locator).
+  return new ElementArrayFinder(ptor, getWebElements, locator).
       toElementFinder_();
 };
 

--- a/lib/element.js
+++ b/lib/element.js
@@ -260,7 +260,7 @@ ElementArrayFinder.prototype.get = function(index) {
         throw new Error('Index out of bound. Trying to access element at ' +
             'index: ' + index + ', but there are only ' +
             parentWebElements.length + ' elements that match locator ' +
-            elementArrayFinder.locator_.toString());
+            self.locator_.toString());
       }
       return [parentWebElements[i]];
     });

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -188,6 +188,17 @@ Runner.prototype.createBrowser = function() {
   var self = this; 
 
   /**
+   * Get the processed configuration object that is currently being run.
+   *
+   * @return {q.Promise} A promise which resolves on finish.
+   */
+  browser_.getProcessedConfig = function() {
+    var deferred = q.defer();
+    deferred.resolve(config);
+    return deferred.promise;
+  };
+
+  /**
    * Fork another instance of protractor for use in interactive tests.
    *
    * @param {boolean} opt_useSameUrl Whether to navigate to current url on creation

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -185,7 +185,7 @@ Runner.prototype.createBrowser = function() {
   if (config.getPageTimeout) {
     browser_.getPageTimeout = config.getPageTimeout;
   }
-  var self = this;
+  var self = this; 
 
   /**
    * Fork another instance of protractor for use in interactive tests.
@@ -281,13 +281,13 @@ Runner.prototype.run = function() {
         // Note: because tests are not paused at this point, any async
         // calls here are not guaranteed to complete before the tests resume.
         self.driverprovider_.quitDriver(browser_.driver);
-        // Copy mock modules, but do not navigate to previous URL.
+        // Copy mock modules, but do not navigate to previous URL. 
         browser_ = browser_.forkNewDriverInstance(false, true);
         self.setupGlobals_(browser_);
       };
 
       self.on('testPass', restartDriver);
-      self.on('testFail', restartDriver);
+      self.on('testFail', restartDriver);      
     }
 
     return require(frameworkPath).run(self, self.config_.specs).

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -73,7 +73,7 @@ Runner.prototype.setTestPreparer = function(filenameOrFn) {
  *     are finished.
  */
 Runner.prototype.runTestPreparer = function() {
-  return helper.runFilenameOrFn_(this.config_.configDir, this.preparer_, [this.config_]);
+  return helper.runFilenameOrFn_(this.config_.configDir, this.preparer_);
 };
 
 
@@ -185,7 +185,7 @@ Runner.prototype.createBrowser = function() {
   if (config.getPageTimeout) {
     browser_.getPageTimeout = config.getPageTimeout;
   }
-  var self = this;
+  var self = this; 
 
   /**
    * Fork another instance of protractor for use in interactive tests.
@@ -281,13 +281,13 @@ Runner.prototype.run = function() {
         // Note: because tests are not paused at this point, any async
         // calls here are not guaranteed to complete before the tests resume.
         self.driverprovider_.quitDriver(browser_.driver);
-        // Copy mock modules, but do not navigate to previous URL.
+        // Copy mock modules, but do not navigate to previous URL. 
         browser_ = browser_.forkNewDriverInstance(false, true);
         self.setupGlobals_(browser_);
       };
 
       self.on('testPass', restartDriver);
-      self.on('testFail', restartDriver);
+      self.on('testFail', restartDriver);      
     }
 
     return require(frameworkPath).run(self, self.config_.specs).

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -73,7 +73,7 @@ Runner.prototype.setTestPreparer = function(filenameOrFn) {
  *     are finished.
  */
 Runner.prototype.runTestPreparer = function() {
-  return helper.runFilenameOrFn_(this.config_.configDir, this.preparer_);
+  return helper.runFilenameOrFn_(this.config_.configDir, this.preparer_, [this.config_]);
 };
 
 
@@ -185,7 +185,7 @@ Runner.prototype.createBrowser = function() {
   if (config.getPageTimeout) {
     browser_.getPageTimeout = config.getPageTimeout;
   }
-  var self = this; 
+  var self = this;
 
   /**
    * Fork another instance of protractor for use in interactive tests.
@@ -281,13 +281,13 @@ Runner.prototype.run = function() {
         // Note: because tests are not paused at this point, any async
         // calls here are not guaranteed to complete before the tests resume.
         self.driverprovider_.quitDriver(browser_.driver);
-        // Copy mock modules, but do not navigate to previous URL. 
+        // Copy mock modules, but do not navigate to previous URL.
         browser_ = browser_.forkNewDriverInstance(false, true);
         self.setupGlobals_(browser_);
       };
 
       self.on('testPass', restartDriver);
-      self.on('testFail', restartDriver);      
+      self.on('testFail', restartDriver);
     }
 
     return require(frameworkPath).run(self, self.config_.specs).

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -185,7 +185,7 @@ Runner.prototype.createBrowser = function() {
   if (config.getPageTimeout) {
     browser_.getPageTimeout = config.getPageTimeout;
   }
-  var self = this; 
+  var self = this;
 
   /**
    * Fork another instance of protractor for use in interactive tests.
@@ -281,13 +281,13 @@ Runner.prototype.run = function() {
         // Note: because tests are not paused at this point, any async
         // calls here are not guaranteed to complete before the tests resume.
         self.driverprovider_.quitDriver(browser_.driver);
-        // Copy mock modules, but do not navigate to previous URL. 
+        // Copy mock modules, but do not navigate to previous URL.
         browser_ = browser_.forkNewDriverInstance(false, true);
         self.setupGlobals_(browser_);
       };
 
       self.on('testPass', restartDriver);
-      self.on('testFail', restartDriver);      
+      self.on('testFail', restartDriver);
     }
 
     return require(frameworkPath).run(self, self.config_.specs).

--- a/package.json
+++ b/package.json
@@ -53,5 +53,5 @@
     "start": "node testapp/scripts/web-server.js"
   },
   "license": "MIT",
-  "version": "1.6.0"
+  "version": "1.6.1"
 }

--- a/spec/basic/elements_spec.js
+++ b/spec/basic/elements_spec.js
@@ -503,6 +503,25 @@ describe('ElementArrayFinder', function() {
     var e1 = element(by.tagName('body')).then(function(){});
     expect(e1 instanceof protractor.promise.Promise).toBe(true);
   });
+
+  it('should allow using protractor locator within map', function() {
+    browser.get('index.html#/repeater');
+
+    var expected = [ { first: 'M', second: 'Monday' },
+        { first: 'T', second: 'Tuesday' },
+        { first: 'W', second: 'Wednesday' },
+        { first: 'Th', second: 'Thursday' },
+        { first: 'F', second: 'Friday' } ];
+
+    var result = element.all(by.repeater('allinfo in days')).map(function(el) {
+      return {
+        first: el.element(by.binding('allinfo.initial')).getText(),
+        second: el.element(by.binding('allinfo.name')).getText(),
+      };
+    });
+
+    expect(result).toEqual(expected);
+  });
 });
 
 describe('evaluating statements', function() {

--- a/website/index.html
+++ b/website/index.html
@@ -24,7 +24,7 @@
       <div class="collapse navbar-collapse bs-example-js-navbar-collapse">
         <ul class="nav navbar-nav">
           <!-- Home -->
-          <li><a href="#">Home</a></li>
+          <li><a href="#/">Home</a></li>
 
           <!-- Quick start -->
           <li class="dropdown">

--- a/website/test/e2e/api_spec.js
+++ b/website/test/e2e/api_spec.js
@@ -116,9 +116,9 @@ describe('Api', function() {
     // Then ensure the child functions are shown.
     expect(apiPage.getChildFunctionNames()).toEqual([
       'waitForAngular', 'findElement', 'findElements', 'isElementPresent',
-      'addMockModule', 'clearMockModules', 'removeMockModule', 'get',
-      'refresh', 'navigate', 'setLocation', 'getLocationAbsUrl', 'debugger',
-      'pause']);
+      'addMockModule', 'clearMockModules', 'removeMockModule',
+      'getRegisteredMockModules', 'get', 'refresh', 'navigate', 'setLocation',
+      'getLocationAbsUrl', 'debugger', 'pause']);
   });
 
   it('should view inherited function', function() {

--- a/website/test/e2e/menu-partial.js
+++ b/website/test/e2e/menu-partial.js
@@ -3,15 +3,7 @@
  * @constructor
  */
 var MenuPartial = function() {
-  /**
-   * Get the labels for all the top level menu items.
-   * @return A promise that resolves to an array of strings.
-   */
-  this.getTopMenuItems = function() {
-    return $$('.navbar-nav > li > a').map(function(item) {
-      return item.getText();
-    });
-  };
+  this.topMenuItems = $$('.navbar-nav > li > a');
 
   /**
    * Dropdown api. Used to click on an element under a dropdown or to get the
@@ -20,39 +12,35 @@ var MenuPartial = function() {
    * @return {{item: Function, itemNames: Function}}
    */
   this.dropdown = function(dropdownName) {
-
-    /**
-     * Open a dropdown given its name.
-     * @private
-     */
-    var openDropdown_ = function() {
-      $('.navbar-nav').
-          element(by.linkText(dropdownName)).
-          click();
-    };
-
     return {
+      /**
+       * Open a dropdown given its name.
+       */
+      open: function() {
+        $('.navbar-nav')
+            .element(by.linkText(dropdownName))
+            .click();
+      },
       /**
        * Select an item under a menu dropdown.
        * @param {string} itemName
        */
       item: function(itemName) {
-        openDropdown_();
+        this.open();
 
         // Click on an element under the open dropdown.
-        $('.dropdown.open').
-            element(by.linkText(itemName)).
-            click();
+        $('.dropdown.open')
+            .element(by.linkText(itemName))
+            .click();
       },
       /**
        * Get the names of the items under a dropdown menu.
        */
       itemNames: function() {
-        openDropdown_();
+        this.open();
 
-        return $$('.dropdown.open .dropdown-menu li a').map(function(item) {
-          return item.getText();
-        });
+        return $$('.dropdown.open .dropdown-menu li a')
+            .getText();
       }
     };
   };

--- a/website/test/e2e/navigation_spec.js
+++ b/website/test/e2e/navigation_spec.js
@@ -11,7 +11,7 @@ describe('Navigation', function() {
 
     expect($('.protractor-logo').isPresent()).toBe(true);
   });
-  
+
   it('should go to tutorial', function() {
     menu.dropdown('Quick Start').item('Tutorial');
 
@@ -164,6 +164,18 @@ describe('Navigation', function() {
       menu.dropdown('Reference').item('How It Works');
 
       expect($('h1').getText()).toBe('How It Works');
+    });
+
+    it('should go to Upgrading to Jasmine 2.0', function() {
+      menu.dropdown('Reference').item('Upgrading to Jasmine 2.0');
+
+      expect($('h1').getText()).toBe('Upgrading from Jasmine 1.3 to 2.x');
+    });
+
+    it('should go to Mobile Setup', function() {
+      menu.dropdown('Reference').item('Mobile Setup');
+
+      expect($('h1').getText()).toBe('Mobile Setup');
     });
 
     it('should go to FAQ', function() {

--- a/website/test/e2e/navigation_spec.js
+++ b/website/test/e2e/navigation_spec.js
@@ -7,6 +7,8 @@ describe('Navigation', function() {
   });
 
   it('should go to home', function() {
+    menu.dropdown('Home').open();
+
     expect($('.protractor-logo').isPresent()).toBe(true);
   });
   
@@ -19,7 +21,7 @@ describe('Navigation', function() {
   describe('Menu items', function() {
     it('should have menu items', function() {
       // Make sure all the top level menu labels are present.
-      expect(menu.getTopMenuItems()).toEqual([
+      expect(menu.topMenuItems.getText()).toEqual([
         'Home',
         'Quick Start',
         'Protractor Setup',


### PR DESCRIPTION
Currently the `onPrepare()` hook has no arguments passed into it. This means that, even though it is called once per capability, it has no idea which capability is being executed so it can't make context-sensitive decisions. This PR passes that configuration block into `onPrepare()` so it can do that, like including requirements that only certain tests need (for performance reasons, or where only certain environments require/support them).

Since `runFilenameOrFn_()` already supports the concept of passing arguments to the callback, this only requires a 1-line code change.