### PR TITLE
fix(cucumber): missing no-snippet param for cucumber framework

### DIFF
--- a/lib/frameworks/cucumber.js
+++ b/lib/frameworks/cucumber.js
@@ -55,6 +55,12 @@ exports.run = function(runner, specs) {
     if (runner.getConfig().cucumberOpts.coffee) {
       execOptions.push('--coffee');
     }
+
+    // Process Cucumber 'no-snippets' param
+    if (runner.getConfig().cucumberOpts.noSnippets) {
+      execOptions.push('--no-snippets');
+    }
+
   }
   global.cucumber = Cucumber.Cli(execOptions);
 


### PR DESCRIPTION
support to pass no-snippet param from protractor to cucumber