### PR TITLE
fix typo in web driver manager error handling

### DIFF
--- a/bin/webdriver-manager
+++ b/bin/webdriver-manager
@@ -176,7 +176,7 @@ var httpGetFile = function(fileUrl, fileName, outputDir, callback) {
   file.on('close', function() {
     fs.stat(filePath, function(err, stats) {
       if (err) {
-        console.error('Error: Got error ' + error + ' from ' + fileUrl);
+        console.error('Error: Got error ' + err + ' from ' + fileUrl);
       }
       if (stats.size != contentLength) {
         console.error('Error: corrupt download for ' + fileName +


### PR DESCRIPTION
This commit just fixes a small bug with the error handling in web driver manager.