### PR TITLE
feat(configParser): allow configParser to understand arrays

### DIFF
--- a/lib/configParser.js
+++ b/lib/configParser.js
@@ -48,6 +48,38 @@ var ConfigParser = function() {
 };
 
 /**
+ * Returns true if 'obj' is either 
+ * - an array, or
+ * - a dictionary with all its keys represented as positive integers.
+ */
+var isArrayLike_ = function(obj) {
+  if (obj instanceof Array) {
+    return true;
+  }
+  if (!(obj instanceof Object)) {
+    return false;
+  }
+
+  for (var key in obj) {
+    var n = parseInt(key);
+    if (String(n) !== key || n < 0) {
+      // is not positive integer
+      return false;
+    }
+  }
+  return true;
+};
+
+/**
+ * Returns true if 'obj' is a dictionary-like object.
+ */
+var isDictionary_ = function (obj) {
+  return (obj instanceof Object &&
+        !(obj instanceof Function) &&
+        !(isArrayLike_(obj)));
+};
+
+/**
  * Merge config objects together.
  *
  * @private
@@ -58,9 +90,8 @@ var ConfigParser = function() {
  */
 var merge_ = function(into, from) {
   for (var key in from) {
-    if (into[key] instanceof Object &&
-        !(into[key] instanceof Array) &&
-        !(into[key] instanceof Function)) {
+    if ((isArrayLike_(into[key]) && isArrayLike_(from[key])) || 
+        (isDictionary_(into[key]) && isDictionary_(from[key]))) {
       merge_(into[key], from[key]);
     } else {
       into[key] = from[key];

--- a/spec/unit/config_test.js
+++ b/spec/unit/config_test.js
@@ -63,4 +63,63 @@ describe('the config parser', function() {
       expect(specs[1].indexOf(path.normalize('unit/data/fakespecB.js'))).not.toEqual(-1);
     });
   });
+
+  describe('merging configs', function() {
+    it('should merge two entries', function() {
+      var config = new ConfigParser()
+          .addConfig({key: {a1: 1.1, a2: 1.2}})
+          .addConfig({key2: {b1: 2.1, b2: 2.2}})
+          .getConfig();
+      expect(config.key).toEqual({a1: 1.1, a2: 1.2});
+      expect(config.key2).toEqual({b1: 2.1, b2: 2.2});
+    });
+
+    it('should overwrite overlapping objects', function() {
+      var config = new ConfigParser()
+          .addConfig({key: {a1: 1.1, a2: 1.2}})
+          .addConfig({key: 1})
+          .getConfig();
+      expect(config.key).toEqual(1);
+    });
+
+    it('should overwrite overlapping entries within an object', function() {
+      var config = new ConfigParser()
+          .addConfig({key: {a1: 1.1, a2: 1.2}})
+          .addConfig({key: {a1: 1}})
+          .getConfig();
+      expect(config.key).toEqual({a1: 1, a2: 1.2});
+    });
+
+    it('should insert entries', function() {
+      var config = new ConfigParser()
+          .addConfig({key: {a1: 1.1, a2: 1.2}})
+          .addConfig({key: {c1: 3.1}})
+          .getConfig();
+      expect(config.key).toEqual({a1: 1.1, a2: 1.2, c1: 3.1});
+    });
+
+    it('should insert using array-like objects', function() {
+      var config = new ConfigParser()
+          .addConfig({key: []})
+          .addConfig({key: {0: 'a', 1: 'b'}}) // ['a', 'b']
+          .getConfig();
+      expect(config.key).toEqual(['a', 'b']);
+    });
+
+    it('should replace using array-like objects', function() {
+      var config = new ConfigParser()
+          .addConfig({key: ['a', 'b']})
+          .addConfig({key: {0: 'c', 2: 'd'}}) // ['c', undefined, 'd']
+          .getConfig();
+      expect(config.key).toEqual(['c', 'b', 'd']);
+    });
+
+    it('should selectively replace in a multi-layered object', function() {
+      var config = new ConfigParser()
+          .addConfig({key: [{'a': {'b': 1, 'c': 2}}]})
+          .addConfig({key: {0: {'a': {'c': 3}}}}) // [{'a': {'c': 3}}]
+          .getConfig();
+      expect(config.key).toEqual([{'a': {'b': 1, 'c': 3}}]);
+    });
+  });
 });


### PR DESCRIPTION
e.g. allow user to pass `multiCapabilities` via cli

See http://stackoverflow.com/questions/28239378/is-there-any-way-to-pass-multiple-browser-via-protractor-cli for context