### PR TITLE
Corrected sauce connect documentation.

### DIFF
--- a/docs/referenceConf.js
+++ b/docs/referenceConf.js
@@ -54,7 +54,7 @@ exports.config = {
   // Use sauceSeleniumAddress if you need to customize the URL Protractor
   // uses to connect to sauce labs (for example, if you are tunneling selenium
   // traffic through a sauce connect tunnel). Default is
-  // ondemand.saucelabs.com:80/wd/hub
+  // localhost:4445/wd/hub
   sauceSeleniumAddress: null,
 
   // ---- 4. To connect directly to Drivers ------------------------------------


### PR DESCRIPTION
Fixed the documenation for using sauce connect with protractor.  The documenation stated that the default sauceSeleniumAddress config variable for sacuce connect was
```
ondemand.saucelabs.com:80/wd/hub
```
This is entirely not correct.  The above is the default ondemand saucelabs address.  The correct sauce connect address is
```
localhost:4445/wd/hub
```