### PR TITLE
fix(debugger): fix 'getControlFlowText()' which broken for webdriver 2.45

### DIFF
--- a/lib/debugger/modes/debuggerRepl.js
+++ b/lib/debugger/modes/debuggerRepl.js
@@ -100,7 +100,7 @@ DebuggerRepl.prototype.printControlFlow_ = function(callback) {
       command: 'evaluate',
       arguments: {
         frame: 0,
-        maxStringLength: 2000,
+        maxStringLength: 4000,
         expression: 'protractor.promise.controlFlow().getControlFlowText()'
       }
     }, function(err, controlFlowResponse) {

--- a/lib/protractor.js
+++ b/lib/protractor.js
@@ -625,40 +625,16 @@ Protractor.prototype.initDebugger_ = function(debuggerClientPath, opt_debugPort)
   // Patch in a function to help us visualize what's going on in the control
   // flow.
   webdriver.promise.ControlFlow.prototype.getControlFlowText = function() {
-    var descriptions = [];
-
-    var getDescriptions = function(frameOrTask, descriptions) {
-      if (frameOrTask.getDescription) {
-        var stacktrace = frameOrTask.snapshot_.getStacktrace();
-        stacktrace = stacktrace ? stacktrace.join('\n').trim() : '';
-        descriptions.push({
-          description: frameOrTask.getDescription(),
-          stack: helper.filterStackTrace(stacktrace)
-        });
-      } else {
-        for (var i = 0; i < frameOrTask.children_.length; ++i) {
-          getDescriptions(frameOrTask.children_[i], descriptions);
-        }
-      }
-    };
-    if (this.history_.length) {
-      getDescriptions(this.history_[this.history_.length - 1], descriptions);
-    }
-    if (this.activeFrame_.getPendingTask()) {
-      getDescriptions(this.activeFrame_.getPendingTask(), descriptions);
-    }
-    getDescriptions(this.activeFrame_.getRoot(), descriptions);
-    var asString = '-- WebDriver control flow schedule \n';
-    for (var i = 0; i < descriptions.length; ++i) {
-      asString += ' |- ' + descriptions[i].description;
-      if (descriptions[i].stack) {
-        asString += '\n |---' + descriptions[i].stack.replace(/\n/g, '\n |---');
-      }
-      if (i != (descriptions.length - 1)) {
-        asString += '\n';
-      }
-    }
-    return asString;
+    var controlFlowText = this.getSchedule(/* opt_includeStackTraces */ true);
+    // This filters the entire control flow text, not just the stack trace, so
+    // unless we maintain a good (i.e. non-generic) set of keywords in 
+    // STACK_SUBSTRINGS_TO_FILTER, we run the risk of filtering out non stack 
+    // trace. The alternative though, which is to reimplement 
+    // webdriver.promise.ControlFlow.prototype.getSchedule() here is much
+    // hackier, and involves messing with the control flow's internals / private
+    // variables.  
+    return helper.filterStackTrace(controlFlowText);
+    
   };
 
   if (opt_debugPort) {


### PR DESCRIPTION
What it looks like now:

```
-- Next command: get
ControlFlow::1
| Frame::72
| | Frame::82
| | | Frame::84
| | | | (pending) Task::116<Run fit in control flow>
| | | | | Task: Run fit in control flow
| | | | | Frame::124
| | | | | | (pending) Task::137<WebDriver.navigate().to(data:text/html,<html></html>)>
| | | | | | | Task: WebDriver.navigate().to(data:text/html,<html></html>)
| | | | | | |     at Env.<anonymous> (/workspace/protractor/spec/basic/elements_spec.js:34:13)
| | | | | | | (active) Frame::353
| | | | | | | | Frame::355
| | | | | | Task::151<Protractor.get(http://localhost:8081/index.html#/form) - reset url>
| | | | | | | Task: Protractor.get(http://localhost:8081/index.html#/form) - reset url
| | | | | | |     at Env.<anonymous> (/workspace/protractor/spec/basic/elements_spec.js:34:13)
| | | | | | Task::155<waiting for page to load for 10000ms>
| | | | | | | Task: waiting for page to load for 10000ms
| | | | | | |     at Env.<anonymous> (/workspace/protractor/spec/basic/elements_spec.js:34:13)
| | | | | | Task::167<Protractor.get(http://localhost:8081/index.html#/form) - test for angular>
| | | | | | | Task: Protractor.get(http://localhost:8081/index.html#/form) - test for angular
| | | | | | |     at Env.<anonymous> (/workspace/protractor/spec/basic/elements_spec.js:34:13)
| | | | | | Task::183<Protractor.get(http://localhost:8081/index.html#/form) - add mock module protractorBaseModule_>
| | | | | | | Task: Protractor.get(http://localhost:8081/index.html#/form) - add mock module protractorBaseModule_
| | | | | | |     at Env.<anonymous> (/workspace/protractor/spec/basic/elements_spec.js:34:13)
| | | | | | Task::202<Protractor.get(http://localhost:8081/index.html#/form) - resume bootstrap>
| | | | | | | Task: Protractor.get(http://localhost:8081/index.html#/form) - resume bootstrap
| | | | | | |     at Env.<anonymous> (/workspace/protractor/spec/basic/elements_spec.js:34:13)
| | | | | | Task::216<Protractor.waitForAngular()>
| | | | | | | Task: Protractor.waitForAngular()
| | | | | | |     at Env.<anonymous> (/workspace/protractor/spec/basic/elements_spec.js:39:17)
| | | | | | Task::232<Expect toEqual>
| | | | | | | Task: Expect toEqual
| | | | | | |     at Env.<anonymous> (/workspace/protractor/spec/basic/elements_spec.js:39:28)
| | | | | | Task::244<Protractor.waitForAngular()>
| | | | | | | Task: Protractor.waitForAngular()
| | | | | | |     at Env.<anonymous> (/workspace/protractor/spec/basic/elements_spec.js:41:19)
| | | | | | Task::270<Protractor.waitForAngular()>
| | | | | | | Task: Protractor.waitForAngular()
| | | | | | |     at Env.<anonymous> (/workspace/protractor/spec/basic/elements_spec.js:41:27)
| | | | | | Task::298<Protractor.waitForAngular()>
| | | | | | | Task: Protractor.waitForAngular()
| | | | | | |     at Env.<anonymous> (/workspace/protractor/spec/basic/elements_spec.js:42:17)
| | | | | | Task::314<Expect toEqual>
| | | | | | | Task: Expect toEqual
| | | | | | |     at Env.<anonymous> (/workspace/protractor/spec/basic/elements_spec.js:42:28)
```

Before: 
```
-- WebDriver control flow schedule 
 |- waiting for debugger to attach
 |---    at Env.<anonymous> (/workspace/protractor/spec/basic/elements_spec.js:32:13)
 |- WebDriver.navigate().to(data:text/html,<html></html>)
 |---    at Env.<anonymous> (/workspace/protractor/spec/basic/elements_spec.js:33:13)
 |- Protractor.get(http://localhost:8081/index.html#/form) - reset url
 |---    at Env.<anonymous> (/workspace/protractor/spec/basic/elements_spec.js:33:13)
 |- waiting for page to load for 10000ms
 |---    at Env.<anonymous> (/workspace/protractor/spec/basic/elements_spec.js:33:13)
 |- Protractor.get(http://localhost:8081/index.html#/form) - test for angular
 |---    at Env.<anonymous> (/workspace/protractor/spec/basic/elements_spec.js:33:13)
 |- Protractor.get(http://localhost:8081/index.html#/form) - add mock module protractorBaseModule_
 |---    at Env.<anonymous> (/workspace/protractor/spec/basic/elements_spec.js:33:13)
 |- Protractor.get(http://localhost:8081/index.html#/form) - resume bootstrap
 |---    at Env.<anonymous> (/workspace/protractor/spec/basic/elements_spec.js:33:13)
 |- Protractor.waitForAngular()
 |---    at Env.<anonymous> (/workspace/protractor/spec/basic/elements_spec.js:38:17)
 |- 
 |---at Expectation.toEqual 
 |---    at Env.<anonymous> (/workspace/... (length: 2693)
```