### PR TITLE
fix(bootstrap): enable debug info before setting defer label

### DIFF
--- a/lib/protractor.js
+++ b/lib/protractor.js
@@ -637,7 +637,8 @@ Protractor.prototype.get = function(destination, opt_timeout) {
 
   this.driver.get(this.resetUrl).then(null, deferred.reject);
   this.executeScript_(
-      'window.name = "' + DEFER_LABEL + ENABLE_DEBUG_INFO_LABEL + '" + window.name;' +
+      'window.name = "' + ENABLE_DEBUG_INFO_LABEL + DEFER_LABEL + '" + window.name;' +
+
       'window.location.replace("' + destination + '");',
       msg('reset url'))
       .then(null, deferred.reject);


### PR DESCRIPTION
Note that in most cases, this should not have surfaced as an issue because
the base test mock modules will also try to turn on debug info.

Closes #3009