### PR TITLE
feat(webdriver): add support for selenium webdriver proxy

### DIFF
--- a/docs/referenceConf.js
+++ b/docs/referenceConf.js
@@ -49,6 +49,10 @@ exports.config = {
   // connect to an already running instance of Selenium. This usually looks like
   // seleniumAddress: 'http://localhost:4444/wd/hub'
   seleniumAddress: null,
+  // The address of a proxy server to use for the connection to the
+  // Selenium Server. If not specified no proxy is configured. Looks like
+  // webDriverProxy: 'http://localhost:3128'
+  webDriverProxy: null,
 
   // ---- 3. To use remote browsers via Sauce Labs -----------------------------
   // If sauceUser and sauceKey are specified, seleniumServerJar will be ignored.

--- a/lib/driverProviders/driverProvider.js
+++ b/lib/driverProviders/driverProvider.js
@@ -34,6 +34,7 @@ DriverProvider.prototype.getExistingDrivers = function() {
 DriverProvider.prototype.getNewDriver = function() {
   var builder = new webdriver.Builder().
     usingServer(this.config_.seleniumAddress).
+    usingWebDriverProxy(this.config_.seleniumProxy).
     withCapabilities(this.config_.capabilities);
   if (this.config_.disableEnvironmentOverrides === true) {
     builder.disableEnvironmentOverrides();

--- a/lib/driverProviders/driverProvider.js
+++ b/lib/driverProviders/driverProvider.js
@@ -34,7 +34,7 @@ DriverProvider.prototype.getExistingDrivers = function() {
 DriverProvider.prototype.getNewDriver = function() {
   var builder = new webdriver.Builder().
     usingServer(this.config_.seleniumAddress).
-    usingWebDriverProxy(this.config_.seleniumProxy).
+    usingWebDriverProxy(this.config_.webDriverProxy).
     withCapabilities(this.config_.capabilities);
   if (this.config_.disableEnvironmentOverrides === true) {
     builder.disableEnvironmentOverrides();


### PR DESCRIPTION
Allows the configuration of a proxy by using selenium webdriver `Builder#usingWebDriverProxy()` (was added with [v2.46.0](https://github.com/SeleniumHQ/selenium/blob/master/javascript/node/selenium-webdriver/CHANGES.md#v2460)).

This is useful when you sit behind a corporate proxy and you need to connect to a remote webdriver server (e.g. BrowserStack).

There is also an issue related to it #2345.