### PR TITLE
docs(readme): add instructions for starting selenium

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ Clone the github repository:
     npm install
     cd ..
 
-Start up a selenium server. By default, the tests expect the selenium server to be running at `http://localhost:4444/wd/hub`.
+Start up a selenium server. By default, the tests expect the selenium server to be running at `http://localhost:4444/wd/hub`. A selenium server can be started with `webdriver-manager`.
+
+    bin/webdriver-manager start
 
 Protractor's test suite runs against the included test application. Start that up with
 


### PR DESCRIPTION
Trying to contribute something for the first time it wasn't completely obvious how to start a selenium server for running the tests.