### PR TITLE
fix(Chrome Accessibility Plugin) No error context

### DIFF
--- a/plugins/accessibility/index.js
+++ b/plugins/accessibility/index.js
@@ -178,6 +178,12 @@ function runChromeDevTools(context) {
                 code: result.rule.code,
                 list: trimText(text)
               };
+            },
+            function(reason){
+              return {
+                code: result.rule.code,
+                list: reason
+              };
             })
           );
         });


### PR DESCRIPTION
If your tests fail because of StaleElementReferenceError then there is no context about where this is coming from.
By having the failure be handled inside of the plugin then grunt can fail gracefully.
Additionally, this provides context about where the error originated from.

Fixes #2331