### PR TITLE
fix(browser): remove subsequent duplicate module

### DIFF
--- a/lib/protractor.js
+++ b/lib/protractor.js
@@ -386,7 +386,7 @@ Protractor.prototype.clearMockModules = function() {
 Protractor.prototype.removeMockModule = function(name) {
   for (var i = 0; i < this.mockModules_.length; ++i) {
     if (this.mockModules_[i].name == name) {
-      this.mockModules_.splice(i, 1);
+      this.mockModules_.splice(i--, 1);
     }
   }
 };

--- a/spec/basic/mockmodule_spec.js
+++ b/spec/basic/mockmodule_spec.js
@@ -68,6 +68,16 @@ describe('mock modules', function() {
     expect(element(by.css('[app-version]')).getText()).toEqual('2');
   });
 
+  it('should remove duplicate mock modules', function () {
+    browser.addMockModule('moduleA', mockModuleA);
+    browser.addMockModule('moduleA', mockModuleA);
+    browser.removeMockModule('moduleA');
+
+    browser.get('index.html');
+
+    expect(element(by.css('[app-version]')).getText()).toEqual('0.1');
+  });
+
   it('should be a noop to remove a module which does not exist', function() {
     browser.addMockModule('moduleA', mockModuleA);
     browser.removeMockModule('moduleB');


### PR DESCRIPTION
browser.removeMockModule() misses next duplicate module because of iteration over an array it's modifying.