### PR TITLE
test(configParser): removed unneeded "new" operator

### DIFF
--- a/spec/unit/config_test.js
+++ b/spec/unit/config_test.js
@@ -49,7 +49,7 @@ describe('the config parser', function() {
         }
       };
 
-      var specs = new ConfigParser.getSpecs(config);
+      var specs = ConfigParser.getSpecs(config);
 
       expect(specs).toEqual(['bar.spec.js', 'foo.spec.js']);
     });


### PR DESCRIPTION
Hi, while iterating over #2926 I mistakenly forgot to remove an unneeded `new` operator in the test. This PR cleans it up, sorry about that :)