### PR TITLE
Correct quotation marks for Windows cmd.

### DIFF
--- a/docs/referenceConf.js
+++ b/docs/referenceConf.js
@@ -234,7 +234,7 @@ exports.config = {
   // and can be accessed from your test as browser.params. It is an arbitrary
   // object and can contain anything you may need in your test.
   // This can be changed via the command line as:
-  //   --params.login.user 'Joe'
+  //   --params.login.user "Joe"
   params: {
     login: {
       user: 'Jane',


### PR DESCRIPTION
For Windows users the provided example with single quotes doesn't work. Correct are double quotes for Windows cmd.

We spent almost hour finding out why our protractor parameters works on my machine and does not on colleague PC :-/