### PR TITLE
chore(configParser): allow non-glob file pattern

### DIFF
--- a/lib/configParser.ts
+++ b/lib/configParser.ts
@@ -117,7 +117,7 @@ export class ConfigParser {
 
     if (patterns) {
       for (let fileName of patterns) {
-        let matches = glob.sync(fileName, {cwd});
+        let matches = glob.hasMagic(fileName) ? glob.sync(fileName, {cwd}) : [fileName];
         if (!matches.length && !opt_omitWarnings) {
           logger.warn('pattern ' + fileName + ' did not match any files.');
         }

--- a/spec/unit/configParser_test.js
+++ b/spec/unit/configParser_test.js
@@ -129,5 +129,15 @@ describe('the config parser', function() {
       expect(specs[0].indexOf(path.normalize('unit/data/fakespecA.js'))).not.toEqual(-1);
       expect(specs[1].indexOf(path.normalize('unit/data/fakespecB.js'))).not.toEqual(-1);
     });
+
+    it('should not try to expand non-glob patterns', function() {
+      var toAdd = {
+        specs: 'data/fakespecA.js:5'
+      };
+      var config = new ConfigParser().addConfig(toAdd).getConfig();
+      var specs = ConfigParser.resolveFilePatterns(config.specs);
+      expect(specs.length).toEqual(1);
+      expect(specs[0].indexOf(path.normalize('data/fakespecA.js:5'))).not.toEqual(-1);
+    });
   });
 });


### PR DESCRIPTION
Cucumber allows line numbers to be passed in the filename in the
form of `features/some.feature:42`. Glob expanding that results in
an empty array and nothing being passed to the framework runner.
This change checks for glob magic characters and only tries expanding
it if found. Otherwise it just passes the filename verbatim.
This was previously handled in [#2445] by stripping the line number
first, but this is a more generic (non-cucumber) way to do it.

Glob needed to be upgraded for this which resulted in a weird [npm 3
bug](https://github.com/npm/npm/issues/10637). Removing the rimraf
package resolved this. It was only used to generate documentation
which itself was removed a while ago.