### PR TITLE
chore(travis): leverage Travis container infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: node_js
+
+sudo: false
+
 node_js:
   - "0.10"
   - "0.12"


### PR DESCRIPTION
Adding `sudo: false` to the Travis config makes it run on a container
infrastructure which starts up faster than default. See:
http://docs.travis-ci.com/user/workers/container-based-infrastructure/