### PR TITLE
tests(browsers): bump Chrome from 38 to 39

### DIFF
--- a/spec/smokeConf.js
+++ b/spec/smokeConf.js
@@ -21,7 +21,7 @@ exports.config = {
     'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
     'build': process.env.TRAVIS_BUILD_NUMBER,
     'name': 'Protractor smoke tests',
-    'version': '38',
+    'version': '39',
     'selenium-version': '2.43.1',
     'chromedriver-version': '2.14',
     'platform': 'OS X 10.9'


### PR DESCRIPTION
Chrome 38 doesn't work with latest chromedriver which caused smoke tests
to fail