### PR TITLE
chore(repo): Add GH issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -1,0 +1,31 @@
+Hi there!
+
+Thanks for submitting an issue to Protractor.
+
+To help us help you better, please do the following before submitting an issue:
+
+1. Review the questions section of [CONTRIBUTING.md](https://github.com/angular/protractor/blob/master/CONTRIBUTING.md#contributing)
+2. Make sure you are not asking a usage or debugging question. If you are, use [StackOverflow](http://stackoverflow.com/questions/tagged/protractor), [Google Group discussion list](https://groups.google.com/forum/?fromgroups#!forum/angular), or [Gitter](https://gitter.im/angular/protractor) to get help.
+3. Fill in the information that corresponds to your type of issue below
+4. Delete this intro and any unrelated text :smile: (if you do not we'll assume you haven't read these instructions and automatically close the issue)
+
+
+Bug report
+---
+
+- Node Version: ``
+- Protractor Version: ``
+- Browser(s): ``
+- Operating System and Version ``
+- Your protractor configuration file
+- A relevant example test
+- Output from running the test
+- Steps to reproduce the bug
+- The URL you are running your tests against (if relevant)
+
+
+Feature Request
+---
+
+- Reasons for adopting new feature
+- Is this a breaking change? (How will this affect existing functionality)


### PR DESCRIPTION
I took a first crack at creating an issue template (so excited about that feature!). I am not attached to anything here so fire away.

Submitting an issue:

![screen shot 2016-02-17 at 4 51 07 pm](https://cloud.githubusercontent.com/assets/1290336/13127802/245f5af0-d597-11e5-8d16-dbdc6e5390d7.png)

Submitted Issue:

![screen shot 2016-02-17 at 4 52 42 pm](https://cloud.githubusercontent.com/assets/1290336/13127804/285726b0-d597-11e5-9085-35b824c57a7f.png)


(this Closes #2952 )
