### PR TITLE
Feat(accessibility plugin): added option "showUnsupportedRulesWarning…

### DIFF
--- a/plugins/accessibility/index.js
+++ b/plugins/accessibility/index.js
@@ -148,7 +148,14 @@ function runTenonIO(context) {
 function runChromeDevTools(context) {
 
   var data = fs.readFileSync(AUDIT_FILE, 'utf-8');
-  data = data + ' return axs.Audit.run();';
+  data += 'var configuration = new axs.AuditConfiguration();';
+
+  if (typeof context.config.chromeA11YDevTools.showUnsupportedRulesWarning !== 'undefined' &&
+      !context.config.chromeA11YDevTools.showUnsupportedRulesWarning) {
+    data += 'configuration.showUnsupportedRulesWarning = false;';
+  }
+
+  data = data + ' return axs.Audit.run(configuration);';
 
   var elementPromises = [],
       elementStringLength = 200;


### PR DESCRIPTION
…" to plugins.chromeA11YDevTools

Defaults to "true", which is the vanilla behaviour.

This change is desirable because without it, there is no way to use both the A11Y plugin **and** the console plugin with errors turned on - the A11Y plugin outputs errors (see below) that cause a test run to fail. 

When the "showUnsupportedRulesWarning" is set to "false", the following console output will not be emitted:

```TEXT
 	 Fail:  Console output
		WARNING: console-api 1753:141 Some rules cannot be checked using the axs.Audit.run() method call. Use the Chrome plugin to check these rules: AX_FOCUS_02
		WARNING: console-api 1753:286 To remove this message, pass an AuditConfiguration object to axs.Audit.run() and set configuration.showUnsupportedRulesWarning = false.
```