### PR TITLE
driverProviders/direct.js: fix driver path generation for *nix platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Protractor [![Build Status](https://travis-ci.org/angular/protractor.png?branch=master)](https://travis-ci.org/angular/protractor)
 ==========
 
-[Protractor](http://angular.github.io/protractor) is an end-to-end test framework for [AngularJS](http://angularjs.org/) applications. Protractor is a [Node.js](http://nodejs.org/) program built on top of [WebDriverJS](https://github.com/SeleniumHQ/selenium/wiki/WebDriverJs). Protractor runs tests against your application running in a real browser, interacting with it as a user would. 
+[Protractor](http://angular.github.io/protractor) is an end-to-end test framework for [AngularJS](http://angularjs.org/) applications. Protractor is a [Node.js](http://nodejs.org/) program built on top of [WebDriverJS](https://github.com/SeleniumHQ/selenium/wiki/WebDriverJs). Protractor runs tests against your application running in a real browser, interacting with it as a user would.
 
 
 Getting Started
@@ -42,6 +42,7 @@ Clone the github repository:
     git clone https://github.com/angular/protractor.git
     cd protractor
     npm install
+    ./bin/webdriver-manager update
     cd website
     npm install
     cd ..

--- a/lib/driverProviders/direct.js
+++ b/lib/driverProviders/direct.js
@@ -51,17 +51,16 @@ DirectDriverProvider.prototype.getNewDriver = function() {
   var driver;
   switch (this.config_.capabilities.browserName) {
     case 'chrome':
-      var chromeDriverFile = this.config_.chromeDriver ||
-          path.resolve(__dirname, '../../selenium/chromedriver');
+      var defaultChromeDriverPath = path.resolve(__dirname, '../../selenium/chromedriver');
 
-      // Check if file exists, if not try .exe or fail accordingly
+      if (process.platform.indexOf('win') === 0) {
+        defaultChromeDriverPath += '.exe';
+      }
+
+      var chromeDriverFile = this.config_.chromeDriver || defaultChromeDriverPath;
+
       if (!fs.existsSync(chromeDriverFile)) {
-        chromeDriverFile += '.exe';
-        // Throw error if the client specified conf chromedriver and its not found
-        if (!fs.existsSync(chromeDriverFile)) {
-          throw new Error('Could not find chromedriver at ' +
-            chromeDriverFile);
-        }
+        throw new Error('Could not find chromedriver at ' + chromeDriverFile);
       }
 
       var service = new chrome.ServiceBuilder(chromeDriverFile).build();


### PR DESCRIPTION
I was trying to run protractor tests locally on mac os, but was having error messages that `selenium/chromedriver.exe` not found. Very confusing. Hopefully this change would make it more clearer.