### PR TITLE
chore(docs): document $ and $$ better

### DIFF
--- a/lib/element.js
+++ b/lib/element.js
@@ -772,7 +772,8 @@ ElementFinder.prototype.then = function(fn, errorFn) {
 };
 
 /** 
- * Calls to element may be chained to find an array of elements within a parent.
+ * Calls to {@code all} may be chained to find an array of elements within a
+ * parent.
  *
  * @alias element(locator).all(locator)
  * @view
@@ -795,7 +796,7 @@ ElementFinder.prototype.all = function(subLocator) {
 };
 
 /**
- * Calls to element may be chained to find elements within a parent.
+ * Calls to {@code element} may be chained to find elements within a parent.
  *
  * @alias element(locator).element(locator)
  * @view
@@ -826,50 +827,55 @@ ElementFinder.prototype.element = function(subLocator) {
 };
 
 /**
- * Shortcut for querying the document directly with css.
+ * Calls to {@code $$} may be chained to find an array of elements within a
+ * parent.
  *
- * @alias $$(cssSelector)
+ * @alias element(locator).all(selector)
  * @view
- * <div class="count">
- *   <span class="one">First</span>
- *   <span class="two">Second</span>
+ * <div class="parent">
+ *   <ul>
+ *     <li class="one">First</li>
+ *     <li class="two">Second</li>
+ *     <li class="three">Third</li>
+ *   </ul>
  * </div>
  *
  * @example
- * // The following protractor expressions are equivalent.
- * var list = element.all(by.css('.count span'));
- * expect(list.count()).toBe(2);
- *
- * list = $$('.count span');
- * expect(list.count()).toBe(2);
- * expect(list.get(0).getText()).toBe('First');
- * expect(list.get(1).getText()).toBe('Second');
+ * var items = element(by.css('.parent')).$$('li')
  *
  * @param {string} selector a css selector
- * @return {ElementArrayFinder} which identifies the
- *     array of the located {@link webdriver.WebElement}s.
+ * @return {ElementArrayFinder}
  */
 ElementFinder.prototype.$$ = function(selector) {
   return this.all(webdriver.By.css(selector));
 };
 
 /**
- * Shortcut for querying the document directly with css.
+ * Calls to {@code $} may be chained to find elements within a parent.
  *
- * @alias $(cssSelector)
+ * @alias element(locator).$(selector)
  * @view
- * <div class="count">
- *   <span class="one">First</span>
- *   <span class="two">Second</span>
+ * <div class="parent">
+ *   <div class="child">
+ *     Child text
+ *     <div>{{person.phone}}</div>
+ *   </div>
  * </div>
  *
  * @example
- * var item = $('.count .two');
- * expect(item.getText()).toBe('Second');
+ * // Chain 2 element calls.
+ * var child = element(by.css('.parent')).
+ *     $('.child');
+ * expect(child.getText()).toBe('Child text\n555-123-4567');
+ *
+ * // Chain 3 element calls.
+ * var triple = element(by.css('.parent')).
+ *     $('.child').
+ *     element(by.binding('person.phone'));
+ * expect(triple.getText()).toBe('555-123-4567');
  *
  * @param {string} selector A css selector
- * @return {ElementFinder} which identifies the located
- *     {@link webdriver.WebElement}
+ * @return {ElementFinder}
  */
 ElementFinder.prototype.$ = function(selector) {
   return this.element(webdriver.By.css(selector));
@@ -943,3 +949,59 @@ ElementFinder.prototype.allowAnimations = function(value) {
 ElementFinder.prototype.isPending = function() {
   return false;
 };
+
+/**
+ * Shortcut for querying the document directly with css.
+ *
+ * @alias $(cssSelector)
+ * @view
+ * <div class="count">
+ *   <span class="one">First</span>
+ *   <span class="two">Second</span>
+ * </div>
+ *
+ * @example
+ * var item = $('.count .two');
+ * expect(item.getText()).toBe('Second');
+ *
+ * @param {string} selector A css selector
+ * @return {ElementFinder} which identifies the located
+ *     {@link webdriver.WebElement}
+ */
+var build$ = function(element, by) {
+  return function(selector) {
+    return element(by.css(selector));
+  };
+};
+exports.build$ = build$;
+
+/**
+ * Shortcut for querying the document directly with css.
+ *
+ * @alias $$(cssSelector)
+ * @view
+ * <div class="count">
+ *   <span class="one">First</span>
+ *   <span class="two">Second</span>
+ * </div>
+ *
+ * @example
+ * // The following protractor expressions are equivalent.
+ * var list = element.all(by.css('.count span'));
+ * expect(list.count()).toBe(2);
+ *
+ * list = $$('.count span');
+ * expect(list.count()).toBe(2);
+ * expect(list.get(0).getText()).toBe('First');
+ * expect(list.get(1).getText()).toBe('Second');
+ *
+ * @param {string} selector a css selector
+ * @return {ElementArrayFinder} which identifies the
+ *     array of the located {@link webdriver.WebElement}s.
+ */
+var build$$ = function(element, by) {
+  return function(selector) {
+    return element.all(by.css(selector));
+  };
+};
+exports.build$$ = build$$;

--- a/lib/protractor.js
+++ b/lib/protractor.js
@@ -4,6 +4,8 @@ var helper = require('./util');
 var log = require('./logger.js');
 var ElementArrayFinder = require('./element').ElementArrayFinder;
 var ElementFinder = require('./element').ElementFinder;
+var build$ = require('./element').build$;
+var build$$ = require('./element').build$$;
 
 var clientSideScripts = require('./clientsidescripts.js');
 var ProtractorBy = require('./locators.js').ProtractorBy;
@@ -127,18 +129,14 @@ var Protractor = function(webdriverInstance, opt_baseUrl, opt_rootElement) {
    *
    * @type {function(string): ElementFinder}
    */
-  this.$ = function(selector) {
-    return self.element(webdriver.By.css(selector));
-  };
+  this.$ = build$(this.element, webdriver.By);
 
   /**
    * Shorthand function for finding arrays of elements by css.
    *
    * @type {function(string): ElementArrayFinder}
    */
-  this.$$ = function(selector) {
-    return self.element.all(webdriver.By.css(selector));
-  };
+  this.$$ = build$$(this.element, webdriver.By);
 
   /**
    * All get methods will be resolved against this base URL. Relative URLs are =


### PR DESCRIPTION
Before, the documentation for the global instances of $ and $$ was where the
documentation for the chaining of $ and $$ should have been, and the
documentation for chaining was no where.  This fixes that.

Closes issue #1740.