### PR TITLE
feat(webdriver): bump selenium, chromedriver, and iedriver versions

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
   "webdriverVersions": {
-    "selenium": "2.45.0",
-    "chromedriver": "2.15",
-    "iedriver": "2.45.0"
+    "selenium": "2.47.1",
+    "chromedriver": "2.17",
+    "iedriver": "2.47.0"
   }
 }


### PR DESCRIPTION
Hullo, I noticed that the versions that `webdriver-manager` references are slightly outdated. I've seen that there were a few issues/PRs with webdriver @ 2.46.0, so if there are external concerns that mean y'all would like to keep these versions in `webdriver-manager` at those specific ones, feel free to reject.

Cheers & thanks for protractor!