### PR TITLE
add option to log reports to file or custom  logTo function on cucumber

### DIFF
--- a/lib/frameworks/cucumber.js
+++ b/lib/frameworks/cucumber.js
@@ -1,6 +1,34 @@
 var ConfigParser = require('../configParser'),
   q = require('q');
 
+// wrap up configuration to put formatter logs into 
+// specified logTo function
+function Configuration(execOptions,logToFunction) {
+
+  var Cucumber = require('cucumber');
+
+  self = Cucumber.Cli.Configuration(execOptions);
+
+  var originalGetFormatter = self.getFormatter;
+
+  self.getFormatter = function getFormatter() {
+      var formatter = originalGetFormatter();
+
+      var originalLog = formatter.log;
+
+      formatter.log = function(data) {
+        if (logToFunction) {
+          logToFunction(data);
+        }
+        originalLog(data);
+      }
+      return formatter;
+      
+    };
+  return self;
+}
+
+
 /**
  * Execute the Runner's test cases through Cucumber.
  *
@@ -155,9 +183,25 @@ exports.run = function(runner, specs) {
     };
   };
 
+
   return runner.runTestPreparer().then(function() {
     return q.promise(function(resolve, reject) {
-      var cucumberConf = Cucumber.Cli.Configuration(execOptions);
+
+      // set up logReport function to log formatter
+      var logReport;
+
+      if (runner.getConfig().cucumberOpts.logTo) {
+        if(typeof(runner.getConfig().cucumberOpts.logTo) === 'string') {
+          var fs = require('fs');
+          logReport = function(data) {
+            fs.appendFile(runner.getConfig().cucumberOpts.logTo,data);
+          }
+        } else if (typeof(runner.getConfig().cucumberOpts.logTo) === 'function') {
+          logReport = runner.getConfig().cucumberOpts.logTo;
+        }
+      }
+
+      var cucumberConf = Configuration(execOptions,logReport);
       var runtime = Cucumber.Runtime(cucumberConf);
       var formatters = cucumberConf.getFormatter ?
         [cucumberConf.getFormatter()] :

--- a/lib/frameworks/cucumber.js
+++ b/lib/frameworks/cucumber.js
@@ -7,24 +7,43 @@ function Configuration(execOptions,logToFunction) {
 
   var Cucumber = require('cucumber');
 
-  self = Cucumber.Cli.Configuration(execOptions);
+  var self = Cucumber.Cli.Configuration(execOptions);
 
-  var originalGetFormatter = self.getFormatter;
+  var appendLogToFomratter = function(formatter) {
+    var originalLog = formatter.log;
 
-  self.getFormatter = function getFormatter() {
-      var formatter = originalGetFormatter();
-
-      var originalLog = formatter.log;
-
-      formatter.log = function(data) {
-        if (logToFunction) {
-          logToFunction(data);
-        }
-        originalLog(data);
+    formatter.log = function(data) {
+      if (logToFunction) {
+        logToFunction(data);
       }
+      originalLog(data);
+    };
+  };
+
+  if(self.getFormatter) {
+    var originalGetFormatter= self.getFormatter;
+
+    self.getFormatter = function getFormatter() {
+      var formatter = originalGetFormatter();
+      appendLogToFomratter(formatter);
+      
       return formatter;
       
     };
+  } else if(self.getFormatters) {
+    // if multi format
+    var originalGetFormatters= self.getFormatters;
+    self.getFormatters = function getFormatters() {
+      // add logto on the first formatter
+      var formatters = originalGetFormatters();
+
+      appendLogToFomratter(formatters[0]);
+
+      return formatters;
+      
+    };
+  }
+
   return self;
 }
 
@@ -195,13 +214,13 @@ exports.run = function(runner, specs) {
           var fs = require('fs');
           logReport = function(data) {
             fs.appendFile(runner.getConfig().cucumberOpts.logTo,data);
-          }
+          };
         } else if (typeof(runner.getConfig().cucumberOpts.logTo) === 'function') {
           logReport = runner.getConfig().cucumberOpts.logTo;
         }
       }
 
-      var cucumberConf = Configuration(execOptions,logReport);
+      var cucumberConf = new Configuration(execOptions,logReport);
       var runtime = Cucumber.Runtime(cucumberConf);
       var formatters = cucumberConf.getFormatter ?
         [cucumberConf.getFormatter()] :

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -15,6 +15,7 @@ var passingTests = [
   'node lib/cli.js spec/onPreparePromiseFileConf.js',
   'node lib/cli.js spec/mochaConf.js',
   'node lib/cli.js spec/cucumberConf.js',
+  'node node_modules/mocha/bin/mocha spec/cucumber_report_spec.js',
   'node lib/cli.js spec/withLoginConf.js',
   'node lib/cli.js spec/suitesConf.js --suite okmany',
   'node lib/cli.js spec/suitesConf.js --suite okspec',

--- a/spec/cucumber-report/cucumberConfReportFile.js
+++ b/spec/cucumber-report/cucumberConfReportFile.js
@@ -1,0 +1,24 @@
+var env = require('../environment.js');
+
+// A small suite to make sure the cucumber framework works.
+exports.config = {
+  seleniumAddress: env.seleniumAddress,
+
+  framework: 'cucumber',
+
+  // Spec patterns are relative to this directory.
+  specs: [
+    '../cucumber/*.feature'
+  ],
+
+  capabilities: env.capabilities,
+
+  baseUrl: env.baseUrl,
+
+  cucumberOpts: {
+    require: 'cucumber/stepDefinitions.js',
+    tags: '@report',
+    format: 'json',
+    logTo: 'cucumberReport.tmp'
+  }
+};

--- a/spec/cucumber-report/cucumberConfReportFunction.js
+++ b/spec/cucumber-report/cucumberConfReportFunction.js
@@ -1,0 +1,28 @@
+var env = require('../environment.js');
+
+var fs = require('fs');
+
+// A small suite to make sure the cucumber framework works.
+exports.config = {
+  seleniumAddress: env.seleniumAddress,
+
+  framework: 'cucumber',
+
+  // Spec patterns are relative to this directory.
+  specs: [
+    '../cucumber/*.feature'
+  ],
+
+  capabilities: env.capabilities,
+
+  baseUrl: env.baseUrl,
+
+  cucumberOpts: {
+    require: 'cucumber/stepDefinitions.js',
+    tags: '@report',
+    format: 'json',
+    logTo: function(data) {
+            fs.appendFile('cucumberReportFunc.tmp',data);
+          }
+  }
+};

--- a/spec/cucumber-report/cucumber_report_spec.js
+++ b/spec/cucumber-report/cucumber_report_spec.js
@@ -14,7 +14,6 @@ var expect = chai.expect;
 
 function spawnCucumberTests(configFile) {
   return q.promise(function(resolve, reject) {
-      console.log('launching cucumner')
     
       var output = '';
       var test_process;

--- a/spec/cucumber-report/cucumber_report_spec.js
+++ b/spec/cucumber-report/cucumber_report_spec.js
@@ -1,0 +1,76 @@
+// Use the external Chai As Promised to deal with resolving promises in
+// expectations.
+var chai = require('chai');
+var chaiAsPromised = require('chai-as-promised');
+chai.use(chaiAsPromised);
+
+var child_process = require('child_process'),
+    q = require('q'),
+    fs = require('fs');
+
+
+
+var expect = chai.expect;
+
+function spawnCucumberTests(configFile) {
+  return q.promise(function(resolve, reject) {
+      console.log('launching cucumner')
+    
+      var output = '';
+      var test_process;
+      test_process = child_process.spawn('node',['lib/cli.js',configFile]);
+
+   
+      test_process.on('error', function(err) {
+        reject(err);
+      });
+
+      test_process.on('exit', function(exitCode) {
+        resolve(exitCode);
+      });
+    });
+}
+
+// Chai's expect().to.exist style makes default jshint unhappy.
+// jshint expr:true
+
+describe('generate reports for cucumber', function() {
+  
+
+  it('should generate a report in the specified file', function(done) {
+
+    this.timeout(10000);
+    var cucumberTestProcess = spawnCucumberTests('spec/cucumber-report/cucumberConfReportFile.js');
+    expect(cucumberTestProcess).to.eventually.equal(0).then(function() {
+      console.log('now check file');
+      return expect(q.promise(function(resolve,reject)
+        { 
+          fs.exists('cucumberReport.tmp',resolve);
+        }
+        )).to.eventually.be.true;
+    }).then(function(){
+       console.log('now deleting file');
+       return q.promise(function(resolve,reject) { fs.unlink('cucumberReport.tmp',resolve); });
+    }).then(done,done);
+    
+  });
+
+  it('should generate a report in the specified logTo function', function(done) {
+
+    this.timeout(10000);
+    var cucumberTestProcess = spawnCucumberTests('spec/cucumber-report/cucumberConfReportFunction.js');
+    expect(cucumberTestProcess).to.eventually.equal(0).then(function() {
+      console.log('now check file');
+      return expect(q.promise(function(resolve,reject)
+        { 
+          fs.exists('cucumberReportFunc.tmp',resolve);
+        }
+        )).to.eventually.be.true;
+    }).then(function(){
+       console.log('now deleting file');
+       return q.promise(function(resolve,reject) { fs.unlink('cucumberReportFunc.tmp',resolve); });
+    }).then(done,done);
+    
+  });
+
+});

--- a/spec/cucumber/lib.feature
+++ b/spec/cucumber/lib.feature
@@ -9,7 +9,7 @@ Feature: Running Cucumber with Protractor
     Then it should still do normal tests
     Then it should expose the correct global variables
 
-  @dev
+  @dev @report
   Scenario: Wrapping WebDriver
     Given I go on "index.html"
     Then the title should equal "My AngularJS App"


### PR DESCRIPTION
Add an option on cucumber framework to log reports to a file or a custom loTo function.
This is helpfull to write json reports in a file for use in jenkins (https://github.com/cucumber/cucumber-js/issues/90).