### PR TITLE
test(config): use env.webServerDefaultPort and env.interactiveTestPort

### DIFF
--- a/scripts/interactive_tests/interactive_test.js
+++ b/scripts/interactive_tests/interactive_test.js
@@ -1,5 +1,6 @@
+var env = require('../../spec/environment.js');
 var InteractiveTest = require('./interactive_test_util').InteractiveTest;
-var port = 6969;
+var port = env.interactiveTestPort;
 var test = new InteractiveTest('node lib/cli.js --elementExplorer true', port);
 
 // Check state persists.
@@ -12,9 +13,9 @@ test.addCommandExpectation('y', 'function (param) {return param;}');
 
 // Check promises complete.
 test.addCommandExpectation('browser.driver.getCurrentUrl()', 'data:,');
-test.addCommandExpectation('browser.get("http://localhost:8081")');
+test.addCommandExpectation('browser.get("http://localhost:' + env.webServerDefaultPort + '")');
 test.addCommandExpectation('browser.getCurrentUrl()', 
-    'http://localhost:8081/#/form'); 
+    'http://localhost:' + env.webServerDefaultPort + '/#/form'); 
 
 // Check promises are resolved before being returned.
 test.addCommandExpectation('var greetings = element(by.binding("greeting"))');

--- a/scripts/interactive_tests/with_base_url.js
+++ b/scripts/interactive_tests/with_base_url.js
@@ -1,9 +1,12 @@
+var env = require('../../spec/environment.js');
 var InteractiveTest = require('./interactive_test_util').InteractiveTest;
-var port = 6969;
+var port = env.interactiveTestPort;
 var test = new InteractiveTest(
-    'node lib/cli.js --baseUrl http://localhost:8081 --elementExplorer true', 
-    port);
+    'node lib/cli.js --baseUrl http://localhost:' + env.webServerDefaultPort + 
+    ' --elementExplorer true', port);
 
 // Check we automatically go to to baseUrl.
-test.addCommandExpectation('browser.driver.getCurrentUrl()', 'http://localhost:8081/#/form');
+test.addCommandExpectation(
+    'browser.driver.getCurrentUrl()', 
+    'http://localhost:' + env.webServerDefaultPort + '/#/form');
 test.run();

--- a/spec/environment.js
+++ b/spec/environment.js
@@ -17,6 +17,9 @@ module.exports = {
   // Default http port to host the web server
   webServerDefaultPort: webServerDefaultPort,
 
+  // Protractor interactive tests
+  interactiveTestPort: 6969,
+
   // A base URL for your application under test.
   baseUrl:
     'http://' + (process.env.HTTP_HOST || 'localhost') +


### PR DESCRIPTION
* Keep using `env.webServerDefaultPort` instead of hardcoded port **8081**
* Extract port **6969** into `env.interactiveTestPort`
