### PR TITLE
feat(element): Add $x and $$x shortcuts for xpath selectors

### DIFF
--- a/lib/element.js
+++ b/lib/element.js
@@ -308,6 +308,15 @@ ElementArrayFinder.prototype.$$ = function(selector) {
 };
 
 /**
+ * Shorthand function for finding arrays of elements by XPath.
+ *
+ * @type {function(string): ElementArrayFinder}
+ */
+ElementArrayFinder.prototype.$$x = function(selector) {
+  return this.all(webdriver.By.xpath(selector));
+};
+
+/**
  * Returns an ElementFinder representation of ElementArrayFinder. It ensures
  * that the ElementArrayFinder resolves to one and only one underlying element.
  *
@@ -867,6 +876,58 @@ ElementFinder.prototype.$ = function(selector) {
 };
 
 /**
+ * Calls to {@code $$x} may be chained to find an array of elements within a
+ * parent.
+ *
+ * @alias element(locator).all(selector)
+ * @view
+ * <div class="parent">
+ *   <ul>
+ *     <li class="one">First</li>
+ *     <li class="two">Second</li>
+ *     <li class="three">Third</li>
+ *   </ul>
+ * </div>
+ *
+ * @example
+ * var items = element(by.css('.parent')).$$x('.//li')
+ *
+ * @param {string} selector a css selector
+ * @return {ElementArrayFinder}
+ */
+ElementFinder.prototype.$$x = function(selector) {
+  return this.all(webdriver.By.xpath(selector));
+};
+
+/**
+ * Calls to {@code $x} may be chained to find elements within a parent.
+ *
+ * Care should be taken when using an XPath selector with a webdriver.WebElement
+ * as WebDriver will respect the context in the specified in the selector.
+ *
+ * @alias element(locator).$x(selector)
+ * @view
+ * <div id="parent">
+ *   <div id="child">
+ *     Child text
+ *     <div>{{person.phone}}</div>
+ *   </div>
+ * </div>
+ *
+ * @example
+ * // Chain 2 element calls.
+ * var child = element(by.xpath('//[@id='parent']')).
+ *     $x('.//child');
+ * expect(child.getText()).toBe('Child text\n555-123-4567');
+ *
+ * @param {string} selector An XPath selector
+ * @return {ElementFinder}
+ */
+ElementFinder.prototype.$x = function(selector) {
+  return this.element(webdriver.By.xpath(selector));
+};
+
+/**
  * Determine whether the element is present on the page.
  *
  * @view
@@ -1012,3 +1073,62 @@ var build$$ = function(element, by) {
   };
 };
 exports.build$$ = build$$;
+
+/**
+ * Shortcut for querying the document directly with XPath.
+ * `element(by.xpath('.abc'))` is equivalent to `$('.abc')`.
+ *
+ *
+ * @alias $(XPathSelector)
+ * @view
+ * <div class="count">
+ *   <span class="one">First</span>
+ *   <span class="two">Second</span>
+ * </div>
+ *
+ * @example
+ * var item = $x('//span[@id="two"]');
+ * expect(item.getText()).toBe('Second');
+ *
+ * @param {string} selector An XPath selector
+ * @return {ElementFinder} which identifies the located
+ *     {@link webdriver.WebElement}.
+ */
+var build$x = function(element, by) {
+  return function(selector) {
+    return element(by.xpath(selector));
+  };
+};
+exports.build$x = build$x;
+
+/**
+ * Shortcut for querying the document directly with XPath.
+ * `element.all(by.xpath('.abc'))` is equivalent to `$$x('.abc')`
+ *
+ * @alias $$x(XPathSelector)
+ * @view
+ * <div class="count">
+ *   <span class="one">First</span>
+ *   <span class="two">Second</span>
+ * </div>
+ *
+ * @example
+ * // The following protractor expressions are equivalent.
+ * var list = element.all(by.xpath('//span'));
+ * expect(list.count()).toBe(2);
+ *
+ * list = $$x('//span');
+ * expect(list.count()).toBe(2);
+ * expect(list.get(0).getText()).toBe('First');
+ * expect(list.get(1).getText()).toBe('Second');
+ *
+ * @param {string} selector An XPath selector
+ * @return {ElementArrayFinder} which identifies the
+ *     array of the located {@link webdriver.WebElement}s.
+ */
+var build$$x = function(element, by) {
+  return function(selector) {
+    return element.all(by.xpath(selector));
+  };
+};
+exports.build$$x = build$$x;

--- a/lib/protractor.js
+++ b/lib/protractor.js
@@ -7,6 +7,8 @@ var ElementArrayFinder = require('./element').ElementArrayFinder;
 var ElementFinder = require('./element').ElementFinder;
 var build$ = require('./element').build$;
 var build$$ = require('./element').build$$;
+var build$x = require('./element').build$x;
+var build$$x = require('./element').build$$x;
 var Plugins = require('./plugins');
 
 var clientSideScripts = require('./clientsidescripts.js');
@@ -144,6 +146,20 @@ var Protractor = function(webdriverInstance, opt_baseUrl, opt_rootElement,
    * @type {function(string): ElementArrayFinder}
    */
   this.$$ = build$$(this.element, webdriver.By);
+
+  /**
+   * Shorthand function for finding elements by XPath.
+   *
+   * @type {function(string): ElementFinder}
+   */
+  this.$x = build$x(this.element, webdriver.By);
+
+  /**
+   * Shorthand function for finding arrays of elements by XPath.
+   *
+   * @type {function(string): ElementArrayFinder}
+   */
+  this.$$x = build$$x(this.element, webdriver.By);
 
   /**
    * All get methods will be resolved against this base URL. Relative URLs are =

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -157,6 +157,8 @@ Runner.prototype.setupGlobals_ = function(browser_) {
   global.browser = browser_;
   global.$ = browser_.$;
   global.$$ = browser_.$$;
+  global.$x = browser_.$x;
+  global.$$x = browser_.$$x;
   global.element = browser_.element;
   global.by = global.By = protractor.By;
 

--- a/spec/basic/elements_spec.js
+++ b/spec/basic/elements_spec.js
@@ -572,3 +572,25 @@ describe('shortcut css notation', function() {
     expect(withoutShortcutCount).toEqual(withShortcutCount);
   });
 });
+
+describe('shortcut xpath notation', function() {
+  beforeEach(function() {
+    browser.get('index.html#/form');
+  });
+
+  it('should grab by xpath', function() {
+    expect($x('//span[@id="shower"]').getText()).
+        toEqual(element(by.xpath('//span[@id="shower"]')).getText());
+    expect($$x('//input').count()).toEqual(element.all(by.xpath('//input')).count());
+  });
+
+  it('should chain $$x with $x', function() {
+    var withoutShortcutCount =
+        element(by.css('select')).all(by.css('option')).then(function(options) {
+          return options.length;
+        });
+    var withShortcutCount = $x('//select').$$x('.//option').count();
+
+    expect(withoutShortcutCount).toEqual(withShortcutCount);
+  });
+});


### PR DESCRIPTION
(Closes #2855)

I personally don't use a lot of xpath selectors in the tests, and it advised against in the [styleguide](https://github.com/angular/protractor/blob/master/docs/style-guide.md#never-use-xpath), but I can see this coming in handy for those that do. The change itself is very simplistic (it mimics the behavior of `$` and `$$` exactly) so I don't see this as harmful.

Please feel free to reject this if it is going to add too much bloat or encouraging non ideal usage of xpath; we can then close the corresponding issue.

@alexce i'd appreciate another set of eyes on this as well since it was your idea :smiley_cat: 
