### PR TITLE
chore(fix): add reject unauthorized to request for webdriver

### DIFF
--- a/bin/webdriver-manager
+++ b/bin/webdriver-manager
@@ -203,6 +203,7 @@ var httpGetFile = function(fileUrl, fileName, outputDir, callback) {
   var options = {
     url: fileUrl,
     strictSSL: !ignoreSSL,
+    rejectUnauthorized: !ignoreSSL,
     proxy: resolveProxy(fileUrl)
   };
 


### PR DESCRIPTION
Ignoring SSL should also not reject unauthorized per https://github.com/request/request/issues/1777.

Closes #3035.