### PR TITLE
chore(docs): Correctly mark member functions set in the constructor o…

### DIFF
--- a/website/docgen/dgeni-config.js
+++ b/website/docgen/dgeni-config.js
@@ -57,6 +57,7 @@ myPackage.factory(require('./inline_tags/code'))
  * add-toc: Generates the table of contents.
  */
 myPackage.processor(require('./processors/tag-fixer'));
+myPackage.processor(require('./processors/these-children'));
 myPackage.processor(require('./processors/filter-jsdoc'));
 myPackage.processor(require('./processors/set-file-name'));
 myPackage.processor(require('./processors/transfer-see'));

--- a/website/docgen/processors/these-children.js
+++ b/website/docgen/processors/these-children.js
@@ -1,0 +1,23 @@
+/**
+ * Set the parents of member functions set in the constructor of an object.
+ */
+module.exports = function theseChildren() {
+  return {
+    $runAfter: ['extracting-tags'],
+    $runBefore: ['tags-extracted'],
+    $process: function(docs) {
+      var parentDoc = docs[0];
+      for (var i = 0; i < docs.length; i++) {
+        doc = docs[i];
+        if (doc.codeNode && doc.codeNode.expression &&
+            doc.codeNode.expression.left  &&
+            doc.codeNode.expression.left.object  &&
+            doc.codeNode.expression.left.object.type  == 'ThisExpression') {
+          doc.name = parentDoc.name + '.prototype.' + doc.name;
+        } else {
+          parentDoc = doc;
+        }
+      }
+    }
+  };
+};


### PR DESCRIPTION
…f an object

Currently if you have a memeber function set like this:
```js
var Class = function() {
  this.fun = function() {...};
}
```
Then dgeni will not grasp that `fun` is a member of the `Class` class.  This fixes that

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/protractor/2243)
<!-- Reviewable:end -->
