### PR TITLE
fix(tests): fix #1810 environment link in ngHint tests

### DIFF
--- a/plugins/ngHint/spec/failureConfig.js
+++ b/plugins/ngHint/spec/failureConfig.js
@@ -1,4 +1,4 @@
-var env = require('./environment.js');
+var env = require('../../../spec/environment.js');
 
 exports.config = {
   seleniumAddress: env.seleniumAddress,

--- a/plugins/ngHint/spec/successConfig.js
+++ b/plugins/ngHint/spec/successConfig.js
@@ -1,4 +1,4 @@
-var env = require('./environment.js');
+var env = require('../../../spec/environment.js');
 
 exports.config = {
   seleniumAddress: env.seleniumAddress,


### PR DESCRIPTION
There is no "./environment.js" in the ngHint plugin test directory, point
at the existing environment.js in top-level test dir.