### PR TITLE
fix(navigation): fix timeout using browser.get with safari driver

### DIFF
--- a/lib/protractor.js
+++ b/lib/protractor.js
@@ -15,7 +15,6 @@ var ExpectedConditions = require('./expectedConditions.js');
 /* global angular */
 
 var DEFER_LABEL = 'NG_DEFER_BOOTSTRAP!';
-var DEFAULT_RESET_URL = 'data:text/html,<html></html>';
 var DEFAULT_GET_PAGE_TIMEOUT = 10000;
 
 /*
@@ -180,22 +179,6 @@ var Protractor = function(webdriverInstance, opt_baseUrl, opt_rootElement) {
    * @type {Object}
    */
   this.params = {};
-
-  /**
-   * The reset URL to use between page loads.
-   *
-   * @type {string}
-   */
-  this.resetUrl = DEFAULT_RESET_URL;
-  this.driver.getCapabilities().then(function(caps) {
-    // Internet Explorer does not accept data URLs, which are the default
-    // reset URL for Protractor.
-    // Safari accepts data urls, but SafariDriver fails after one is used.
-    var browserName = caps.get('browserName');
-    if (browserName === 'internet explorer' || browserName === 'safari') {
-      self.resetUrl = 'about:blank';
-    }
-  });
 
   /**
    * Information about mock modules that will be installed during every
@@ -436,6 +419,7 @@ Protractor.prototype.addBaseMockModules_ = function() {
  */
 Protractor.prototype.get = function(destination, opt_timeout) {
   var timeout = opt_timeout ? opt_timeout : this.getPageTimeout;
+  var activeElement = this.driver.switchTo().activeElement();
   var self = this;
 
   destination = this.baseUrl.indexOf('file://') === 0 ?
@@ -448,7 +432,6 @@ Protractor.prototype.get = function(destination, opt_timeout) {
     return this.driver.get(destination);
   }
 
-  this.driver.get(this.resetUrl);
   this.executeScript_(
       'window.name = "' + DEFER_LABEL + '" + window.name;' +
       'window.location.replace("' + destination + '");',
@@ -457,21 +440,20 @@ Protractor.prototype.get = function(destination, opt_timeout) {
   // We need to make sure the new url has loaded before
   // we try to execute any asynchronous scripts.
   this.driver.wait(function() {
-    return self.executeScript_('return window.location.href;', msg('get url')).
-        then(function(url) {
-          return url !== self.resetUrl;
-        }, function(err) {
-          if (err.code == 13) {
-            // Ignore the error, and continue trying. This is because IE
-            // driver sometimes (~1%) will throw an unknown error from this
-            // execution. See https://github.com/angular/protractor/issues/841
-            // This shouldn't mask errors because it will fail with the timeout
-            // anyway.
-            return false;
-          } else {
-            throw err;
-          }
-        });
+    // The "activeElement" variable has a reference to an element from the old
+    // page. Once the new page is loaded, this reference will become stale and
+    // webdriver will throw "StaleElementReferenceError" when trying to
+    // interact with it. For instance, we will try to interact by calling
+    // "isEnabled".
+    return activeElement.isEnabled().then(function() {
+      return false;
+    }, function(err) {
+      if (err.name === 'StaleElementReferenceError') {
+        return true;
+      } else {
+        throw err;
+      }
+    });
   }, timeout,
   'waiting for page to load for ' + timeout + 'ms');
 


### PR DESCRIPTION
```Protractor.get``` was not working on latest Safari (8.04) on latest OS X (10.10.2). Not sure if this is related but I had to manually install SafariDriver 2.45 downloaded at http://selenium-release.storage.googleapis.com/2.45/SafariDriver.safariextz

I figured the problem was safari could not execute script ```window.location.replace(...)``` after calling ```driver.get('about:blank')```. It used to work in the past and I think it might be an issue with the latest SafariDriver.

In order to get this working I've refactored ```Protractor.get```. I've removed the initial ```driver.get``` call to **resetUrl** (*about:blank* or *data:text/html,\<html\>\</html\>*). I believe the **resetUrl** was being called only to help detecting the "page load event" by the checking the moment when ```window.location.href``` becomes different from **resetUrl**. In order to detect this moment I now keep a reference to an old element on the page and try to interact with it until *webdriver* throws a *StaleElementReferenceError*, which means the element no longer exists and the new page is loaded. I've read about this new page load approach on http://www.obeythetestinggoat.com/how-to-get-selenium-to-wait-for-page-load-after-a-click.html

It's working on Safari, Chrome and Firefox. No idea about IE.