### PR TITLE
chore(README): Add gitter badge and info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Protractor [![Build Status](https://travis-ci.org/angular/protractor.png?branch=master)](https://travis-ci.org/angular/protractor)
+Protractor [![Build Status](https://travis-ci.org/angular/protractor.png?branch=master)](https://travis-ci.org/angular/protractor) [![Join the chat at https://gitter.im/angular/protractor](https://badges.gitter.im/angular/protractor.svg)](https://gitter.im/angular/protractor)
 ==========
 
 [Protractor](http://angular.github.io/protractor) is an end-to-end test framework for [AngularJS](http://angularjs.org/) applications. Protractor is a [Node.js](http://nodejs.org/) program built on top of [WebDriverJS](https://github.com/SeleniumHQ/selenium/wiki/WebDriverJs). Protractor runs tests against your application running in a real browser, interacting with it as a user would. 
@@ -22,17 +22,9 @@ To better understand how Protractor works with the Selenium WebDriver and Seleni
 Getting Help
 ------------
 
-Check the
-[Protractor FAQ](https://github.com/angular/protractor/blob/master/docs/faq.md)
-and read through
-the [Top 20 questions on StackOverflow](http://stackoverflow.com/questions/tagged/protractor?sort=votes&pageSize=20).
+Check the [Protractor FAQ](https://github.com/angular/protractor/blob/master/docs/faq.md) and read through the [Top 20 questions on StackOverflow](http://stackoverflow.com/questions/tagged/protractor?sort=votes&pageSize=20).
 
-Please ask usage and debugging questions on
-[StackOverflow](http://stackoverflow.com/questions/tagged/protractor) (use
-the "protractor" tag)
-or in the
-[Angular discussion group](https://groups.google.com/forum/?fromgroups#!forum/angular).
-(Please do not ask support questions here on Github.)
+Please ask usage and debugging questions on [StackOverflow](http://stackoverflow.com/questions/tagged/protractor) (use the ["protractor"](http://stackoverflow.com/questions/ask?tags=protractor) tag), the [Gitter](https://gitter.im/angular/protractor) chat room, or in the [Angular discussion group](https://groups.google.com/forum/?fromgroups#!forum/angular). (Please do not ask support questions here on Github.)
 
 
 For Contributors


### PR DESCRIPTION
This adds Gitter information to the README and includes two aesthetic changes:

1. Removing the line breaks in the "Getting Help" section. We seem to be okay with wrapping elsewhere in the document and I think it reads easier :)
2. Adds a link to StackOverflow's "ask a question" page with the "protractor" tag pre-filled.

I'd be happy to roll back any/all of these if they are out of bounds. Thanks!