### PR TITLE
Fix launcher.js typo from capabilites to capabilities

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -119,7 +119,7 @@ var init = function(configFile, additionalConfig) {
       if (config.getMultiCapabilities &&
           typeof config.getMultiCapabilities === 'function') {
         if (config.multiCapabilities.length || config.capabilities) {
-          log.warn('getMultiCapabilities() will override both capabilites ' +
+          log.warn('getMultiCapabilities() will override both capabilities ' +
                   'and multiCapabilities');
         }
         // If getMultiCapabilities is defined and a function, use this.
@@ -131,11 +131,11 @@ var init = function(configFile, additionalConfig) {
         resolve();
       }
     }).then(function() {
-      // 2) Set `multicapabilities` using `capabilities`, `multicapabilites`,
+      // 2) Set `multicapabilities` using `capabilities`, `multicapabilities`,
       // or default
       if (config.capabilities) {
         if (config.multiCapabilities.length) {
-          log.warn('You have specified both capabilites and ' +
+          log.warn('You have specified both capabilities and ' +
               'multiCapabilities. This will result in capabilities being ' +
               'ignored');
         } else {


### PR DESCRIPTION
Noticed this while Googling an error message and seeing that
Google recommended the correct spelling.