### PR TITLE
feat(plugins) Calculate skipAngularStability dynamically.

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -22,7 +22,6 @@ var Plugins = function(config) {
   this.pluginObjs = [];
   this.assertions = {};
   this.resultsReported = false;
-  this.skipAngularStability = false;
   this.pluginConfs.forEach(function(pluginConf, i) {
     var path;
     if (pluginConf.path) {
@@ -46,8 +45,6 @@ var Plugins = function(config) {
     }
 
     annotatePluginObj(self, pluginObj, pluginConf, i);
-    self.skipAngularStability = self.skipAngularStability ||
-        pluginObj.skipAngularStability;
 
     log.debug('Plugin "' + pluginObj.name + '" loaded.');
     self.pluginObjs.push(pluginObj);
@@ -152,6 +149,18 @@ Plugins.prototype.getResults = function() {
   printPluginResults(results.specResults);
   this.resultsReported = true;
   return results;
+};
+
+/**
+ * Returns true if any loaded plugin has skipAngularStability enabled.
+ *
+ * @return {boolean}
+ */
+Plugins.prototype.skipAngularStability = function() {
+  var result = this.pluginObjs.reduce(function(skip, pluginObj) {
+    return pluginObj.skipAngularStability || skip;
+  }, false);
+  return result;
 };
 
 /**

--- a/lib/protractor.js
+++ b/lib/protractor.js
@@ -357,7 +357,7 @@ Protractor.prototype.waitForAngular = function(opt_description) {
   }
 
   function runWaitForAngularScript() {
-    if (self.plugins_.skipAngularStability) {
+    if (self.plugins_.skipAngularStability()) {
       return webdriver.promise.fulfilled();
     } else if (self.rootEl) {
       return self.executeAsyncScript_(

--- a/spec/plugins/skipStabilityConf.js
+++ b/spec/plugins/skipStabilityConf.js
@@ -1,0 +1,32 @@
+var env = require('../environment.js'),
+    q = require('q');
+
+// Verifies that plugins can change skipAngularStability on the fly.
+exports.config = {
+  seleniumAddress: env.seleniumAddress,
+
+  framework: 'jasmine',
+
+  // Spec patterns are relative to this directory.
+  specs: [
+    'specs/skip_stability_spec.js'
+  ],
+
+  capabilities: env.capabilities,
+
+  baseUrl: env.baseUrl + '/ng1/',
+
+  // Define a plugin that allows skipAngularStability to be changed.
+  plugins: [{
+    inline: {
+      setup: function() {
+        this.skipAngularStability = false;
+        var plugin = this;
+
+        protractor._PluginSetSkipStability = function(newValue) {
+          plugin.skipAngularStability = newValue;
+        };
+      }
+    }
+  }]
+};

--- a/spec/plugins/specs/skip_stability_spec.js
+++ b/spec/plugins/specs/skip_stability_spec.js
@@ -1,0 +1,29 @@
+describe('plugins that can disable synchronization', function() {
+  beforeEach(function() {
+    browser.get('index.html#/async');
+  });
+
+  it('DOES NOT wait for $timeout with synchronization disabled', function() {
+    protractor._PluginSetSkipStability(true);
+    var status = element(by.binding('slowAngularTimeoutStatus'));
+    var button = element(by.css('[ng-click="slowAngularTimeout()"]'));
+
+    expect(status.getText()).toEqual('not started');
+
+    button.click();
+
+    expect(status.getText()).toEqual('pending...');
+  });
+
+  it('waits for $timeout with synchronization enabled', function() {
+    protractor._PluginSetSkipStability(false);
+    var status = element(by.binding('slowAngularTimeoutStatus'));
+    var button = element(by.css('[ng-click="slowAngularTimeout()"]'));
+
+    expect(status.getText()).toEqual('not started');
+
+    button.click();
+
+    expect(status.getText()).toEqual('done');
+  });
+});


### PR DESCRIPTION
This allows plugins to turn Protractor's default synchronization on and
off as needed.