### PR TITLE
chore(dependencies): update selenium-webdriver to 2.47.1

### DIFF
--- a/lib/debugger/debuggerCommons.js
+++ b/lib/debugger/debuggerCommons.js
@@ -18,7 +18,7 @@ exports.attachDebugger = function(pid, opt_port) {
     client.setBreakpoint({
       type: 'scriptRegExp',
       target: '.*executors\.js', //jshint ignore:line
-      line: 37
+      line: 40
     }, function() {
       process.send('ready');
       client.reqContinue(function() {

--- a/lib/driverProviders/direct.js
+++ b/lib/driverProviders/direct.js
@@ -65,7 +65,7 @@ DirectDriverProvider.prototype.getNewDriver = function() {
       }
 
       var service = new chrome.ServiceBuilder(chromeDriverFile).build();
-      driver = chrome.createDriver(
+      driver = new chrome.Driver(
           new webdriver.Capabilities(this.config_.capabilities), service);
       break;
     case 'firefox':

--- a/lib/protractor.js
+++ b/lib/protractor.js
@@ -320,7 +320,9 @@ Protractor.prototype.waitForAngular = function(opt_description) {
   var description = opt_description ? ' - ' + opt_description : '';
   var self = this;
   if (this.ignoreSynchronization) {
-    return webdriver.promise.fulfilled();
+    return self.driver.controlFlow().execute(function() {
+      return true;
+    }, 'Ignore Synchronization Protractor.waitForAngular()');
   }
 
   return this.executeAsyncScript_(

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
   "author": "Julie Ralph <ju.ralph@gmail.com>",
   "dependencies": {
     "request": "~2.57.0",
-    "selenium-webdriver": "2.45.1",
+    "selenium-webdriver": "2.47.0",
     "minijasminenode": "1.1.1",
     "jasminewd": "1.1.0",
-    "jasminewd2": "0.0.5",
+    "jasminewd2": "0.0.6",
     "jasmine": "2.3.2",
     "saucelabs": "~1.0.1",
     "glob": "~3.2",


### PR DESCRIPTION
Along with it, update `jasminewd2` to avoid situations where the
control flow gets locked up and hangs.

Potential Breaking Change:

This is passing all existing Protractor tests, but there is a
possibility that the changes to the control flow will cause some
test flows to hang. If this causes issues, please revisit your
use of functions affecting the control flow, such as
`flow.execute`.