### PR TITLE
Update selenium-webdriver.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "Julie Ralph <ju.ralph@gmail.com>",
   "dependencies": {
     "request": "~2.57.0",
-    "selenium-webdriver": "2.45.1",
+    "selenium-webdriver": "2.47.0",
     "minijasminenode": "1.1.1",
     "jasminewd": "1.1.0",
     "jasminewd2": "0.0.5",


### PR DESCRIPTION
This updates selenium-webdriver, which will use a newer version of ws, which will use a newer version of bufferutil finally fixing node 4.1.0 compatibility issue. The older bufferutil didn't support newest nan package, which caused a build failure for me on node 4.1.0.

I verified that this change fixed my issue.