### PR TITLE
tests(node version): test on Node 0.12 & io.js instead of unstable Node 0.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
   - "0.10"
-  - "0.11"
+  - "0.12"
+  - "iojs"
 
 env:
   global:

--- a/spec/smokeConf.js
+++ b/spec/smokeConf.js
@@ -21,7 +21,7 @@ exports.config = {
     'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
     'build': process.env.TRAVIS_BUILD_NUMBER,
     'name': 'Protractor smoke tests',
-    'version': '38',
+    'version': '40',
     'selenium-version': '2.43.1',
     'chromedriver-version': '2.14',
     'platform': 'OS X 10.9'
@@ -30,7 +30,7 @@ exports.config = {
     'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
     'build': process.env.TRAVIS_BUILD_NUMBER,
     'name': 'Protractor smoke tests',
-    'version': '33',
+    'version': '34',
     'selenium-version': '2.43.1'
   }, {
     'browserName': 'safari',


### PR DESCRIPTION
I've also updated Chrome & Firefox in the first commit (I can split them into two PRs if you want). Chrome 38 doesn't work with latest chromedriver which caused smoke tests
to fail.