### PR TITLE
docs(plugins): Add a section for community plugins

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -17,6 +17,7 @@ The `plugins` folder contains default plugins for Protractor.
   * [ngHint Plugin](/docs/plugins.md#nghint-plugin)
   * [Timeline Plugin](/docs/plugins.md#timeline-plugin)
   * [Console Plugin](/docs/plugins.md#console-plugin-chrome-only)
+* [Community Plugins](/docs/plugins.md#community-plugins)
 
 Using Plugins
 -------------
@@ -423,3 +424,10 @@ exports.config = {
 
 Note that this plugin's behavior is undefined on browsers other than Chrome.
 Firefox users have reported flaky results.
+
+Community Plugins
+-----------------
+
+This list is here for reference and the plugins included are not developed or mantained by protractor's team by any means. If you find any issues with this plugins please report them to the corresponding plugin developer.
+
+* [Protractor testability plugin](https://github.com/alfonso-presa/protractor-testability-plugin): this plugins enables synchronous testing with protractor for features that are not developed using the services provided by AngularJS, preventing the need of additional waits coded in the tests. This happens for example if you have WebSockets communication with the server or for web applications built with frameworks different than AngularJS.


### PR DESCRIPTION
Now that the plugins API is much more powerful, I though it might be worth including a section in the docs for community plugins for reference. I've included mine :-).

- Includes in the list the protractor-testability-plugin

Closes #2246