### PR TITLE
bump source-map-support

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "optimist": "~0.6.0",
     "q": "1.0.0",
     "lodash": "~2.4.1",
-    "source-map-support": "~0.2.6",
+    "source-map-support": "~0.3.2",
     "html-entities": "~1.1.1",
     "accessibility-developer-tools": "~2.6.0"
   },


### PR DESCRIPTION
In order to integrate with the a new version of cucumber-js, need source-map-support to be up to date.
cucumber-js listens for uncaughtException, as does source-map-support. With 0.3.2, source-map-support will not exit on uncaughtException, if there are other listeners.