### PR TITLE
fix(webdriver): bump selenium to 2.45.0

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
   "webdriverVersions": {
-    "selenium": "2.44.0",
+    "selenium": "2.45.0",
     "chromedriver": "2.14",
-    "iedriver": "2.44.0"
+    "iedriver": "2.45.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "Julie Ralph <ju.ralph@gmail.com>",
   "dependencies": {
     "request": "~2.36.0",
-    "selenium-webdriver": "2.44.0",
+    "selenium-webdriver": "2.45.0",
     "minijasminenode": "1.1.1",
     "jasminewd": "1.1.0",
     "jasminewd2": "0.0.2",

--- a/spec/ciConf.js
+++ b/spec/ciConf.js
@@ -22,7 +22,7 @@ exports.config = {
     'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
     'build': process.env.TRAVIS_BUILD_NUMBER,
     'name': 'Protractor suite tests',
-    'version': '39',
+    'version': '40',
     'selenium-version': '2.44.0',
     'chromedriver-version': '2.14',
     'platform': 'OS X 10.9'

--- a/spec/smokeConf.js
+++ b/spec/smokeConf.js
@@ -21,8 +21,8 @@ exports.config = {
     'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
     'build': process.env.TRAVIS_BUILD_NUMBER,
     'name': 'Protractor smoke tests',
-    'version': '39',
-    'selenium-version': '2.43.1',
+    'version': '40',
+    'selenium-version': '2.44.0',
     'chromedriver-version': '2.14',
     'platform': 'OS X 10.9'
   }, {
@@ -31,21 +31,21 @@ exports.config = {
     'build': process.env.TRAVIS_BUILD_NUMBER,
     'name': 'Protractor smoke tests',
     'version': '33',
-    'selenium-version': '2.43.1'
+    'selenium-version': '2.44.0'
   }, {
     'browserName': 'safari',
     'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
     'build': process.env.TRAVIS_BUILD_NUMBER,
     'name': 'Protractor smoke tests',
     'version': '7',
-    'selenium-version': '2.43.1'
+    'selenium-version': '2.44.0'
   }, {
     'browserName': 'internet explorer',
     'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
     'build': process.env.TRAVIS_BUILD_NUMBER,
     'name': 'Protractor smoke tests',
     'version': '11',
-    'selenium-version': '2.43.1',
+    'selenium-version': '2.44.0',
     'platform': 'Windows 7'
   }, {
     'browserName': 'internet explorer',
@@ -53,7 +53,7 @@ exports.config = {
     'build': process.env.TRAVIS_BUILD_NUMBER,
     'name': 'Protractor smoke tests',
     'version': '10',
-    'selenium-version': '2.43.1',
+    'selenium-version': '2.44.0',
     'platform': 'Windows 7'
   }],
 


### PR DESCRIPTION
Bump selenium-webdriver module and the selenium standalone binary to
2.45.0. Also bump to testing against the two latest versions of
chrome and firefox.

Closes #1734