### PR TITLE
chore(website): parse relative links correctly

### DIFF
--- a/website/gulpfile.js
+++ b/website/gulpfile.js
@@ -98,7 +98,7 @@ gulp.task('markdown', function() {
       // Parse markdown.
       .pipe(markdown())
       // Fix in-page hash paths.
-      .pipe(replace(/"#([^ ]*?)"/g, '#/{{path}}#$1'))
+      .pipe(replace(/"#([^ ]*?)"/g, '#{{path}}#$1'))
       // Fix md urls.
       .pipe(replace(/"(?:\/docs\/)?([\w\-]+)\.md/g, '"#/$1'))
       // Fix png urls.


### PR DESCRIPTION
Before it would add two forward slashes after the hash mark, thus causing the navigation to fail

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/protractor/2288)
<!-- Reviewable:end -->
