### PR TITLE
Update tutorial prerequisites to correct node version

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -6,7 +6,7 @@ This is a simple tutorial that shows you how to set up Protractor and start runn
 Prerequisites
 -------------
 
-Protractor is a [Node.js](http://nodejs.org/) program. To run, you will need to have Node.js installed. You will download Protractor package using [npm](https://www.npmjs.org/), which comes with Node.js. Check the version of Node.js you have by running `node --version`. It should be greater than v0.10.0.
+Protractor is a [Node.js](http://nodejs.org/) program. To run, you will need to have Node.js installed. You will download Protractor package using [npm](https://www.npmjs.org/), which comes with Node.js. Check the version of Node.js you have by running `node --version`. It should be greater than or equal to v4.0.0.
 
 By default, Protractor uses the [Jasmine](http://jasmine.github.io/) test framework for its testing interface. This tutorial assumes some familiarity with Jasmine, and we will use version 2.3.
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -6,7 +6,7 @@ This is a simple tutorial that shows you how to set up Protractor and start runn
 Prerequisites
 -------------
 
-Protractor is a [Node.js](http://nodejs.org/) program. To run, you will need to have Node.js installed. You will download Protractor package using [npm](https://www.npmjs.org/), which comes with Node.js. Check the version of Node.js you have by running `node --version`. It should be greater than or equal to v4.0.0.
+Protractor is a [Node.js](http://nodejs.org/) program. To run, you will need to have Node.js installed. You will download Protractor package using [npm](https://www.npmjs.org/), which comes with Node.js. Check the version of Node.js you have by running `node --version`. Then, check the [compatibility notes] (https://github.com/angular/protractor#compatibility) in the Protractor README to make sure your version of Node.js is compatible with Protractor. 
 
 By default, Protractor uses the [Jasmine](http://jasmine.github.io/) test framework for its testing interface. This tutorial assumes some familiarity with Jasmine, and we will use version 2.3.
 


### PR DESCRIPTION
After Protractor upgraded to webdriver 2.48.2 users were not able to use node versions < 4. Updating tutorial instructions to reflect this breaking change. Changing instructions at the beginning to tell users to make sure their version of Node is >= v4.0.0