### PR TITLE
Add --ie32 commandline option to webdriver_manager

### DIFF
--- a/bin/webdriver-manager
+++ b/bin/webdriver-manager
@@ -79,7 +79,7 @@ var binaries = {
     }
   },
   ie32: {
-    name: 'IEDriver',
+    name: 'IEDriver-32bit',
     isDefault: false,
     prefix: 'IEDriverServer',
     filename: 'IEDriverServer_' + versions.iedriver + '.zip',
@@ -106,9 +106,7 @@ var cli = optimist.
     describe('ignore_ssl', 'Ignore SSL certificates').boolean('ignore_ssl').
     default('ignore_ssl', false).
     describe('proxy', 'Proxy to use for the install or update command').
-    describe('alternate_cdn', 'Alternate CDN to the binaries').
-    describe('ie32', 'Use 32-bit IE driver regardless of current architecture').boolean('ie32').
-    default('ie32', false);
+    describe('alternate_cdn', 'Alternate CDN to the binaries');
 
 for (bin in binaries) {
   cli.describe(bin, 'Install or update ' + binaries[bin].name).

--- a/bin/webdriver-manager
+++ b/bin/webdriver-manager
@@ -77,6 +77,20 @@ var binaries = {
         }
       }
     }
+  },
+  ie32: {
+    name: 'IEDriver',
+    isDefault: false,
+    prefix: 'IEDriverServer',
+    filename: 'IEDriverServer_' + versions.iedriver + '.zip',
+    cdn: 'https://selenium-release.storage.googleapis.com/',
+    url: function() {
+      var urlPrefix = this.cdn +
+          shortVersion(versions.iedriver) + '/IEDriverServer';
+      if (os.type() == 'Windows_NT') {
+        return urlPrefix + '_Win32_' + versions.iedriver + '.zip';
+      }
+    }
   }
 };
 
@@ -92,7 +106,9 @@ var cli = optimist.
     describe('ignore_ssl', 'Ignore SSL certificates').boolean('ignore_ssl').
     default('ignore_ssl', false).
     describe('proxy', 'Proxy to use for the install or update command').
-    describe('alternate_cdn', 'Alternate CDN to the binaries');
+    describe('alternate_cdn', 'Alternate CDN to the binaries').
+    describe('ie32', 'Use 32-bit IE driver regardless of current architecture').boolean('ie32').
+    default('ie32', false);
 
 for (bin in binaries) {
   cli.describe(bin, 'Install or update ' + binaries[bin].name).
@@ -312,7 +328,7 @@ switch (argv._[0]) {
         });
     }
     if (argv.ie) {
-       downloadIfNew(binaries.ie, argv.out_dir, existingFiles,
+       downloadIfNew(argv.ie32 ? binaries.ie32 : binaries.ie, argv.out_dir, existingFiles,
         function(filename) {
           var zip = new AdmZip(filename);
           // Expected contents of the zip:

--- a/bin/webdriver-manager
+++ b/bin/webdriver-manager
@@ -276,7 +276,7 @@ switch (argv._[0]) {
       args.push('-Dwebdriver.chrome.driver=' +
           path.join(argv.out_dir, executableName('chromedriver')));
     }
-    if (binaries.ie.exists) {
+    if (binaries.ie.exists || binaries.ie32.exists) {
        args.push('-Dwebdriver.ie.driver=' +
           path.join(argv.out_dir, executableName('IEDriverServer')));
     }
@@ -326,7 +326,16 @@ switch (argv._[0]) {
         });
     }
     if (argv.ie) {
-       downloadIfNew(argv.ie32 ? binaries.ie32 : binaries.ie, argv.out_dir, existingFiles,
+       downloadIfNew(binaries.ie, argv.out_dir, existingFiles,
+        function(filename) {
+          var zip = new AdmZip(filename);
+          // Expected contents of the zip:
+          //   IEDriverServer.exe
+          zip.extractAllTo(argv.out_dir, true);
+        });
+    }
+    if (argv.ie32) {
+       downloadIfNew(binaries.ie32, argv.out_dir, existingFiles,
         function(filename) {
           var zip = new AdmZip(filename);
           // Expected contents of the zip:


### PR DESCRIPTION
Fixes #1297

The new option allows to download the 32-bit version of the IE driver on
a 64-bit system, as the 64-bit version has been broken for over a year
now (the sendKeys() function works very slowly on it).
