### PR TITLE
Allow binding to loopback address

### DIFF
--- a/docs/referenceConf.js
+++ b/docs/referenceConf.js
@@ -38,6 +38,10 @@ exports.config = {
   // seleniumArgs: ['-browserTimeout=60']
   // Ignored if seleniumServerJar is null.
   seleniumArgs: [],
+  // If you set this option to true, the started server will listen on 127.0.0.1.
+  // If it's set to false or not set at all it will listen to the ip address in your
+  // local network (e.g. 192.168.0.10).
+  seleniumUseLoopback: false,
   // ChromeDriver location is used to help find the chromedriver binary.
   // This will be passed to the Selenium jar as the system property
   // webdriver.chrome.driver. If null, Selenium will

--- a/docs/referenceConf.js
+++ b/docs/referenceConf.js
@@ -38,10 +38,10 @@ exports.config = {
   // seleniumArgs: ['-browserTimeout=60']
   // Ignored if seleniumServerJar is null.
   seleniumArgs: [],
-  // If you set this option to true, the started server will listen on 127.0.0.1.
-  // If it's set to false or not set at all it will listen to the ip address in your
-  // local network (e.g. 192.168.0.10).
-  seleniumUseLoopback: false,
+  // Can be an object which will be passed to the SeleniumServer class as args.
+  // If you specify `args` or `port` in this object, it will overwrite the values
+  // set via `seleniumPort` and `seleniumArgs`.
+  localSeleniumStandaloneOpts: null,
   // ChromeDriver location is used to help find the chromedriver binary.
   // This will be passed to the Selenium jar as the system property
   // webdriver.chrome.driver. If null, Selenium will

--- a/docs/server-setup.md
+++ b/docs/server-setup.md
@@ -49,6 +49,9 @@ To start the standalone Selenium Server from within your test script, set these 
 
  - `seleniumArgs` -  Array of command line options to pass to the server. For a full list, start the server with the `-help` flag.
 
+ - `seleniumUseLoopback` - Listen on 127.0.0.1 if set to true. If not specified or set to false,
+ use your ip address in your current local network (e.g. 192.168.0.10).
+
 **Connecting to a Running Server**
 
 To connect to a running instance of a standalone Selenium Server, set this option:

--- a/docs/server-setup.md
+++ b/docs/server-setup.md
@@ -49,9 +49,6 @@ To start the standalone Selenium Server from within your test script, set these 
 
  - `seleniumArgs` -  Array of command line options to pass to the server. For a full list, start the server with the `-help` flag.
 
- - `seleniumUseLoopback` - Listen on 127.0.0.1 if set to true. If not specified or set to false,
- use your ip address in your current local network (e.g. 192.168.0.10).
-
 **Connecting to a Running Server**
 
 To connect to a running instance of a standalone Selenium Server, set this option:

--- a/lib/driverProviders/local.js
+++ b/lib/driverProviders/local.js
@@ -79,7 +79,8 @@ LocalDriverProvider.prototype.setupEnv = function() {
   }
   this.server_ = new remote.SeleniumServer(this.config_.seleniumServerJar, {
       args: this.config_.seleniumArgs,
-      port: this.config_.seleniumPort
+      port: this.config_.seleniumPort,
+      loopback: !!this.config_.seleniumUseLoopback
     });
 
   //start local server, grab hosted address, and resolve promise

--- a/lib/driverProviders/local.js
+++ b/lib/driverProviders/local.js
@@ -72,16 +72,24 @@ LocalDriverProvider.prototype.setupEnv = function() {
 
   log.puts('Starting selenium standalone server...');
 
+  var serverConf = this.config_.localSeleniumStandaloneOpts || {};
+
+  // If args or port is not set use seleniumArgs and seleniumPort
+  // for backward compatibility
+  if (serverConf.args === undefined) {
+    serverConf.args = this.config_.seleniumArgs || [];
+  }
+  if (serverConf.port === undefined) {
+    serverConf.port = this.config_.seleniumPort;
+  }
+
   // configure server
   if (this.config_.chromeDriver) {
-    this.config_.seleniumArgs.push('-Dwebdriver.chrome.driver=' +
+    serverConf.args.push('-Dwebdriver.chrome.driver=' +
       this.config_.chromeDriver);
   }
-  this.server_ = new remote.SeleniumServer(this.config_.seleniumServerJar, {
-      args: this.config_.seleniumArgs,
-      port: this.config_.seleniumPort,
-      loopback: !!this.config_.seleniumUseLoopback
-    });
+
+  this.server_ = new remote.SeleniumServer(this.config_.seleniumServerJar, serverConf);
 
   //start local server, grab hosted address, and resolve promise
   this.server_.start().then(function(url) {


### PR DESCRIPTION
Implements what was asked for in #2605 

With an additional (optional) option `seleniumUseLoopback` selenium will bind to `127.0.0.1` instead of your current network ip (e.g. `192.168.0.10`).

The default for that option is false to not introduce any changes (even though they most likely wouldn't break anything).

This is useful especially in situations where you might use some VPN like let's say Ciscos AnyConnect, which forbids connections to your computer via your current network ip, but would allow connecting to localhost/127.0.0.1. Without that we currently unfortunately cannot run End2End tests via protractor when working remote.

Unfortunately I wasn't able to run the tests (`npm start` and `npm test`) without nearly all of them failing. Perhaps if this flag should have a test, someone would be so kind and write one, or give me some additional help, why my tests might not be working (and where the best place for that test would be).