### PR TITLE
chore(docs): fixe typo + adds more on custom frameworks

### DIFF
--- a/docs/frameworks.md
+++ b/docs/frameworks.md
@@ -43,7 +43,7 @@ expect(myElement.getText()).to.eventually.equal('some text');
 
 Finally, set the 'framework' property to 'mocha', either by adding `framework: 'mocha'` to the config file or by adding `--framework=mocha` to the command line.
 
-Options for Mocha such as 'reporter' and 'slow' can be given in the [config file](https://github.com/angular/protractor/blob/master/spec/mochaConf.js) with mochaOpts:
+Options for Mocha such as 'reporter' and 'slow' can be given in the [config file](../spec/mochaConf.js) with mochaOpts:
 
 ```js
 mochaOpts: {
@@ -52,7 +52,7 @@ mochaOpts: {
 }
 ```
 
-For a full example, see Protractor’s own test: [/spec/mocha](https://github.com/angular/protractor/tree/master/spec/mocha).
+For a full example, see Protractor’s own test: [/spec/mocha](../spec/mocha).
 
 
 Using Cucumber
@@ -67,7 +67,7 @@ If you would  like to use the Cucumber test framework, download the dependencies
 npm install -g cucumber
 ```
 
-Set the 'framework' property to cucumber, either by adding `framework: 'cucumber'` to the [config file](https://github.com/angular/protractor/blob/master/spec/cucumberConf.js) or by adding `--framework=cucumber` to the command line.
+Set the 'framework' property to cucumber, either by adding `framework: 'cucumber'` to the [config file](../spec/cucumberConf.js) or by adding `--framework=cucumber` to the command line.
 
 Options for Cucumber such as 'format' can be given in the config file with cucumberOpts:
 
@@ -77,6 +77,12 @@ cucumberOpts: {
 }
 ```
 
-For a full example, see Protractor’s own test: [/spec/cucumber](https://github.com/angular/protractor/tree/master/spec/cucumber).
+For a full example, see Protractor’s own test: [/spec/cucumber](../spec/cucumber).
+
+
+Using a Custom Framework
+------------------------
+
+Check section [Framework Adapters for Protractor](../lib/frameworks/README.md) specifically [Custom Frameworks](../lib/frameworks/README.md#custom-frameworks)
 
 

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -74,5 +74,5 @@ exports.teardown = function(config) {};
 exports.postResults = function(config) {};
 ```
 
-The protractor results object follows the the format specified in
+The protractor results object follows the format specified in
 the [Framework documentation](../lib/frameworks/README.md).


### PR DESCRIPTION
* `the the` typo in plugins/README.md
* replace absolute markdown links with relatives in docs/frameworks.md
* adds section `Using a Custom Framework` in docs/frameworks.md
