### PR TITLE
fix(element): ElementArrayFinder.count was slow

### DIFF
--- a/lib/element.js
+++ b/lib/element.js
@@ -350,23 +350,7 @@ ElementArrayFinder.prototype.toElementFinder_ = function() {
  */
 ElementArrayFinder.prototype.count = function() {
   return this.getWebElements().then(function(arr) {
-    var list = arr.map(function(webElem) {
-      // Calling any method forces a staleness check
-      return webElem.isEnabled().then(function() {
-        return 1; // is present
-      }, function(err) {
-        if (err.code == webdriver.error.ErrorCode.STALE_ELEMENT_REFERENCE) {
-          return 0; // not present
-        } else {
-          throw err;
-        }
-      });
-    });
-    return webdriver.promise.all(list).then(function(presenceArr) {
-      return presenceArr.reduce(function(acc, isPresent) {
-        return acc + isPresent;
-      }, 0);
-    });
+    return arr.length;
   }, function(err) {
     if (err.code == webdriver.error.ErrorCode.NO_SUCH_ELEMENT) {
       return 0;
@@ -922,8 +906,25 @@ ElementFinder.prototype.$ = function(selector) {
  *     the element is present on the page.
  */
 ElementFinder.prototype.isPresent = function() {
-  return this.parentElementArrayFinder.count().then(function(count) {
-    return !!count;
+  return this.parentElementArrayFinder.getWebElements().then(function(arr) {
+    if (arr.length == 0) {
+      return false;
+    }
+    return arr[0].isEnabled().then(function() {
+      return true; // is present, whether it is enabled or not
+    }, function(err) {
+      if (err.code == webdriver.error.ErrorCode.STALE_ELEMENT_REFERENCE) {
+        return false;
+      } else {
+        throw err;
+      }
+    });
+  }, function(err) {
+    if (err.code == webdriver.error.ErrorCode.NO_SUCH_ELEMENT) {
+      return false;
+    } else {
+      throw err;
+    }
   });
 };
 


### PR DESCRIPTION
The bug fix for #1903 (https://github.com/angular/protractor/commit/2a765c76e121de13ff86a279fe3f21cb15c17783)
was causing ElementArrayFinder.prototype.count to be slow because of
the extranous checks that must be performed. However, the checks could be
delayed into the isPresent check, which will mitigate this issue

fixes(#2359)