### PR TITLE
fix: Update module main in package.json to use built.

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "protractor": "bin/protractor",
     "webdriver-manager": "bin/webdriver-manager"
   },
-  "main": "lib/protractor.js",
+  "main": "built/protractor.js",
   "scripts": {
     "prepublish": "gulp prepublish",
     "pretest": "gulp pretest",


### PR DESCRIPTION
`require`ing protractor is currently broken because we now publish with the built javascript at `built` instead of `lib`. 

Closes #3034 