### PR TITLE
fix(ci): Install g++ 4.8 on Travis to prevent compilation errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
     - BROWSER_STACK_ACCESS_KEY=BWCd4SynLzdDcv8xtzsB
     - LOGS_DIR=/tmp/protractor-build/logs
     - BROWSER_PROVIDER_READY_FILE=/tmp/sauce-connect-ready
+    - CXX=g++-4.8
   matrix:
     - JOB=full
     - JOB=smoke
@@ -27,6 +28,15 @@ matrix:
     - env: JOB=bstack
       node_js: "5"
 
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
+
+before_install:
+  - g++-4.8 --version
 
 before_script:
   - npm run pretest


### PR DESCRIPTION
Node.js 4 and newer require g++ newer than the one included in Travis by
default. Using the default g++ causes `npm install` to fail on compiled
dependencies - currently every such dependency of Protractor is optional
so the whole build doesn't fail but it still causes errors & excessive
logging.

If the number of compiled dependencies grows, install logs might become so
big that Travis stops - Karma has been hit by this problem recently.

Refs karma-runner/karma#1672