### PR TITLE
chore(configParser): allow non-glob file pattern

### DIFF
--- a/lib/configParser.js
+++ b/lib/configParser.js
@@ -95,7 +95,7 @@ ConfigParser.resolveFilePatterns =
   if (patterns) {
     for (var i = 0; i < patterns.length; ++i) {
       var fileName = patterns[i];
-      var matches = glob.sync(fileName, {cwd: cwd});
+      var matches = glob.hasMagic(fileName) ? glob.sync(fileName, {cwd: cwd}) : [fileName];
 
       if (!matches.length && !opt_omitWarnings) {
         log.warn('pattern ' + patterns[i] + ' did not match any files.');

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "jasminewd2": "0.0.6",
     "jasmine": "2.3.2",
     "saucelabs": "~1.0.1",
-    "glob": "~3.2",
+    "glob": "~5.0",
     "adm-zip": "0.4.4",
     "optimist": "~0.6.0",
     "q": "1.0.0",

--- a/spec/unit/config_test.js
+++ b/spec/unit/config_test.js
@@ -62,5 +62,15 @@ describe('the config parser', function() {
       expect(specs[0].indexOf(path.normalize('unit/data/fakespecA.js'))).not.toEqual(-1);
       expect(specs[1].indexOf(path.normalize('unit/data/fakespecB.js'))).not.toEqual(-1);
     });
+
+    it('should not try to expand non-glob patterns', function() {
+      var toAdd = {
+        specs: 'data/fakespecA.js:5'
+      };
+      var config = new ConfigParser().addConfig(toAdd).getConfig();
+      var specs = ConfigParser.resolveFilePatterns(config.specs);
+      expect(specs.length).toEqual(1);
+      expect(specs[0].indexOf(path.normalize('data/fakespecA.js:5'))).not.toEqual(-1);
+    });
   });
 });


### PR DESCRIPTION
re: the conversation at https://github.com/angular/protractor/pull/2445#issuecomment-159019360

Cucumber allows line numbers to be passed in the filename in the
form of `features/some.feature:42`. Glob expanding that results in
an empty array and nothing being passed to the framework runner.
This change checks for glob magic characters and only tries expanding
it if found. Otherwise it just passes the filename verbatim.
This was previously handled in #2445 by stripping the line number
first, but this is a more generic (non-cucumber) way to do it.