### PR TITLE
fix(ng-repeat): properly detect the end of an ng-repeat-start block

### DIFF
--- a/lib/clientsidescripts.js
+++ b/lib/clientsidescripts.js
@@ -190,7 +190,7 @@ function findRepeaterRows(repeater, exact, index, using) {
         var elem = repeatElems[i];
         var row = [];
         while (elem.nodeType != 8 ||
-            !repeaterMatch(elem.nodeValue, repeater, exact)) {
+            !repeaterMatch(elem.nodeValue, repeater)) {
           if (elem.nodeType == 1) {
             row.push(elem);
           }
@@ -237,7 +237,7 @@ function findAllRepeaterRows(repeater, exact, using) {
       if (repeaterMatch(repeatElems[i].getAttribute(attr), repeater, exact)) {
         var elem = repeatElems[i];
         while (elem.nodeType != 8 ||
-            !repeaterMatch(elem.nodeValue, repeater, exact)) {
+            !repeaterMatch(elem.nodeValue, repeater)) {
           if (elem.nodeType == 1) {
             rows.push(elem);
           }
@@ -291,7 +291,7 @@ function findRepeaterElement(repeater, exact, index, binding, using, rootSelecto
         var elem = repeatElems[i];
         var row = [];
         while (elem.nodeType != 8 || (elem.nodeValue &&
-            !repeaterMatch(elem.nodeValue, repeater, exact))) {
+            !repeaterMatch(elem.nodeValue, repeater))) {
           if (elem.nodeType == 1) {
             row.push(elem);
           }
@@ -390,7 +390,7 @@ function findRepeaterColumn(repeater, exact, binding, using, rootSelector) {
         var elem = repeatElems[i];
         var row = [];
         while (elem.nodeType != 8 || (elem.nodeValue &&
-            !repeaterMatch(elem.nodeValue, repeater, exact))) {
+            !repeaterMatch(elem.nodeValue, repeater))) {
           if (elem.nodeType == 1) {
             row.push(elem);
           }


### PR DESCRIPTION
This bug was introduced when by.exactRepeater was

Discovered while investigating issue #2365