### PR TITLE
Give some older android platforms a way to proceed

### DIFF
--- a/lib/protractor.js
+++ b/lib/protractor.js
@@ -640,7 +640,7 @@ Protractor.prototype.get = function(destination, opt_timeout) {
   }
 
   this.executeScript_(
-      'angular.resumeBootstrap(arguments[0]);',
+      'if (angular.resumeBootstrap) {angular.resumeBootstrap(arguments[0]);}',
       msg('resume bootstrap'),
       moduleNames)
       .then(null, deferred.reject);


### PR DESCRIPTION
Some older android platforms don't end up with a resumeBootstrap method despite the defer tag in window.name.  This gives the tests a way to proceed despite that.  I noticed this being an issue while testing at SauceLabs on some android 4.x versions.  It's unclear to me why the resumeBootstrap method never gets applied to angular, but it doesn't.  This change at least allows things to move forward.