### PR TITLE
fix(taskscheduler): label sharded tasks with numbers instead of letters

### DIFF
--- a/lib/taskScheduler.js
+++ b/lib/taskScheduler.js
@@ -89,7 +89,7 @@ TaskScheduler.prototype.nextTask = function() {
       ++queue.numRunningInstances;
       var taskId = rotatedIndex + 1;
       if (queue.specLists.length > 1) {
-        taskId += String.fromCharCode(97 + queue.specsIndex); //ascii 97 is 'a'
+        taskId += '-' + queue.specsIndex;
       }
       var specs = queue.specLists[queue.specsIndex];
       ++queue.specsIndex;


### PR DESCRIPTION
Letters run into a problem with a maximum of 26.
See #2042