### PR TITLE
 Add a slice method to ElementArrayFinder

### DIFF
--- a/lib/element.js
+++ b/lib/element.js
@@ -161,6 +161,100 @@ ElementArrayFinder.prototype.all = function(locator) {
 };
 
 /**
+ * Get a slice of elements within the ElementArrayFinder.
+ * Negative indices are wrapped (i.e. -i means ith element from last)
+ * This does not actually retrieve the underlying element.
+ *
+ * Slice can be negative in which case we go backwards.
+ *
+ * Note that if step is positive and start > stop, an error is thrown
+ * Note that if step is negative and start < stop, an error is thrown
+ * Note that slice(null,null,-1) will NOT produce a reversed array - use reverse() on the result instead.
+ *
+ * @view
+ * <ul class="items">
+ *   <li>Zeroth</li>
+ *   <li>First</li>
+ *   <li>Second</li>
+ *   <li>Third</li>
+ *   <li>Fourth</li>
+ *   <li>Fifth</li>
+ *   <li>Sixth</li>
+ *   <li>Seventh</li>
+ * </ul>
+ *
+ * @example
+ * var list = element.all(by.css('.items li'));
+ *
+ * expect(element.all(locator).slice(1,4).getText()).toEqual(['First','Second','Third']);
+ * expect(element.all(locator).slice(6).getText()).toEqual(['Sixth','Seventh']);
+ * expect(element.all(locator).slice(-1,-5,-2).getText()).toEqual(['Seventh','Fifth']);
+ *
+ * @param {sliceStart} start of the slice. Defaults to 0.
+ * @param {sliceStop} end of the slice(not included). Defaults to last element.
+ * @param {sliceStep} The jump. Defaults to 1.
+ * @return {ElementArrayFinder} finder representing sliced elements
+ */
+ElementArrayFinder.prototype.slice = function (sliceStart,sliceStop,sliceStep) {
+  var self = this;
+
+  var getWebElements = function () {
+    return self.getWebElements().then(function (parentWebElements) {
+      var start = (sliceStart === undefined || sliceStart === null) ? 0 : sliceStart;
+      var stop = (sliceStop === undefined || sliceStop === null) ? parentWebElements.length : sliceStop;
+      var step = (sliceStep === undefined || sliceStep === null || sliceStep === 0) ? 1 : sliceStep;
+
+      if (start < 0) {
+        // wrap negative indices
+        start = parentWebElements.length + start;
+      }
+      if (stop < 0) {
+        // wrap negative indices
+        stop = parentWebElements.length + stop;
+      }
+      if (start > parentWebElements.length) {
+        throw new Error('Start ' + start + ' > result length ' + parentWebElements.length);
+      }
+      if (stop > parentWebElements.length) {
+        throw new Error('Stop ' + stop + ' > result length ' + parentWebElements.length);
+      }
+
+      var list = [];
+      var lt = function (x, y) {
+        return x < y;
+      };
+      var gt = function (x, y) {
+        return x > y;
+      };
+      var compare = lt;
+
+      if (step < 0) {
+        compare = gt;
+        // If step is negative and start is less than stop, error out.
+        if (start < stop) {
+          throw new Error('Start ' + start + ' < Stop ' + stop + ' for negative step value : ' + step);
+        }
+      } else {
+        // If step is positive and start is greater than stop, error out.
+        if (start > stop) {
+          throw new Error('Start ' + start + ' > Stop ' + stop + ' for positive step value: ' + step);
+        }
+      }
+
+      var current = start;
+      while (compare(current, stop)) {
+        list.push(parentWebElements[current]);
+        current += step;
+      }
+
+      return list;
+    });
+  };
+
+  return new ElementArrayFinder(this.ptor_, getWebElements, this.locator_);
+};
+
+/**
  * Apply a filter function to each element within the ElementArrayFinder. Returns
  * a new ElementArrayFinder with all elements that pass the filter function. The
  * filter function receives the ElementFinder as the first argument


### PR DESCRIPTION
 Currently, we have no way of taking a slice of all elements of an ElementArrayFinder. The slicing syntax is modelled after the slice syntax in python. ie : start defaults to 0, stop defaults to one past the last element in the array and step defaults to 1.