### PR TITLE
chore: fix jshint errors blocking npm test

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -16,5 +16,6 @@
   "loopfunc": true,
   "sub": true,
   "undef": true,
-  "quotmark": "single"
+  "quotmark": "single",
+  "evil": true
 }

--- a/lib/clientsidescripts.js
+++ b/lib/clientsidescripts.js
@@ -33,7 +33,7 @@ function wrapWithHelpers(fun) {
   return new Function(
       helpers.join(';') + ';' +
       '  return (' + fun.toString() + ').apply(this, arguments);');
-};
+}
 
 /**
  * Wait until Angular has finished rendering and has
@@ -170,7 +170,7 @@ function findRepeaterRows(repeater, exact, index, using) {
   }
   var row = rows[index] || [], multiRow = multiRows[index] || [];
   return [].concat(row, multiRow);
-};
+}
 functions.findRepeaterRows = wrapWithHelpers(findRepeaterRows, repeaterMatch); 
 
  /**
@@ -215,7 +215,7 @@ function findAllRepeaterRows(repeater, exact, using) {
     }
   }
   return rows;
-};
+}
 functions.findAllRepeaterRows = wrapWithHelpers(findAllRepeaterRows, repeaterMatch);
 
 /**
@@ -315,7 +315,7 @@ function findRepeaterElement(repeater, exact, index, binding, using, rootSelecto
     }
   }
   return matches;
-};
+}
 functions.findRepeaterElement = wrapWithHelpers(findRepeaterElement, repeaterMatch);
 
 /**
@@ -412,7 +412,7 @@ function findRepeaterColumn(repeater, exact, binding, using, rootSelector) {
     }
   }
   return matches;
-};
+}
 functions.findRepeaterColumn = wrapWithHelpers(findRepeaterColumn, repeaterMatch);
 
 /**

--- a/lib/element.js
+++ b/lib/element.js
@@ -907,7 +907,7 @@ ElementFinder.prototype.$ = function(selector) {
  */
 ElementFinder.prototype.isPresent = function() {
   return this.parentElementArrayFinder.getWebElements().then(function(arr) {
-    if (arr.length == 0) {
+    if (arr.length === 0) {
       return false;
     }
     return arr[0].isEnabled().then(function() {


### PR DESCRIPTION
To get `npm test` to run again, some cleanup was necessary. Note this includes a change to the jshint config allowing `eval`, rather than rewriting the `wrapWithHelpers` function in `lib/clientsidescripts.js`.

Refs #2398