### PR TITLE
chore(ci): bump to test against chrome 40

### DIFF
--- a/spec/ciConf.js
+++ b/spec/ciConf.js
@@ -22,7 +22,7 @@ exports.config = {
     'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
     'build': process.env.TRAVIS_BUILD_NUMBER,
     'name': 'Protractor suite tests',
-    'version': '39',
+    'version': '40',
     'selenium-version': '2.44.0',
     'chromedriver-version': '2.14',
     'platform': 'OS X 10.9'

--- a/spec/smokeConf.js
+++ b/spec/smokeConf.js
@@ -22,7 +22,7 @@ exports.config = {
     'build': process.env.TRAVIS_BUILD_NUMBER,
     'name': 'Protractor smoke tests',
     'version': '39',
-    'selenium-version': '2.43.1',
+    'selenium-version': '2.44.0',
     'chromedriver-version': '2.14',
     'platform': 'OS X 10.9'
   }, {
@@ -31,21 +31,21 @@ exports.config = {
     'build': process.env.TRAVIS_BUILD_NUMBER,
     'name': 'Protractor smoke tests',
     'version': '33',
-    'selenium-version': '2.43.1'
+    'selenium-version': '2.44.0'
   }, {
     'browserName': 'safari',
     'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
     'build': process.env.TRAVIS_BUILD_NUMBER,
     'name': 'Protractor smoke tests',
     'version': '7',
-    'selenium-version': '2.43.1'
+    'selenium-version': '2.44.0'
   }, {
     'browserName': 'internet explorer',
     'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
     'build': process.env.TRAVIS_BUILD_NUMBER,
     'name': 'Protractor smoke tests',
     'version': '11',
-    'selenium-version': '2.43.1',
+    'selenium-version': '2.44.0',
     'platform': 'Windows 7'
   }, {
     'browserName': 'internet explorer',
@@ -53,7 +53,7 @@ exports.config = {
     'build': process.env.TRAVIS_BUILD_NUMBER,
     'name': 'Protractor smoke tests',
     'version': '10',
-    'selenium-version': '2.43.1',
+    'selenium-version': '2.44.0',
     'platform': 'Windows 7'
   }],
 


### PR DESCRIPTION
Also, update the version of selenium webdriver to 2.44 (the latest
that sauce labs provides) for the smoke tests.