### PR TITLE
feat(capabilites): custom instance name

### DIFF
--- a/docs/referenceConf.js
+++ b/docs/referenceConf.js
@@ -108,9 +108,9 @@ exports.config = {
   capabilities: {
     browserName: 'chrome',
 
-    // Name of the process executing this capability.  Not used directly by
-    // protractor or the browser, but instead pass directly to third parties
-    // like SauceLabs as the name of the job running this test
+    // Name of the process executing this capability. Primarily used by third
+    // parties like SauceLabs, but is also used by protractor to give a
+    // capability instance a user defined name.
     name: 'Unnamed Job',
 
     // Number of times to run this set of capabilities (in parallel, unless

--- a/docs/referenceConf.js
+++ b/docs/referenceConf.js
@@ -114,7 +114,8 @@ exports.config = {
     name: 'Unnamed Job',
 
     // User defined name for the capability that will display in the results log
-    logName: 'Chrome - French Canadian'
+    // Default is 'Chrome #1', 'Firefox #2', etc.
+    logName: 'Chrome - French Canadian',
 
     // Number of times to run this set of capabilities (in parallel, unless
     // limited by maxSessions). Default is 1.

--- a/docs/referenceConf.js
+++ b/docs/referenceConf.js
@@ -108,10 +108,13 @@ exports.config = {
   capabilities: {
     browserName: 'chrome',
 
-    // Name of the process executing this capability. Primarily used by third
-    // parties like SauceLabs, but is also used by protractor to give a
-    // capability instance a user defined name.
+    // Name of the process executing this capability.  Not used directly by
+    // protractor or the browser, but instead pass directly to third parties
+    // like SauceLabs as the name of the job running this test
     name: 'Unnamed Job',
+
+    // User defined name for the capability that will display in the results log
+    logName: 'Chrome - French Canadian'
 
     // Number of times to run this set of capabilities (in parallel, unless
     // limited by maxSessions). Default is 1.

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -71,8 +71,10 @@ var taskResults_ = {
     this.results_.forEach(function(result) {
       var capabilities = result.capabilities;
       var shortName = (capabilities.browserName) ? capabilities.browserName : '';
+      shortName = (capabilities.name) ? capabilities.name
+        : (capabilities.browserName) ? capabilities.browserName : '';
       shortName += (capabilities.version) ? capabilities.version : '';
-      shortName += (' #' + result.taskId);
+      shortName += (capabilities.name && capabilities.count < 2) ? '' : ' #' + result.taskId;
       if (result.failedCount) {
         log_(shortName + ' failed ' + result.failedCount + ' test(s)');
       } else if (result.exitCode !== 0) {

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -74,7 +74,8 @@ var taskResults_ = {
       shortName = (capabilities.logName) ? capabilities.logName
         : (capabilities.browserName) ? capabilities.browserName : '';
       shortName += (capabilities.version) ? capabilities.version : '';
-      shortName += (capabilities.logName && capabilities.count < 2) ? '' : ' #' + result.taskId;
+      shortName += (capabilities.logName && capabilities.count < 2) ?
+        '' : ' #' + result.taskId;
       if (result.failedCount) {
         log_(shortName + ' failed ' + result.failedCount + ' test(s)');
       } else if (result.exitCode !== 0) {

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -71,10 +71,10 @@ var taskResults_ = {
     this.results_.forEach(function(result) {
       var capabilities = result.capabilities;
       var shortName = (capabilities.browserName) ? capabilities.browserName : '';
-      shortName = (capabilities.name) ? capabilities.name
+      shortName = (capabilities.logName) ? capabilities.logName
         : (capabilities.browserName) ? capabilities.browserName : '';
       shortName += (capabilities.version) ? capabilities.version : '';
-      shortName += (capabilities.name && capabilities.count < 2) ? '' : ' #' + result.taskId;
+      shortName += (capabilities.logName && capabilities.count < 2) ? '' : ' #' + result.taskId;
       if (result.failedCount) {
         log_(shortName + ' failed ' + result.failedCount + ' test(s)');
       } else if (result.exitCode !== 0) {

--- a/lib/taskLogger.js
+++ b/lib/taskLogger.js
@@ -55,13 +55,11 @@ TaskLogger.prototype.flush = function() {
 TaskLogger.prototype.log = function(data) {
   var tag = '[';
   var capabilities = this.task.capabilities;
-  tag += (capabilities.browserName) ?
-    capabilities.browserName : '';
-  tag += (capabilities.version) ?
-    (' ' + capabilities.version) : '';
-  tag += (capabilities.platform) ?
-    (' ' + capabilities.platform) : '';
-  tag += (' #' + this.task.taskId);
+  tag += (capabilities.name) ? capabilities.name
+    : (capabilities.browserName) ? capabilities.browserName : '';
+  tag += (capabilities.version) ? (' ' + capabilities.version) : '';
+  tag += (capabilities.platform) ? (' ' + capabilities.platform) : '';
+  tag += (capabilities.name && capabilities.count < 2) ? '' : ' #' + this.task.taskId;
   tag += '] ';
 
   data = data.toString();

--- a/lib/taskLogger.js
+++ b/lib/taskLogger.js
@@ -59,7 +59,8 @@ TaskLogger.prototype.log = function(data) {
     : (capabilities.browserName) ? capabilities.browserName : '';
   tag += (capabilities.version) ? (' ' + capabilities.version) : '';
   tag += (capabilities.platform) ? (' ' + capabilities.platform) : '';
-  tag += (capabilities.logName && capabilities.count < 2) ? '' : ' #' + this.task.taskId;
+  tag += (capabilities.logName && capabilities.count < 2) ?
+    '' : ' #' + this.task.taskId;
   tag += '] ';
 
   data = data.toString();

--- a/lib/taskLogger.js
+++ b/lib/taskLogger.js
@@ -55,11 +55,11 @@ TaskLogger.prototype.flush = function() {
 TaskLogger.prototype.log = function(data) {
   var tag = '[';
   var capabilities = this.task.capabilities;
-  tag += (capabilities.name) ? capabilities.name
+  tag += (capabilities.logName) ? capabilities.logName
     : (capabilities.browserName) ? capabilities.browserName : '';
   tag += (capabilities.version) ? (' ' + capabilities.version) : '';
   tag += (capabilities.platform) ? (' ' + capabilities.platform) : '';
-  tag += (capabilities.name && capabilities.count < 2) ? '' : ' #' + this.task.taskId;
+  tag += (capabilities.logName && capabilities.count < 2) ? '' : ' #' + this.task.taskId;
   tag += '] ';
 
   data = data.toString();


### PR DESCRIPTION
Resolves angular/protractor#2112.

Naming of instances is now supported by leveraging the "name" option of the capability. This was previously not used by protractor itself but was used to pass to SauceLabs.

Documents updated.

Tested manually