### PR TITLE
chore(ci): update version of sauce connect

### DIFF
--- a/scripts/sauce_connect_setup.sh
+++ b/scripts/sauce_connect_setup.sh
@@ -12,7 +12,7 @@ set -e
 # before_script:
 #   - curl https://gist.github.com/santiycr/5139565/raw/sauce_connect_setup.sh | bash
 
-CONNECT_URL="https://saucelabs.com/downloads/sc-4.3.7-linux.tar.gz"
+CONNECT_URL="https://saucelabs.com/downloads/sc-4.3.11-linux.tar.gz"
 CONNECT_DIR="/tmp/sauce-connect-$RANDOM"
 CONNECT_DOWNLOAD="sc-4.3.7-linux.tar.gz"
 


### PR DESCRIPTION
Bump from 4.3.7 to latest 4.3.11.