### PR TITLE
chore(website): Upgrade e2e tests to 1.6.0 API

### DIFF
--- a/docs/jasmine-upgrade.md
+++ b/docs/jasmine-upgrade.md
@@ -1,4 +1,5 @@
-## Upgrading from Jasmine 1.3 to 2.x
+Upgrading from Jasmine 1.3 to 2.x
+=================================
 
 First, please read [Jasmine's official upgrade documentation](http://jasmine.github.io/2.0/upgrading.html).
 

--- a/website/test/e2e/api_spec.js
+++ b/website/test/e2e/api_spec.js
@@ -116,9 +116,9 @@ describe('Api', function() {
     // Then ensure the child functions are shown.
     expect(apiPage.getChildFunctionNames()).toEqual([
       'waitForAngular', 'findElement', 'findElements', 'isElementPresent',
-      'addMockModule', 'clearMockModules', 'removeMockModule', 'get',
-      'refresh', 'navigate', 'setLocation', 'getLocationAbsUrl', 'debugger',
-      'pause']);
+      'addMockModule', 'clearMockModules', 'removeMockModule',
+      'getRegisteredMockModules', 'get', 'refresh', 'navigate', 'setLocation',
+      'getLocationAbsUrl', 'debugger', 'pause']);
   });
 
   it('should view inherited function', function() {

--- a/website/test/e2e/navigation_spec.js
+++ b/website/test/e2e/navigation_spec.js
@@ -174,7 +174,6 @@ describe('Navigation', function() {
       menu.dropdown('Reference').item('Mobile Setup');
 
       expect($('h1').getText()).toBe('Mobile Setup');
-
     });
 
     it('should go to FAQ', function() {

--- a/website/test/e2e/navigation_spec.js
+++ b/website/test/e2e/navigation_spec.js
@@ -163,6 +163,19 @@ describe('Navigation', function() {
 
       expect($('h1').getText()).toBe('How It Works');
     });
+    
+    it('should go to Upgrading to Jasmine 2.0', function() {
+      menu.dropdown('Reference').item('Upgrading to Jasmine 2.0');
+
+      expect($('h1').getText()).toBe('Upgrading from Jasmine 1.3 to 2.x');
+    });
+    
+    it('should go to Mobile Setup', function() {
+      menu.dropdown('Reference').item('Mobile Setup');
+
+      expect($('h1').getText()).toBe('Mobile Setup');
+
+    });
 
     it('should go to FAQ', function() {
       menu.dropdown('Reference').item('FAQ');


### PR DESCRIPTION
Upgrade the e2e tests to reflect the new 1.6.0 API
Add tests for the new jasmine upgrade and mobile docs.
Fix browser functions scenario.