### PR TITLE
chore(style): Add "curly" rule to jshintrc

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -17,5 +17,6 @@
   "sub": true,
   "undef": true,
   "quotmark": "single",
-  "evil": true
+  "evil": true,
+  "curly": true
 }


### PR DESCRIPTION
This adds the curly option which I noticed was not being properly caught in CI. 

As a side note, how would we feel about switching to eslint and using the [google eslint config](https://github.com/google/eslint-config-google) module for style definitions? I'd be happy to do that work.