### PR TITLE
fix(config): Fixes absolute path parsing in windows

### DIFF
--- a/lib/configParser.js
+++ b/lib/configParser.js
@@ -98,17 +98,23 @@ ConfigParser.resolveFilePatterns =
     for (var i = 0; i < patterns.length; ++i) {
       // Cucumber allows running a spec given a line number. See
       // https://github.com/angular/protractor/issues/2413
-      var fileName = patterns[i].split(':')[0],
-          lineNumber = patterns[i].split(':')[1],
-          matches = glob.sync(fileName, {cwd: cwd});
+      var lineNumber = '';
+      var parsedPath = path.parse(patterns[i]);
+      parsedPath.base = parsedPath.base.replace(/:\d+/, function (match) {
+        lineNumber = match;
+        return '';
+      });
+
+      var filePath = path.format(parsedPath);
+      var matches = glob.sync(filePath, {cwd: cwd});
 
       if (!matches.length && !opt_omitWarnings) {
         log.warn('pattern ' + patterns[i] + ' did not match any files.');
       }
       for (var j = 0; j < matches.length; ++j) {
         var resolvedPath = path.resolve(cwd, matches[j]);
-        if(lineNumber) {
-          resolvedPath += ':' + lineNumber;
+        if (lineNumber) {
+          resolvedPath += lineNumber;
         }
         resolvedFiles.push(resolvedPath);
       }

--- a/spec/unit/config_test.js
+++ b/spec/unit/config_test.js
@@ -62,5 +62,17 @@ describe('the config parser', function() {
       expect(specs[0].indexOf(path.normalize('unit/data/fakespecA.js'))).not.toEqual(-1);
       expect(specs[1].indexOf(path.normalize('unit/data/fakespecB.js'))).not.toEqual(-1);
     });
+
+    it('should allow for line numbers in file paths', function() {
+      spyOn(process, 'cwd').and.returnValue(__dirname + '/');
+      var toAdd = {
+        specs: ['data/fakespecA.js:32', 'data/fakespecB.js']
+      };
+      var config = new ConfigParser().addConfig(toAdd).getConfig();
+      var specs = ConfigParser.resolveFilePatterns(config.specs);
+      expect(specs.length).toEqual(2);
+      expect(specs[0].indexOf(path.normalize('unit/data/fakespecA.js:32'))).not.toEqual(-1);
+      expect(specs[1]).toMatch(/unit\/data\/fakespecB.js$/);
+    });
   });
 });


### PR DESCRIPTION
This allows absolute paths absolute paths in to be properly parsed in windows.
This should maintain the line-number feature introduced in [ff88e](https://github.com/angular/protractor/blob/ff88e969d55585cc4267d75c12c0cafc78a01895/lib/configParser.js#L101) without breakage.

I decided to use `parse` and `format` from [`path`](https://nodejs.org/api/path.html#path_path) instead of a just a regex because it feels a little safer to me, but please let me know if there's a better/cooler way to do this. 

Caveat: I do not use cucumber, or windows, so I'd appreciate a second pass from someone that does use those tools :)