### PR TITLE
fix(waitForAngular): do not crash if waitForAngular gets called befor…

### DIFF
--- a/lib/clientsidescripts.js
+++ b/lib/clientsidescripts.js
@@ -29,23 +29,31 @@ var functions = {};
 functions.waitForAngular = function(rootSelector, callback) {
   var el = document.querySelector(rootSelector);
 
-  try {
-    if (!window.angular) {
-      throw new Error('angular could not be found on the window');
-    }
-    if (angular.getTestability) {
-      angular.getTestability(el).whenStable(callback);
-    } else {
-      if (!angular.element(el).injector()) {
-        throw new Error('root element (' + rootSelector + ') has no injector.' +
-           ' this may mean it is not inside ng-app.');
+  var retryInterval = setInterval(function() {
+    try {
+      if (!window.angular) {
+        if (document.readyState === "complete") {
+          throw new Error('angular could not be found on the window');
+        }
+      } else {
+        if (angular.getTestability) {
+          clearInterval(retryInterval);
+          angular.getTestability(el).whenStable(callback);
+        } else {
+          if (!angular.element(el).injector()) {
+            throw new Error('root element (' + rootSelector + ') has no injector.' +
+               ' this may mean it is not inside ng-app.');
+          }
+          clearInterval(retryInterval);
+          angular.element(el).injector().get('$browser').
+              notifyWhenNoOutstandingRequests(callback);
+        }
       }
-      angular.element(el).injector().get('$browser').
-          notifyWhenNoOutstandingRequests(callback);
+    } catch (err) {
+      clearInterval(retryInterval);
+      callback(err.message);
     }
-  } catch (err) {
-    callback(err.message);
-  }
+  }, 10);
 };
 
 /**


### PR DESCRIPTION
…e angular has been loaded

This is useful in cases where navigation occurs without `browser.get()` being called (e.g. clicking a nav button, a page redirect).

Maybe closes issue #2181?

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/protractor/2217)
<!-- Reviewable:end -->
