### PR TITLE
updated deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "Julie Ralph <ju.ralph@gmail.com>",
   "dependencies": {
     "request": "~2.57.0",
-    "selenium-webdriver": "2.45.1",
+    "selenium-webdriver": "2.47.0",
     "minijasminenode": "1.1.1",
     "jasminewd": "1.1.0",
     "jasminewd2": "0.0.5",


### PR DESCRIPTION
Please update `selenium-webdriver` to `2.47.0` which has updated `ws` to `0.8.0` and release a new protractor version after that. This should fix https://github.com/angular/protractor/issues/2489 and the problems we see with npm3 and Node4.