### PR TITLE
Add additional configuration options to example/conf.js

### DIFF
--- a/example/conf.js
+++ b/example/conf.js
@@ -7,6 +7,14 @@ exports.config = {
     'browserName': 'chrome'
   },
 
+  // If you would like to test against multiple browsers, use the multiCapabilities
+  // configuration option instead.
+  multiCapabilities: [{
+    'browserName': 'firefox'
+    }, {
+    'browserName': 'chrome'
+  }],
+
   // Spec patterns are relative to the current working directly when
   // protractor is called.
   specs: ['example_spec.js'],
@@ -16,4 +24,7 @@ exports.config = {
     showColors: true,
     defaultTimeoutInterval: 30000
   }
+
+  // Specify a framework you wish to use. Default version is Jasmine v1.3.
+    framework: 'jasmine2'
 };


### PR DESCRIPTION
I added these two options into the example as I thought they made more sense if someone was looking at immediately setting up Protractor to test multiple browsers, and configure a different framework.