### PR TITLE
fix(cucumber): fix beforeFeature event handler call guard

### DIFF
--- a/lib/frameworks/cucumber.js
+++ b/lib/frameworks/cucumber.js
@@ -79,7 +79,7 @@ exports.run = function(runner, specs) {
     var originalHandleBeforeFeatureEvent = formatter.handleBeforeFeatureEvent;
     formatter.handleBeforeFeatureEvent = function(event, callback) {
       feature = event.getPayloadItem('feature');
-      if (typeof originalHandleAfterScenarioEvent == 'function') {
+      if (typeof originalHandleBeforeFeatureEvent == 'function') {
         originalHandleBeforeFeatureEvent.apply(formatter, arguments);
       } else {
         callback();


### PR DESCRIPTION
Fixes the run failures reported in https://github.com/cucumber/cucumber-js/issues/342.