### PR TITLE
Possibility to disable WebDriver's environment variables overrides functionality

### DIFF
--- a/docs/referenceConf.js
+++ b/docs/referenceConf.js
@@ -336,5 +336,9 @@ exports.config = {
 
   // Turns off source map support.  Stops protractor from registering global
   // variable `source-map-support`.  Defaults to `false`
-  skipSourceMapSupport: false
+  skipSourceMapSupport: false,
+
+  // Turns off WebDriver's environment variables overrides to ignore any
+  // environment variable and to only use the configuration in this file.
+  environmentOverrides: false
 };

--- a/docs/referenceConf.js
+++ b/docs/referenceConf.js
@@ -340,6 +340,6 @@ exports.config = {
 
   // Turns off WebDriver's environment variables overrides to ignore any
   // environment variable and to only use the configuration in this file.
-  // Defaults to `true`
-  environmentOverrides: true
+  // Defaults to `false`
+  disableEnvironmentOverrides: false
 };

--- a/docs/referenceConf.js
+++ b/docs/referenceConf.js
@@ -340,5 +340,6 @@ exports.config = {
 
   // Turns off WebDriver's environment variables overrides to ignore any
   // environment variable and to only use the configuration in this file.
-  environmentOverrides: false
+  // Defaults to `true`
+  environmentOverrides: true
 };

--- a/lib/driverProviders/driverProvider.js
+++ b/lib/driverProviders/driverProvider.js
@@ -36,7 +36,8 @@ DriverProvider.prototype.getNewDriver = function() {
   var builder = new webdriver.Builder().
     usingServer(this.config_.seleniumAddress).
     withCapabilities(this.config_.capabilities);
-  if (!_.isUndefined(this.config_.environmentOverrides) && this.config_.environmentOverrides === false) {
+  if (!_.isUndefined(this.config_.environmentOverrides)
+      && this.config_.environmentOverrides === false) {
     builder.disableEnvironmentOverrides();
   }
   var newDriver = builder.build();

--- a/lib/driverProviders/driverProvider.js
+++ b/lib/driverProviders/driverProvider.js
@@ -36,8 +36,7 @@ DriverProvider.prototype.getNewDriver = function() {
   var builder = new webdriver.Builder().
     usingServer(this.config_.seleniumAddress).
     withCapabilities(this.config_.capabilities);
-  if (!_.isUndefined(this.config_.environmentOverrides)
-      && this.config_.environmentOverrides === false) {
+  if (this.config_.environmentOverrides === false) {
     builder.disableEnvironmentOverrides();
   }
   var newDriver = builder.build();

--- a/lib/driverProviders/driverProvider.js
+++ b/lib/driverProviders/driverProvider.js
@@ -5,6 +5,7 @@
  */
 
 var webdriver = require('selenium-webdriver'),
+    _ = require('lodash'),
     q = require('q');
 
 
@@ -32,10 +33,13 @@ DriverProvider.prototype.getExistingDrivers = function() {
  * @return webdriver instance
  */
 DriverProvider.prototype.getNewDriver = function() {
-  var newDriver = new webdriver.Builder().
-      usingServer(this.config_.seleniumAddress).
-      withCapabilities(this.config_.capabilities).
-      build();
+  var builder = new webdriver.Builder().
+    usingServer(this.config_.seleniumAddress).
+    withCapabilities(this.config_.capabilities);
+  if (!_.isUndefined(this.config_.environmentOverrides) && this.config_.environmentOverrides === false) {
+    builder.disableEnvironmentOverrides();
+  }
+  var newDriver = builder.build();
   this.drivers_.push(newDriver);
   return newDriver;
 };

--- a/lib/driverProviders/driverProvider.js
+++ b/lib/driverProviders/driverProvider.js
@@ -5,7 +5,6 @@
  */
 
 var webdriver = require('selenium-webdriver'),
-    _ = require('lodash'),
     q = require('q');
 
 

--- a/lib/driverProviders/driverProvider.js
+++ b/lib/driverProviders/driverProvider.js
@@ -35,7 +35,7 @@ DriverProvider.prototype.getNewDriver = function() {
   var builder = new webdriver.Builder().
     usingServer(this.config_.seleniumAddress).
     withCapabilities(this.config_.capabilities);
-  if (this.config_.environmentOverrides === false) {
+  if (this.config_.disableEnvironmentOverrides === true) {
     builder.disableEnvironmentOverrides();
   }
   var newDriver = builder.build();


### PR DESCRIPTION
I spent few days fighting with capabilities issues (especially, with platform part of it) and this issues forced me to investigate Protractors and later WebDriver's source code.

Unfortunately, i am one of that stupid (or unlucky) person, who named one of his environment variables "SELENIUM_BROWSER". As a result, from the logs of selenium hub i found that Capabilities object didn't contain a "platform" field.

My investigation led me to this part of WebDriver's code base: http://selenium.googlecode.com/git/docs/api/javascript/source/builder.js.src.html#l368

Looks like, no matter what value you specify in your "capabilities" object, it will not be used and overridden by parsed values from "SELENIUM_BROWSER" environment variable.

One of the possible solutions is, of course, to rename the variable, but in my case this caused a lot of buthurt trying to understand the exact reason.

Looks like, some of Selenium users already had that issue that's why this method is introduced in WebDriver: http://selenium.googlecode.com/git/docs/api/javascript/source/builder.js.src.html#l124

*My pull request is quiet simple. I propose to give Protractor user's a chance to enable / disable this "environment variable overrides" feature*