### PR TITLE
Update cucumber.js to run with json formatter

### DIFF
--- a/lib/frameworks/cucumber.js
+++ b/lib/frameworks/cucumber.js
@@ -80,7 +80,7 @@ exports.run = function(runner, specs) {
     formatter.handleBeforeFeatureEvent = function(event, callback) {
       feature = event.getPayloadItem('feature');
       if (typeof originalHandleBeforeFeatureEvent == 'function') {
-        originalHandleBeforeFeatureEvent.apply(formatter, arguments);
+        originalHandleBeforeFeatureEvent(event, callback);
       } else {
         callback();
       }


### PR DESCRIPTION
I don't know the meaning inside originalHandleBeforeFeatureEvent.apply(formatter, arguments) but it produce bug when use json formatter.
When I change the code like this, it run normally.