### PR TITLE
bug(element): test crashes when using certain locators with `fromWebElem...

### DIFF
--- a/lib/element.js
+++ b/lib/element.js
@@ -207,7 +207,7 @@ ElementArrayFinder.prototype.filter = function(filterFn) {
       var list = [];
       parentWebElements.forEach(function(parentWebElement, index) {
         var elementFinder = 
-            ElementFinder.fromWebElement_(parentWebElement, self.locator_);
+            ElementFinder.fromWebElement_(self.ptor_, parentWebElement, self.locator_);
 
         var filterResults = filterFn(elementFinder, index);
         if (filterResults instanceof webdriver.promise.Promise) {
@@ -412,7 +412,7 @@ ElementArrayFinder.prototype.asElementFinders_ = function() {
   return this.getWebElements().then(function(arr) {
     var list = [];
     arr.forEach(function(webElem) {
-      list.push(ElementFinder.fromWebElement_(webElem, self.locator_));
+      list.push(ElementFinder.fromWebElement_(self.ptor_, webElem, self.locator_));
     });
     return list; 
   });
@@ -703,11 +703,11 @@ util.inherits(ElementFinder, webdriver.promise.Promise);
 
 exports.ElementFinder = ElementFinder;
 
-ElementFinder.fromWebElement_ = function(webElem, locator) {
+ElementFinder.fromWebElement_ = function(ptor, webElem, locator) {
   var getWebElements = function() {
     return webdriver.promise.fulfilled([webElem]);
   };
-  return new ElementArrayFinder(this.ptor_, getWebElements, locator).
+  return new ElementArrayFinder(ptor, getWebElements, locator).
       toElementFinder_();
 };
 

--- a/spec/basic/elements_spec.js
+++ b/spec/basic/elements_spec.js
@@ -503,6 +503,25 @@ describe('ElementArrayFinder', function() {
     var e1 = element(by.tagName('body')).then(function(){});
     expect(e1 instanceof protractor.promise.Promise).toBe(true);
   });
+
+  it('should allow using protractor locator within map', function() {
+    browser.get('index.html#/repeater');
+
+    var expected = [ { first: 'M', second: 'Monday' },
+        { first: 'T', second: 'Tuesday' },
+        { first: 'W', second: 'Wednesday' },
+        { first: 'Th', second: 'Thursday' },
+        { first: 'F', second: 'Friday' } ];
+
+    var result = element.all(by.repeater('allinfo in days')).map(function(el) {
+      return {
+        first: el.element(by.binding('allinfo.initial')).getText(),
+        second: el.element(by.binding('allinfo.name')).getText(),
+      };
+    });
+
+    expect(result).toEqual(expected);
+  });
 });
 
 describe('evaluating statements', function() {


### PR DESCRIPTION
...ent_`

Protractor crashes when one uses locators with findElementsOverride (i.e.
any custom protractor locator like by.binding/repeater/etc) in
map/filter/then/each/reduce