### PR TITLE
feat(webdriver-manager): Custom binaries

### DIFF
--- a/bin/webdriver-manager
+++ b/bin/webdriver-manager
@@ -91,14 +91,13 @@ var cli = optimist.
     describe('seleniumPort', 'Optional port for the selenium standalone server').
     describe('ignore_ssl', 'Ignore SSL certificates').boolean('ignore_ssl').
     default('ignore_ssl', false).
-    describe('proxy', 'Proxy to use for the install or update command');
+    describe('proxy', 'Proxy to use for the install or update command').
+    describe('alternate_cdn', 'Alternate CDN to the binaries');
 
 for (bin in binaries) {
   cli.describe(bin, 'Install or update ' + binaries[bin].name).
   boolean(bin).
-  default(bin, binaries[bin].isDefault).
-  describe(bin + '_cdn', 'Alternate CDN to the binaries of ' + binaries[bin].name).
-  default(bin + '_cdn', binaries[bin].cdn);
+  default(bin, binaries[bin].isDefault);
 }
 
 var argv = cli.
@@ -226,7 +225,7 @@ var existingFiles = fs.readdirSync(argv.out_dir);
 
 for (name in binaries) {
   bin = binaries[name];
-  bin.cdn = bin.argv[bin + '_cdn'];
+  bin.cdn = argv.alternate_cdn || bin.cdn;
   var exists = fs.existsSync(path.join(argv.out_dir, bin.filename));
   var outOfDateExists = false;
   existingFiles.forEach(function(file) {

--- a/bin/webdriver-manager
+++ b/bin/webdriver-manager
@@ -31,8 +31,9 @@ var binaries = {
     isDefault: true,
     prefix: 'selenium-server-standalone',
     filename: 'selenium-server-standalone-' + versions.selenium + '.jar',
+    cdn: 'https://selenium-release.storage.googleapis.com/',
     url: function() {
-      return 'https://selenium-release.storage.googleapis.com/' +
+      return this.cdn +
           shortVersion(versions.selenium) + '/' +
           'selenium-server-standalone-' + versions.selenium + '.jar';
     }
@@ -42,8 +43,9 @@ var binaries = {
     isDefault: true,
     prefix: 'chromedriver_',
     filename: 'chromedriver_' + versions.chromedriver + '.zip',
+    cdn: 'https://chromedriver.storage.googleapis.com/',
     url: function() {
-      var urlPrefix = 'https://chromedriver.storage.googleapis.com/' +
+      var urlPrefix = this.cdn +
           versions.chromedriver + '/chromedriver_';
       if (os.type() == 'Darwin') {
         return urlPrefix + 'mac32.zip';
@@ -63,8 +65,9 @@ var binaries = {
     isDefault: false,
     prefix: 'IEDriverServer',
     filename: 'IEDriverServer_' + versions.iedriver + '.zip',
+    cdn: 'https://selenium-release.storage.googleapis.com/',
     url: function() {
-      var urlPrefix = 'https://selenium-release.storage.googleapis.com/' +
+      var urlPrefix = this.cdn +
           shortVersion(versions.iedriver) + '/IEDriverServer';
       if (os.type() == 'Windows_NT') {
         if (os.arch() == 'x64') {
@@ -93,7 +96,9 @@ var cli = optimist.
 for (bin in binaries) {
   cli.describe(bin, 'Install or update ' + binaries[bin].name).
   boolean(bin).
-  default(bin, binaries[bin].isDefault);
+  default(bin, binaries[bin].isDefault).
+  describe(bin + '_cdn', 'Alternate CDN to the binaries of ' + binaries[bin].name).
+  default(bin + '_cdn', binaries[bin].cdn);
 }
 
 var argv = cli.
@@ -221,6 +226,7 @@ var existingFiles = fs.readdirSync(argv.out_dir);
 
 for (name in binaries) {
   bin = binaries[name];
+  bin.cdn = bin.argv[bin + '_cdn'];
   var exists = fs.existsSync(path.join(argv.out_dir, bin.filename));
   var outOfDateExists = false;
   existingFiles.forEach(function(file) {


### PR DESCRIPTION
This closes #1839.

Added the ability to specify an alternate cdn to the required binaries (IEDriver, chromedriver, selenium-server-standalone).

The output of the webdriver-manager:
```
Usage: webdriver-manager <command>
Commands:
  update: install or update selected binaries
  start: start up the selenium server
  status: list the current available drivers

Options:
  --out_dir         Location to output/expect                             [default: "C:\\Projects\\protractor\\selenium"]
  --seleniumPort    Optional port for the selenium standalone server
  --ignore_ssl      Ignore SSL certificates                               [default: false]
  --proxy           Proxy to use for the install or update command
  --standalone      Install or update selenium standalone                 [default: true]
  --standalone_cdn  Alternate CDN to the binaries of selenium standalone  [default: "https://selenium-release.storage.googleapis.com/"]
  --chrome          Install or update chromedriver                        [default: true]
  --chrome_cdn      Alternate CDN to the binaries of chromedriver         [default: "https://chromedriver.storage.googleapis.com/"]
  --ie              Install or update IEDriver                            [default: false]
  --ie_cdn          Alternate CDN to the binaries of IEDriver             [default: "https://selenium-release.storage.googleapis.com/"]

Please specify one command
```