### PR TITLE
feat(protractor): Change the default root element selector

### DIFF
--- a/docs/referenceConf.js
+++ b/docs/referenceConf.js
@@ -160,8 +160,8 @@ exports.config = {
   baseUrl: 'http://localhost:9876',
 
   // CSS Selector for the element housing the angular app - this defaults to
-  // body, but is necessary if ng-app is on a descendant of <body>.
-  rootElement: 'body',
+  // an attribute selector of [ng-app].
+  rootElement: '[ng-app]',
 
   // The timeout in milliseconds for each script run on the browser. This should
   // be longer than the maximum time your application needs to stabilize between

--- a/lib/protractor.js
+++ b/lib/protractor.js
@@ -144,12 +144,11 @@ var Protractor = function(webdriverInstance, opt_baseUrl, opt_rootElement) {
 
   /**
    * The css selector for an element on which to find Angular. This is usually
-   * 'body' but if your ng-app is on a subsection of the page it may be
-   * a subelement.
+   * an element with a ng-app attribute.
    *
    * @type {string}
    */
-  this.rootEl = opt_rootElement || 'body';
+  this.rootEl = opt_rootElement || '[ng-app]';
 
   /**
    * If true, Protractor will not attempt to synchronize with the page before


### PR DESCRIPTION
Changes the default angular app element CSS selector from <body> to [ng-app] which will look for an element with the ng-app attribute.