### PR TITLE
chore(cucumber): allow multiple formatters for cucumber

### DIFF
--- a/lib/frameworks/cucumber.js
+++ b/lib/frameworks/cucumber.js
@@ -46,7 +46,12 @@ exports.run = function(runner, specs) {
     }
 
     // Process Cucumber Format param
-    if (runner.getConfig().cucumberOpts.format) {
+    if (Array.isArray(runner.getConfig().cucumberOpts.format)) {
+      runner.getConfig().cucumberOpts.format.forEach(function (format) {
+        execOptions.push('-f');
+        execOptions.push(format);
+      });
+    } else if (runner.getConfig().cucumberOpts.format) {
       execOptions.push('-f');
       execOptions.push(runner.getConfig().cucumberOpts.format);
     }
@@ -118,12 +123,19 @@ exports.run = function(runner, specs) {
     var originalHandleStepResultEvent = formatter.handleStepResultEvent;
     formatter.handleStepResultEvent = function(event, callback) {
       var stepResult = event.getPayloadItem('stepResult');
-      if (stepResult.isSuccessful()) {
+      var isStepFailed = stepResult.isFailed ?
+        stepResult.isFailed() :
+        stepResult.getStatus() === Cucumber.Status.FAILED;
+      var isStepSuccessful = stepResult.isSuccessful ?
+        stepResult.isSuccessful() :
+        stepResult.getStatus() === Cucumber.Status.PASSED;
+
+      if (isStepSuccessful) {
         stepResults.assertions.push({
           passed: true
         });
         stepResults.duration += stepResult.getDuration();
-      } else if (stepResult.isFailed()) {
+      } else if (isStepFailed) {
         scenarioFailed = true;
         var failureMessage = stepResult.getFailureException();
         stepResults.assertions.push({
@@ -147,9 +159,13 @@ exports.run = function(runner, specs) {
     return q.promise(function(resolve, reject) {
       var cucumberConf = Cucumber.Cli.Configuration(execOptions);
       var runtime = Cucumber.Runtime(cucumberConf);
-      var formatter = cucumberConf.getFormatter();
-      addResultListener(formatter);
-      runtime.attachListener(formatter);
+      var formatters = cucumberConf.getFormatter ?
+        [cucumberConf.getFormatter()] :
+        cucumberConf.getFormatters();
+
+      addResultListener(formatters[0]);
+      formatters.forEach(runtime.attachListener.bind(runtime));
+
       runtime.start(function() {
         try {
           if (runner.getConfig().onComplete) {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "chai-as-promised": "~5.1.0",
     "jshint": "2.5.0",
     "mocha": "2.3.3",
-    "cucumber": "~0.6.0",
+    "cucumber": "~0.8.0",
     "express": "~3.3.4",
     "rimraf": "~2.2.6"
   },


### PR DESCRIPTION
Cucumber added support for multiple formatters in 0.8.0 which changed up
the configuration api that protractor is hooking into. This fixes
protractor for those changes while also allowing multiple formatters
to be specified in the `cucumberOpts`.