### PR TITLE
Update plugins.md

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -186,7 +186,7 @@ Enable this plugin in your config file:
         chromeA11YDevTools: {
           treatWarningsAsFailures: true
         },
-        path: 'node_modules/protractor.plugins/accessiblity'
+        path: 'node_modules/protractor.plugins/accessibility'
       }]
     }
 ```
@@ -203,7 +203,7 @@ Enable this plugin in your config file:
           printAll: false, // whether the plugin should log API response
         },
         chromeA11YDevTools: true,
-        path: 'node_modules/protractor/plugins/accessiblity'
+        path: 'node_modules/protractor/plugins/accessibility'
       }]
     }
 ```


### PR DESCRIPTION
Fixes a misspelled path for the accessibility plugin.
Changes `path: 'node_modules/protractor.plugins/accessiblity'` to `path: 'node_modules/protractor.plugins/accessibility'`