### PR TITLE
chore(travis): test against node "4", not "4.1"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 sudo: false
 node_js:
   - "0.12"
-  - "4.1"
+  - "4"
 
 env:
   global:


### PR DESCRIPTION
Node is now adhering to semver & receiving minor updates pretty often;
only the latest one is supported upstream.

When Node 4.2.0 comes out Protractor should be tested on it instead of 4.1.1.