### PR TITLE
fix(config): Do not sort spec keys

### DIFF
--- a/lib/configParser.js
+++ b/lib/configParser.js
@@ -151,7 +151,7 @@ ConfigParser.getSpecs = function(config) {
     return config.specs;
   }
 
-  Object.keys(config.suites || {}).sort().forEach(function(suite) {
+  Object.keys(config.suites || {}).forEach(function(suite) {
     union(specs, makeArray(config.suites[suite]));
   });
   return specs;

--- a/spec/unit/config_test.js
+++ b/spec/unit/config_test.js
@@ -51,7 +51,7 @@ describe('the config parser', function() {
 
       var specs = new ConfigParser.getSpecs(config);
 
-      expect(specs).toEqual(['bar.spec.js', 'foo.spec.js']);
+      expect(specs).toEqual(['foo.spec.js', 'bar.spec.js']);
     });
   });
 


### PR DESCRIPTION
I think it makes sense to preserve the original non-sorted behavior here.

This fixes #2928