### PR TITLE
feat(element): Add getter and setter for value of input elements

### DIFF
--- a/lib/element.js
+++ b/lib/element.js
@@ -953,6 +953,49 @@ ElementFinder.prototype.isPending = function() {
 };
 
 /**
+ * Shortcut for getting the value of any element that you would normally
+ * use element.getAttribute('value') to get it's value
+ * (e.g. <input type="text|number|...">
+ *
+ * getValue() and setValue() provide API-symmetry when working with
+ * input elements.
+ *
+ * @alias element(locator).getValue() element(locator).getAttribute('value').
+ *
+ * @return {!webdriver.promise.Promise.<?string>} A promise that will be
+ *     resolved with the attribute's value. The returned value will always be
+ *     either a string or null.
+ */
+ElementFinder.prototype.getValue = function() {
+  return this.getAttribute('value');
+};
+
+/**
+ * Shortcut for setting the value of any element that you would normally
+ * use sendKeys() to set it's value (e.g. <input type="text|number|...">
+ *
+ * getValue() and setValue() provide API-symmetry when working with
+ * input elements.
+ *
+ * @alias element(locator).setValue('value') element(locator).clear().sendKeys('value');
+ *
+ * @param {...(string|!webdriver.promise.Promise<string>)} var_args The sequence
+ *     of keys to type. All arguments will be joined into a single sequence.
+ * @param {boolean} An optional flag (default = false) to tab-out of the input
+ *     element after sending keys.
+ * @return {!webdriver.promise.Promise.<void>} A promise that will be resolved
+ *     when all keys have been typed.
+ */
+ElementFinder.prototype.setValue = function(value, optTabNext) {
+  var element = this.clear().sendKeys(value);
+  if (optTabNext) {
+    element.sendKeys(webdriver.Key.TAB);
+  }
+  return element;
+};
+
+
+/**
  * Shortcut for querying the document directly with css.
  *
  * @alias $(cssSelector)

--- a/spec/basic/elements_spec.js
+++ b/spec/basic/elements_spec.js
@@ -28,6 +28,19 @@ describe('ElementFinder', function() {
     expect(name.getText()).toEqual('Jane');
   });
 
+  it('should wait to grab the WebElement until a method is called, using setValue()', function() {
+    // These should throw no error before a page is loaded.
+    var usernameInput = element(by.model('username'));
+    var name = element(by.binding('username'));
+
+    browser.get('index.html#/form');
+
+    expect(name.getText()).toEqual('Anon');
+
+    usernameInput.setValue('Jane');
+    expect(name.getText()).toEqual('Jane');
+  });
+
   it('should chain element actions', function() {
     browser.get('index.html#/form');
 
@@ -38,6 +51,41 @@ describe('ElementFinder', function() {
 
     usernameInput.clear().sendKeys('Jane');
     expect(name.getText()).toEqual('Jane');
+  });
+
+  it('should allow element.setValue() to clear-and-set the value of an input field, and optionally tab to the next element', function() {
+    browser.get('index.html#/form');
+
+    var usernameInput = element(by.model('username'));
+    var name = element(by.binding('username'));
+
+    expect(name.getText()).toEqual('Anon');
+
+    // Set value and tab to the next field
+    usernameInput.setValue('Jane', true);
+    expect(name.getText()).toEqual('Jane');
+    //browser.sleep(20000);
+    expect(browser.driver.switchTo().activeElement().getAttribute('ng-model')).not.toEqual('username');
+
+    // This time, set the value and don't tab to the next field
+    usernameInput.setValue('Brett');
+    expect(name.getText()).toEqual('Brett');
+    expect(browser.driver.switchTo().activeElement().getAttribute('ng-model')).toEqual('username');
+  });
+
+  it('should allow element.setValue() to clear-and-set the value of an input field, and optionally tab to the next element', function() {
+    browser.get('index.html#/form');
+
+    var aboutbox = element(by.model('aboutbox'));
+
+    aboutbox.setValue('Long comment');
+    expect(aboutbox.getValue()).toEqual('Long comment');
+    expect(browser.driver.switchTo().activeElement().getAttribute('ng-model')).toEqual('aboutbox');
+
+    // Now change the value and tab-out
+    aboutbox.setValue('An even longer comment', true);
+    expect(aboutbox.getValue()).toEqual('An even longer comment');
+    expect(browser.driver.switchTo().activeElement().getAttribute('ng-model')).not.toEqual('aboutbox');
   });
 
   it('chained call should wait to grab the WebElement until a method is called',
@@ -374,6 +422,16 @@ describe('ElementArrayFinder', function() {
     expect(colorList.get(2).getAttribute('value')).toEqual('red');
   });
 
+  it('should get an element from an array using getValue()', function() {
+    var colorList = element.all(by.model('color'));
+
+    browser.get('index.html#/form');
+
+    expect(colorList.get(0).getValue()).toEqual('blue');
+    expect(colorList.get(1).getValue()).toEqual('green');
+    expect(colorList.get(2).getValue()).toEqual('red');
+  });
+
   it('should get an element from an array using negative indices', function() {
     var colorList = element.all(by.model('color'));
 
@@ -384,11 +442,22 @@ describe('ElementArrayFinder', function() {
     expect(colorList.get(-1).getAttribute('value')).toEqual('red');
   });
 
+  it('should get an element from an array using negative indices using getValue()', function() {
+    var colorList = element.all(by.model('color'));
+
+    browser.get('index.html#/form');
+
+    expect(colorList.get(-3).getValue()).toEqual('blue');
+    expect(colorList.get(-2).getValue()).toEqual('green');
+    expect(colorList.get(-1).getValue()).toEqual('red');
+  });
+
   it('should get the first element from an array', function() {
     var colorList = element.all(by.model('color'));
     browser.get('index.html#/form');
 
     expect(colorList.first().getAttribute('value')).toEqual('blue');
+    expect(colorList.first().getValue()).toEqual('blue');
   });
 
   it('should get the last element from an array', function() {
@@ -396,6 +465,7 @@ describe('ElementArrayFinder', function() {
     browser.get('index.html#/form');
 
     expect(colorList.last().getAttribute('value')).toEqual('red');
+    expect(colorList.last().getValue()).toEqual('red');
   });
 
   it('should perform an action on each element in an array', function() {


### PR DESCRIPTION
This PR tries to solve the inconsistency (referred to in the [FAQ](https://github.com/angular/protractor/blob/master/docs/faq.md#the-result-of-gettext-from-an-input-element-is-always-empty)) when querying and setting the value of input elements, by adding `getValue()` and `setValue()` methods to the `element` object. This makes working with text-based form fields much easier. 

Examples:
```js
var aboutbox = element(by.model('aboutbox'));

// Existing approach
aboutbox.clear().sendKeys('Long comment');
// This doesn't return the value: aboutbox.getText() , so use this instead:
expect(aboutbox.getAttribute('value')).toEqual('Long comment');

// NEW approach
aboutbox.setValue('Long comment');
expect(aboutbox.getValue()).toEqual('Long comment');

// Additionally, setValue() supports an optional boolean parameter, indicating
// whether to send a TAB-key to the control, causing the control to loose focus.
// This behaviour is really helpful when trying to test field validations that are
// triggered by change or blur events.

aboutbox.setValue('Long comment', false);  // default = no tab key sent
expect(aboutbox.getValue()).toEqual('Long comment');
expect(browser.driver.switchTo().activeElement().getAttribute('ng-model')).toEqual('aboutbox');

// Now send a TAB keypress after clearing & setting the value
aboutbox.setValue('Long comment', true);  // true = send tab key
expect(aboutbox.getValue()).toEqual('Long comment');
expect(browser.driver.switchTo().activeElement().getAttribute('ng-model')).not.toEqual('aboutbox');
```