### PR TITLE
chore(ci): move node 0.12 tests out of allowed failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
   allow_failures:
     - env: "JOB=smoke"
   exclude:
-    - env: JOB=suite
+    - env: JOB=smoke
       node_js: "0.12"
 
 


### PR DESCRIPTION
Test the full suite against node 0.12, and make this not an
allowed failure, now that node 0.12 is roughly stable.