### PR TITLE
make restart() available on browser instance

### DIFF
--- a/lib/protractor.js
+++ b/lib/protractor.js
@@ -267,6 +267,12 @@ Protractor.prototype.getProcessedConfig = null;
  */
 Protractor.prototype.forkNewDriverInstance = null;
 
+/**
+ * Restart the browser instance.
+ *
+ * Set by the runner.
+ */
+Protractor.prototype.restart = null;
 
 /**
  * Instead of using a single root element, search through all angular apps

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -223,6 +223,16 @@ Runner.prototype.createBrowser = function(plugins) {
     }
     return newBrowser;
   };
+
+  browser_.restart = function() {
+    // Note: because tests are not paused at this point, any async
+    // calls here are not guaranteed to complete before the tests resume.
+    self.driverprovider_.quitDriver(browser_.driver);
+    // Copy mock modules, but do not navigate to previous URL.
+    browser_ = browser_.forkNewDriverInstance(false, true);
+    self.setupGlobals_(browser_);
+  };
+
   return browser_;
 };
 
@@ -304,14 +314,8 @@ Runner.prototype.run = function() {
 
     if (self.config_.restartBrowserBetweenTests) {
       var restartDriver = function() {
-        // Note: because tests are not paused at this point, any async
-        // calls here are not guaranteed to complete before the tests resume.
-        self.driverprovider_.quitDriver(browser_.driver);
-        // Copy mock modules, but do not navigate to previous URL.
-        browser_ = browser_.forkNewDriverInstance(false, true);
-        self.setupGlobals_(browser_);
+        browser_.restart();
       };
-
       self.on('testPass', restartDriver);
       self.on('testFail', restartDriver);
     }


### PR DESCRIPTION
A shame to have such a useful function buried in a private scope.  Closes #1696
Allows usage in beforeAll() to close  #1785 and a more general solution to #1435 