### PR TITLE
Fix repeater inline documentation.

### DIFF
--- a/lib/locators.js
+++ b/lib/locators.js
@@ -320,11 +320,11 @@ function byRepeaterInner(exact) {
  *
  * // Returns the SPAN for the first cat's name.
  * var firstCatName = element(by.repeater('cat in pets').
- *     row(0).column('{{cat.name}}'));
+ *     row(0).column('cat.name'));
  *
  * // Returns a promise that resolves to an array of WebElements from a column
  * var ages = element.all(
- *     by.repeater('cat in pets').column('{{cat.age}}'));
+ *     by.repeater('cat in pets').column('cat.age'));
  *
  * // Returns a promise that resolves to an array of WebElements containing
  * // all top level elements repeated by the repeater. For 2 pets rows resolves
@@ -341,7 +341,7 @@ function byRepeaterInner(exact) {
  *
  * // Returns the H4 for the first book's name.
  * var firstBookName = element(by.repeater('book in library').
- *     row(0).column('{{book.name}}'));
+ *     row(0).column('book.name'));
  *
  * // Returns a promise that resolves to an array of WebElements containing
  * // all top level elements repeated by the repeater. For 2 books divs


### PR DESCRIPTION
Hi, I noticed that the documentation for the column method of by.repeater doesn't match up to it's usage. 

Hope this is now correct, it seems to match the specs.