### PR TITLE
fix(configParser): use all the suites if no other spec sources are provided

### DIFF
--- a/lib/configParser.js
+++ b/lib/configParser.js
@@ -151,8 +151,8 @@ ConfigParser.getSpecs = function(config) {
     return config.specs;
   }
 
-  Array.prototype.forEach.call(config.suites, function(suite) {
-    union(specs, makeArray(suite));
+  Object.keys(config.suites || {}).sort().forEach(function(suite) {
+    union(specs, makeArray(config.suites[suite]));
   });
   return specs;
 };

--- a/spec/unit/config_test.js
+++ b/spec/unit/config_test.js
@@ -39,6 +39,22 @@ describe('the config parser', function() {
     expect(config.onPrepare).toEqual(path.normalize(process.cwd() + '/baz/qux.js'));
   });
 
+  describe('getSpecs()', function() {
+    it('should return all the specs from "config.suites" if no other sources are provided', function() {
+      var config = {
+        specs: [],
+        suites: {
+          foo: 'foo.spec.js',
+          bar: 'bar.spec.js'
+        }
+      };
+
+      var specs = new ConfigParser.getSpecs(config);
+
+      expect(specs).toEqual(['bar.spec.js', 'foo.spec.js']);
+    });
+  });
+
   describe('resolving globs', function() {
     it('should resolve relative to the cwd', function() {
       spyOn(process, 'cwd').and.returnValue(__dirname + '/');


### PR DESCRIPTION
Hi, this PR restores the behavior where if both `config.specs` and `config.suite` are empty, but `config.suites` is provided, all the specs from `config.suites` are scheduled to be executed.