### PR TITLE
feat(plugins): Add config option to disable logging of warnings in co…

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -408,14 +408,15 @@ This plugin checks the browser log after each test for warnings and errors.  It
 can be configured to fail a test if either is detected.  There is also an
 optional exclude parameter which accepts both regex and strings.  Any log
 matching the exclude parameter will not fail the test or be logged to the
-console.
+console. A false setting to logWarnings also overrides the failOnWarning setting.
 
 ```js
 exports.config = {
   plugins: [{
     path: 'node_modules/protractor/plugins/console',
     failOnWarning: {Boolean}                (Default - false),
-    failOnError: {Boolean}                  (Default - true)
+    failOnError: {Boolean}                  (Default - true),
+    logWarnings: {Boolean}                  (Default - true),
     exclude: {Array of strings and regex}   (Default - [])
   }]
 };

--- a/plugins/console/index.js
+++ b/plugins/console/index.js
@@ -5,13 +5,14 @@ var q = require('q');
  * It can be configured to fail a test if either is detected.  There is also an
  * optional exclude parameter which accepts both regex and strings.  Any log
  * matching the exclude parameter will not fail the test or be logged to the
- * console.
+ * console. A false setting to logWarnings also overrides the failOnWarning setting.
  *
  *    exports.config = {
  *      plugins: [{
  *        path: 'node_modules/protractor/plugins/console',
  *        failOnWarning: {Boolean}                (Default - false),
- *        failOnError: {Boolean}                  (Default - true)
+ *        failOnError: {Boolean}                  (Default - true),
+ *        logWarnings: {Boolean}                  (Default - true),
  *        exclude: {Array of strings and regex}   (Default - [])
  *      }]
  *    };
@@ -76,14 +77,18 @@ ConsolePlugin.parseLog = function(context) {
       context.config.failOnWarning;
   var failOnError = (context.config.failOnError === undefined) ? true :
       context.config.failOnError;
+  var logWarnings = (context.config.logWarnings === undefined) ? true :
+      context.config.logWarnings;
   ConsolePlugin.exclude = context.config.exclude || [];
 
   return ConsolePlugin.getBrowserLog().then(function(log) {
-
-    var warnings = log.filter(function(node) {
-      return (node.level || {}).name === 'WARNING' &&
-          ConsolePlugin.includeLog(node.message);
-    });
+    var warnings = [];
+    if (logWarnings) {
+      warnings = log.filter(function(node) {
+        return (node.level || {}).name === 'WARNING' &&
+            ConsolePlugin.includeLog(node.message);
+      });
+    }
 
     var errors = log.filter(function(node) {
       return (node.level || {}).name === 'SEVERE' &&

--- a/plugins/console/spec/consoleFailLogWarnings.js
+++ b/plugins/console/spec/consoleFailLogWarnings.js
@@ -1,0 +1,14 @@
+var env = require('../../../spec/environment.js');
+
+exports.config = {
+  seleniumAddress: env.seleniumAddress,
+  framework: 'jasmine2',
+  specs: ['fail_warning_spec.js'],
+  baseUrl: env.baseUrl,
+  plugins: [{
+    path: '../index.js',
+    failOnWarning: true,
+    logWarnings: true,
+    failOnError: false
+  }]
+};

--- a/plugins/console/spec/consolePassLogWarnings.js
+++ b/plugins/console/spec/consolePassLogWarnings.js
@@ -1,0 +1,14 @@
+var env = require('../../../spec/environment.js');
+
+exports.config = {
+  seleniumAddress: env.seleniumAddress,
+  framework: 'jasmine2',
+  specs: ['pass_spec.js'],
+  baseUrl: env.baseUrl,
+  plugins: [{
+    path: '../index.js',
+    failOnWarning: true,
+    logWarnings: false,
+    failOnError: false
+  }]
+};

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -46,7 +46,8 @@ passingTests.push(
     'node lib/cli.js plugins/timeline/spec/conf.js',
     'node lib/cli.js plugins/ngHint/spec/successConfig.js',
     'node lib/cli.js plugins/accessibility/spec/successConfig.js',
-    'node lib/cli.js plugins/console/spec/consolePassConfig.js'
+    'node lib/cli.js plugins/console/spec/consolePassConfig.js',
+    'node lib/cli.js plugins/console/spec/consolePassLogWarnings.js'
 );
 
 var executor = new Executor();
@@ -189,6 +190,13 @@ executor.addCommandlineTest(
   .expectExitCode(1)
   .expectErrors([
     {message: 'This is a test error'}
+  ]);
+
+executor.addCommandlineTest(
+  'node lib/cli.js plugins/console/spec/consoleFailLogWarnings.js')
+  .expectExitCode(1)
+  .expectErrors([
+    {message: 'This is a test warning'}
   ]);
 
 executor.execute();


### PR DESCRIPTION
…nsole plugin

Running tests in multiple browsers ends up printing out a lot of useless warnings I'm already aware of. To make skimming through logs in the case of an actual failure easier, I want to be able to disable the logging of warnings in the console plugin.