### PR TITLE
refactor(element): make each just forward to map

### DIFF
--- a/lib/element.js
+++ b/lib/element.js
@@ -484,11 +484,9 @@ ElementArrayFinder.prototype.then = function(fn, errorFn) {
  *
  * @param {function(ElementFinder)} fn Input function
  */
-ElementArrayFinder.prototype.each = function(fn) {
-  return this.asElementFinders_().then(function(arr) {
-    arr.forEach(function(elementFinder, index) {
-      fn(elementFinder, index);
-    });
+ElementArrayFinder.prototype.each = function(fn, index) {
+  return this.map(fn).then(function() {
+    return null;
   });
 };
 


### PR DESCRIPTION
ElementArrayFinder.each is just a call to ElementArrayFinder.map
without gathering the return values - reduce logic by making it so.

See https://github.com/angular/protractor/issues/2026