### PR TITLE
Provide access to the processed configuration block

### DIFF
--- a/docs/referenceConf.js
+++ b/docs/referenceConf.js
@@ -193,6 +193,14 @@ exports.config = {
     // are using Jasmine, you can add a reporter with:
     //     jasmine.getEnv().addReporter(new jasmine.JUnitXmlReporter(
     //         'outputdir/', true, true));
+    //
+    // As a convenience, if you need access back to the current configuration
+    // object, you may use a pattern like the following:
+    //     browser.getProcessedConfig().then(function(config) {
+    //       // config.capabilities is the CURRENT capability being run, if
+    //       // you are using multiCapabilities.
+    //       console.log('Executing capability', config.capabilities);
+    //     });
   },
 
   // A callback function called once tests are finished.

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -188,6 +188,17 @@ Runner.prototype.createBrowser = function() {
   var self = this; 
 
   /**
+   * Get the processed configuration object that is currently being run.
+   *
+   * @return {q.Promise} A promise which resolves on finish.
+   */
+  browser_.getProcessedConfig = function() {
+    var deferred = q.defer();
+    deferred.resolve(config);
+    return deferred.promise;
+  };
+
+  /**
    * Fork another instance of protractor for use in interactive tests.
    *
    * @param {boolean} opt_useSameUrl Whether to navigate to current url on creation

--- a/spec/basic/processedconfig_spec.js
+++ b/spec/basic/processedconfig_spec.js
@@ -1,0 +1,11 @@
+var util = require('util');
+
+describe('configuration elements', function() {
+  it('should have access to the processed config block', function() {
+    browser.getProcessedConfig().then(function(config) {
+      expect(config.capabilities.browserName).toEqual('chrome');
+      expect(config.capabilities.version).toEqual('ANY');
+      expect(config.params.login.name).toEqual('Jane');
+    });
+  });
+});


### PR DESCRIPTION
This is a continuation of PR #1708 with a few changes:

1. Un-bork my fork (that OUGHT to be a song).
2. Use the maintainers' recommended pattern for the call.
3. On instinct I went with a promise return to be consistent getCapabilities() - let me know if that should change (a promise is not actually required here).
4. Added a comment block to referenceConfig.js to illustrate its use.
