### PR TITLE
Reset URL cannot be a data url for PhantomJS

### DIFF
--- a/lib/protractor.js
+++ b/lib/protractor.js
@@ -192,8 +192,9 @@ var Protractor = function(webdriverInstance, opt_baseUrl, opt_rootElement) {
     // Internet Explorer does not accept data URLs, which are the default
     // reset URL for Protractor.
     // Safari accepts data urls, but SafariDriver fails after one is used.
+    // PhantomJS produces a "Detected a page unload event" if we use data urls
     var browserName = caps.get('browserName');
-    if (browserName === 'internet explorer' || browserName === 'safari') {
+    if (browserName === 'internet explorer' || browserName === 'safari' || browserName === 'phantomjs') {
       self.resetUrl = 'about:blank';
     }
   });


### PR DESCRIPTION
When trying to use the lates version of Angular with PhantomJS we get a message complaining about "Detected a page unload event". This was fixed in earlier versions of Angular, see issue #85, but reappeared now. The problem is that using data urls to reset the page causes this issue, so we have to do as we do with Safari and use "about:blank" instead