### PR TITLE
feat(sauce-lab): Pass custom agent to SauceLabs from protractor config

### DIFF
--- a/docs/referenceConf.js
+++ b/docs/referenceConf.js
@@ -51,6 +51,9 @@ exports.config = {
   // The tests will be run remotely using Sauce Labs.
   sauceUser: null,
   sauceKey: null,
+  // Use sauceAgent if you need customize agent for https connection to
+  // saucelabs.com (i.e. your computer behind corporate proxy)
+  sauceAgent: null,
   // Use sauceSeleniumAddress if you need to customize the URL Protractor
   // uses to connect to sauce labs (for example, if you are tunneling selenium
   // traffic through a sauce connect tunnel). Default is

--- a/lib/driverProviders/sauce.js
+++ b/lib/driverProviders/sauce.js
@@ -56,7 +56,8 @@ SauceDriverProvider.prototype.setupEnv = function() {
   var deferred = q.defer();
   this.sauceServer_ = new SauceLabs({
     username: this.config_.sauceUser,
-    password: this.config_.sauceKey
+    password: this.config_.sauceKey,
+    agent: this.config_.sauceAgent
   });
   this.config_.capabilities.username = this.config_.sauceUser;
   this.config_.capabilities.accessKey = this.config_.sauceKey;


### PR DESCRIPTION
Hello,

This PR for the saucelabs driver running behind proxy.

#124 does not work for this, because SauceLab.js issues `https.request()`, which does not use environment proxy variables and issues a call ti saucelab.com directly, leading to `Sauce pass/fail status: 'Could not send request: connect ETIMEDOUT'` error.


With this PR now in protractor configuration file I can specify

```js
var HttpsProxyAgent = require("https-proxy-agent");
 
var agent = new HttpsProxyAgent('http://<user>:<password>@<proxy host>:<port>');
 
exports.config = {
    agent: agent,
    // other things
};
```

And last request to saucelabs.com will not cause tests to fail.

based on guide by [Amber Kaplan](http://sauceio.com/index.php/2015/03/repost-angular-protractor-sauce-connect-launched-from-gulp-all-behind-a-corporate-firewall/)