### PR TITLE
chore(jasmine2): upgrade jasmine to 2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "minijasminenode": "1.1.1",
     "jasminewd": "1.1.0",
     "jasminewd2": "0.0.2",
-    "jasmine": "2.1.1",
+    "jasmine": "2.2.1",
     "saucelabs": "~0.1.0",
     "glob": "~3.2",
     "adm-zip": "0.4.4",


### PR DESCRIPTION
This will enable spec-based timeout (i.e. it('description', test_func, timeout))
and proper stack trace propagation