### PR TITLE
Return a promise that handles errors in protractor.get

### DIFF
--- a/lib/protractor.js
+++ b/lib/protractor.js
@@ -212,7 +212,7 @@ var Protractor = function(webdriverInstance, opt_baseUrl, opt_rootElement) {
    * when running element explorer.
    * @private {number}
    */
-  this.debuggerServerPort_; 
+  this.debuggerServerPort_;
 };
 
 /**
@@ -448,11 +448,14 @@ Protractor.prototype.get = function(destination, opt_timeout) {
     return this.driver.get(destination);
   }
 
-  this.driver.get(this.resetUrl);
+  var deferred = webdriver.promise.defer();
+
+  this.driver.get(this.resetUrl).then(null, deferred.reject);
   this.executeScript_(
       'window.name = "' + DEFER_LABEL + '" + window.name;' +
       'window.location.replace("' + destination + '");',
-      msg('reset url'));
+      msg('reset url'))
+      .then(null, deferred.reject);
 
   // We need to make sure the new url has loaded before
   // we try to execute any asynchronous scripts.
@@ -473,7 +476,8 @@ Protractor.prototype.get = function(destination, opt_timeout) {
           }
         });
   }, timeout,
-  'waiting for page to load for ' + timeout + 'ms');
+  'waiting for page to load for ' + timeout + 'ms')
+  .then(null, deferred.reject);
 
   // Make sure the page is an Angular page.
   self.executeAsyncScript_(clientSideScripts.testForAngular,
@@ -488,7 +492,8 @@ Protractor.prototype.get = function(destination, opt_timeout) {
         }
       }, function(err) {
         throw 'Error while running testForAngular: ' + err.message;
-      });
+      })
+      .then(null, deferred.reject);
 
   // At this point, Angular will pause for us until angular.resumeBootstrap
   // is called.
@@ -503,13 +508,17 @@ Protractor.prototype.get = function(destination, opt_timeout) {
         then(null, function(err) {
           throw 'Error while running module script ' + name +
               ': ' + err.message;
-        });
+        })
+        .then(null, deferred.reject);
   }
 
-  return this.executeScript_(
+  this.executeScript_(
       'angular.resumeBootstrap(arguments[0]);',
       msg('resume bootstrap'),
-      moduleNames);
+      moduleNames)
+      .then(deferred.fulfill, deferred.reject);
+
+  return deferred;
 };
 
 /**
@@ -627,14 +636,14 @@ Protractor.prototype.initDebugger_ = function(debuggerClientPath, opt_debugPort)
   webdriver.promise.ControlFlow.prototype.getControlFlowText = function() {
     var controlFlowText = this.getSchedule(/* opt_includeStackTraces */ true);
     // This filters the entire control flow text, not just the stack trace, so
-    // unless we maintain a good (i.e. non-generic) set of keywords in 
-    // STACK_SUBSTRINGS_TO_FILTER, we run the risk of filtering out non stack 
-    // trace. The alternative though, which is to reimplement 
+    // unless we maintain a good (i.e. non-generic) set of keywords in
+    // STACK_SUBSTRINGS_TO_FILTER, we run the risk of filtering out non stack
+    // trace. The alternative though, which is to reimplement
     // webdriver.promise.ControlFlow.prototype.getSchedule() here is much
     // hackier, and involves messing with the control flow's internals / private
-    // variables.  
+    // variables.
     return helper.filterStackTrace(controlFlowText);
-    
+
   };
 
   if (opt_debugPort) {
@@ -677,7 +686,7 @@ Protractor.prototype.initDebugger_ = function(debuggerClientPath, opt_debugPort)
     });
   };
   var sandbox = vm_.createContext(context);
-  
+
   var browserUnderDebug = this;
 
   // Helper used only by debuggers at './debugger/modes/*.js' to insert code
@@ -734,11 +743,11 @@ Protractor.prototype.initDebugger_ = function(debuggerClientPath, opt_debugPort)
             return undefined;
           } else {
             // The '' forces res to be expanded into a string instead of just
-            // '[Object]'. Then we remove the extra space caused by the '' using 
-            // substring. 
+            // '[Object]'. Then we remove the extra space caused by the '' using
+            // substring.
             return util.format.apply(this, ['', res]).substring(1);
           }
-        });        
+        });
       };
       this.execute_(execFn_);
     },

--- a/spec/basic/handling_spec.js
+++ b/spec/basic/handling_spec.js
@@ -1,0 +1,11 @@
+
+describe('handling timeout errors', function() {
+
+  it('should call error handler on a timeout', function() {
+    browser.get('dummyUrl', 1).then(function() {
+      throw 'did not handle error';
+    }, function(err) {
+      expect(err).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
If an error occurs during the protractor.get() call, that error cannot be handled.  This is an issue if you want to do cleanup after a failed test, for example.

This change ensures that on failure of any of the calls in protractor.get(), the returned promise will be resolved with an error, rather than the error not being handled.
