### PR TITLE
Fix docs for using protractor-cucumber-framework

### DIFF
--- a/docs/frameworks.md
+++ b/docs/frameworks.md
@@ -78,7 +78,7 @@ exports.config = {
   framework: 'custom',
 
   // path relative to the current config file
-  frameworkPath: 'protractor-cucumber-framework'
+  frameworkPath: require.resolve('protractor-cucumber-framework')
 
   // relevant cucumber command line options
   cucumberOpts: {


### PR DESCRIPTION
The code at https://github.com/angular/protractor/blob/master/lib/configParser.js#L167-L181 will convert a frameworkPath of `protractor-cucumber-framework` to a relative path relative to the configuration file. Instead the path must be supplied as an absolute path, and require.resolve is the best method to achieve this.

It also makes documentation consistent with https://github.com/mattfritz/protractor-cucumber-framework#implementation