### PR TITLE
Fix documentation on evaluate

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -57,7 +57,7 @@ In general, the design of WebDriver tests is to interact with the page as a user
 
 You can use the `evaluate` function on a WebElement to get the value of an Angular expression in the scope of that element. e.g.
 ```javascript
-by.css('.foo').evaluate('bar')
+element(by.css('.foo')).evaluate('bar')
 ```
 would return whatever `{{bar}}` is in the scope of the element with class 'foo'.
 


### PR DESCRIPTION
by.css('.foo').evaluate('bar') gives the following error:

TypeError: Object By.cssSelector(".foo") has no method 'evaluate'

It is element(by.css('.foo')).evaluate('bar') what works

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/protractor/2256)
<!-- Reviewable:end -->
