### PR TITLE
Add support to allow Protractor to test an Angular application which …

### DIFF
--- a/lib/protractor.js
+++ b/lib/protractor.js
@@ -16,6 +16,7 @@ var ExpectedConditions = require('./expectedConditions.js');
 /* global angular */
 
 var DEFER_LABEL = 'NG_DEFER_BOOTSTRAP!';
+var ENABLE_DEBUG_INFO_LABEL = 'NG_ENABLE_DEBUG_INFO!';
 var DEFAULT_RESET_URL = 'data:text/html,<html></html>';
 var DEFAULT_GET_PAGE_TIMEOUT = 10000;
 
@@ -528,7 +529,7 @@ Protractor.prototype.get = function(destination, opt_timeout) {
 
   this.driver.get(this.resetUrl).then(null, deferred.reject);
   this.executeScript_(
-      'window.name = "' + DEFER_LABEL + '" + window.name;' +
+      'window.name = "' + DEFER_LABEL + ENABLE_DEBUG_INFO_LABEL + '" + window.name;' +
       'window.location.replace("' + destination + '");',
       msg('reset url'))
       .then(null, deferred.reject);


### PR DESCRIPTION
…has debugging info disabled

Currently Angular application which for performance reasons, have debug information turn off cannot be tested. 
Per the following issue I've added the Angular debug logging flag to the Protractor run.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/protractor/2261)
<!-- Reviewable:end -->
