### PR TITLE
fix(browser.refresh): use timeout in milliseconds

### DIFF
--- a/lib/protractor.js
+++ b/lib/protractor.js
@@ -605,10 +605,9 @@ Protractor.prototype.get = function(destination, opt_timeout) {
  * If you need to access a page which does not have Angular on load, use
  * the wrapped webdriver directly.
  *
- * @param {number=} opt_timeout Number of seconds to wait for Angular to start.
+ * @param {number=} opt_timeout Number of milliseconds to wait for Angular to start.
  */
 Protractor.prototype.refresh = function(opt_timeout) {
-  var timeout = opt_timeout || 10;
   var self = this;
 
   if (self.ignoreSynchronization) {
@@ -618,7 +617,7 @@ Protractor.prototype.refresh = function(opt_timeout) {
   return self.executeScript_(
       'return window.location.href',
       'Protractor.refresh() - getUrl').then(function(href) {
-        return self.get(href, timeout);
+        return self.get(href, opt_timeout);
       });
 };
 


### PR DESCRIPTION
When invoked without arguments, browser.refresh uses a 10-millisecond timeout, wrongly documented as seconds. Changed it to delegate timeout handling to browser.get, which defaults to DEFAULT_GET_PAGE_TIMEOUT (10 seconds).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/protractor/2268)
<!-- Reviewable:end -->
