### PR TITLE
feat(webdriver-manager): Configurable output directory

### DIFF
--- a/bin/webdriver-manager
+++ b/bin/webdriver-manager
@@ -100,7 +100,7 @@ var cli = optimist.
         '  update: install or update selected binaries\n' +
         '  start: start up the selenium server\n' +
         '  status: list the current available drivers').
-    describe('out_dir', 'Location to output/expect binaries, can be modified with WEBDRIVER_MANAGER_SELENIUM_DIR evn variable').
+    describe('out_dir', 'Location to output/expect binaries, can be modified with WEBDRIVER_MANAGER_SELENIUM_DIR env variable').
     default('out_dir', SELENIUM_DIR).
     describe('seleniumPort', 'Optional port for the selenium standalone server').
     describe('ignore_ssl', 'Ignore SSL certificates').boolean('ignore_ssl').

--- a/bin/webdriver-manager
+++ b/bin/webdriver-manager
@@ -13,7 +13,7 @@ var childProcess = require('child_process');
 /**
  * Download the requested binaries to node_modules/protractor/selenium/
  */
-var SELENIUM_DIR = path.resolve(__dirname, '../selenium');
+var SELENIUM_DIR = process.env.WEBDRIVER_MANAGER_SELENIUM_DIR || path.resolve(__dirname, '../selenium');
 
 var versions = require('../config.json').webdriverVersions;
 
@@ -100,7 +100,7 @@ var cli = optimist.
         '  update: install or update selected binaries\n' +
         '  start: start up the selenium server\n' +
         '  status: list the current available drivers').
-    describe('out_dir', 'Location to output/expect ').
+    describe('out_dir', 'Location to output/expect binaries, can be modified with WEBDRIVER_MANAGER_SELENIUM_DIR evn variable').
     default('out_dir', SELENIUM_DIR).
     describe('seleniumPort', 'Optional port for the selenium standalone server').
     describe('ignore_ssl', 'Ignore SSL certificates').boolean('ignore_ssl').


### PR DESCRIPTION
Allows to change binaries cache directory, so that you don't need to download them each time you remove node_modules and run npm install and webdriver-manager update.