### PR TITLE
resolving the location of AUDIT_FILE

### DIFF
--- a/plugins/accessibility/index.js
+++ b/plugins/accessibility/index.js
@@ -42,7 +42,7 @@ var q = require('q'),
  *
  */
 
-var AUDIT_FILE = path.join(__dirname, '../../node_modules/accessibility-developer-tools/dist/js/axs_testing.js');
+var AUDIT_FILE = require.resolve('accessibility-developer-tools/dist/js/axs_testing.js');
 var TENON_URL = 'http://www.tenon.io/api/';
 
 /**


### PR DESCRIPTION
In my case it installed to the root `node_modules` folder instead of the `protractor/node_modules` folder. Using `require.resolve` should handle both eventualities.

Not sure how to add a test for this, but it passed the existing one