### PR TITLE
feat(config): Add shardTestSuites config option

### DIFF
--- a/lib/taskScheduler.js
+++ b/lib/taskScheduler.js
@@ -4,7 +4,8 @@
  */
 'use strict';
 
-var ConfigParser = require('./configParser');
+var ConfigParser = require('./configParser'),
+    _ = require('lodash');
 
 // A queue of specs for a particular capacity
 var TaskQueue = function(capabilities, specLists) {
@@ -19,7 +20,7 @@ var TaskQueue = function(capabilities, specLists) {
  * A scheduler to keep track of specs that need running and their associated
  * capabilities. It will suggest a task (combination of capabilities and spec)
  * to run while observing the following config rules:
- * multiCapabilities, shardTestFiles, and maxInstance.
+ * multiCapabilities, shardTestFiles, shardTestSuites and maxInstance.
  * Precondition: multiCapabilities is a non-empty array
  * (capabilities and getCapabilities will both be ignored)
  *
@@ -47,7 +48,7 @@ var TaskScheduler = function(config) {
           capabilities.exclude, true, config.configDir);
       capabilitiesSpecs = ConfigParser.resolveFilePatterns(
           capabilitiesSpecs).filter(function(path) {
-              return capabilitiesSpecExcludes.indexOf(path) < 0;
+            return capabilitiesSpecExcludes.indexOf(path) < 0;
           });
     }
 
@@ -59,6 +60,17 @@ var TaskScheduler = function(config) {
       capabilitiesSpecs.forEach(function(spec) {
         specLists.push([spec]);
       });
+    } else if (capabilities.shardTestSuites){
+      var suiteFiles;
+      for (var suite in config.suites) {
+        suiteFiles = config.suites[suite];
+        if (_.isArray(suiteFiles)) {
+          specLists.push(suiteFiles);
+        } else {
+          // Required for suites with only one file.
+          specLists.push([suiteFiles]);
+        }
+      }
     } else {
       specLists.push(capabilitiesSpecs);
     }

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -16,6 +16,7 @@ var passingTests = [
   'node lib/cli.js spec/mochaConf.js',
   'node lib/cli.js spec/cucumberConf.js',
   'node lib/cli.js spec/withLoginConf.js',
+  'node lib/cli.js spec/shardingSuitesConf.js',
   'node lib/cli.js spec/suitesConf.js --suite okmany',
   'node lib/cli.js spec/suitesConf.js --suite okspec',
   'node lib/cli.js spec/suitesConf.js --suite okmany,okspec',

--- a/spec/shardingSuitesConf.js
+++ b/spec/shardingSuitesConf.js
@@ -1,0 +1,35 @@
+// A suite of tests to run on max of two browsers instances at once, splitting test suites between
+// the two instances of chrome.
+var env = require('./environment.js');
+
+exports.config = {
+  seleniumAddress: env.seleniumAddress,
+
+  // Spec patterns are relative to this directory.
+  suites: {
+    okspec: 'spec/suites/ok_spec.js',
+    okstepmodule: ['spec/suites/ok_step_1_spec.js', 'spec/suites/ok_step_2_spec.js']
+  },
+
+  // Exclude patterns are relative to this directory.
+  exclude: [
+    'basic/exclude*.js'
+  ],
+
+  framework: 'jasmine',
+  maxSessions: 2,
+  multiCapabilities: [{
+    'browserName': 'chrome',
+    shardTestSuites: true,
+    maxInstances: 2
+  }],
+
+  baseUrl: env.baseUrl,
+
+  jasmineNodeOpts: {
+    isVerbose: true,
+    showTiming: true,
+    defaultTimeoutInterval: 90000
+  }
+};
+

--- a/spec/suites/ok_step_1_spec.js
+++ b/spec/suites/ok_step_1_spec.js
@@ -1,0 +1,7 @@
+describe('Step 1 from step suite', function() {
+  it('should go to AngularJS homepage', function() {
+	browser.get('http://www.angularjs.org');
+	
+	expect(browser.getCurrentUrl()).toBe('https://www.angularjs.org/');
+  });
+});

--- a/spec/suites/ok_step_2_spec.js
+++ b/spec/suites/ok_step_2_spec.js
@@ -1,0 +1,5 @@
+describe('Step 2 from step suite', function() {
+  it('should be on AngularJS homepage', function() {
+    expect(browser.getCurrentUrl()).toBe('https://www.angularjs.org/');
+  });
+});


### PR DESCRIPTION
Currently the option `shardTestFiles` makes the tests run in parallel but by file, if we have tests that have some dependency on the previous one then this approach does not work.

`shardTestSuites` option will allow to run tests in different instances but grouped by `suite`.

The main goal of this feature is to reduce the time it takes to run tests on big applications that already have tests grouped by `suites`.

I am still testing this approach, but would be nice to have more feedback.

[There is an example of how I am using this feature](https://github.com/BernardoSilva/protractor/blob/add-shard-suite-option/spec/shardingSuitesConf.js).

example to run your suites in two instances:

``` json
maxSessions: 2,
  multiCapabilities: [{
    'browserName': 'chrome',
    shardTestSuites: true,
    maxInstances: 2
  }],
```
