### PR TITLE
docs(links): update links to mocha documentation

### DIFF
--- a/docs/frameworks.md
+++ b/docs/frameworks.md
@@ -13,7 +13,7 @@ Currently, Jasmine Versions 1.3 and 2.0 are supported. Jasmine 1.3 is the defaul
 Using Mocha
 -----------
 
-_Note: Limited support for Mocha is available as of December 2013. For more information, see the [Mocha GitHub site](http://visionmedia.github.io/mocha/)._
+_Note: Limited support for Mocha is available as of December 2013. For more information, see the [Mocha documentation site](http://mochajs.org/)._
 
 If you would like to use the Mocha test framework, you'll need to use the BDD interface and Chai assertions with [Chai As Promised](http://chaijs.com/plugins/chai-as-promised).
 

--- a/docs/referenceConf.js
+++ b/docs/referenceConf.js
@@ -276,7 +276,7 @@ exports.config = {
 
   // Options to be passed to Mocha.
   //
-  // See the full list at http://visionmedia.github.io/mocha/
+  // See the full list at http://mochajs.org/
   mochaOpts: {
     ui: 'bdd',
     reporter: 'list'


### PR DESCRIPTION
I  noticed that the existing links relating to mocha documentation [http://visionmedia.github.io/mocha/](visionmedia.github.io/mocha/) are no longer valid (404), so I've pointed them to [http://mochajs.org/](mochajs.org/) where documentation is available.