### PR TITLE
feat(protractor): isPresent() now is friendly to out of bounds errors

### DIFF
--- a/lib/element.js
+++ b/lib/element.js
@@ -242,10 +242,11 @@ ElementArrayFinder.prototype.get = function(index) {
         i = parentWebElements.length + i;
       }
       if (i < 0 || i >= parentWebElements.length) {
-        throw new Error('Index out of bound. Trying to access element at ' +
+            console.warn('Index out of bound. Trying to access element at ' +
             'index: ' + index + ', but there are only ' +
             parentWebElements.length + ' elements that match locator ' +
             self.locator_.toString());
+            return [];
       }
       return [parentWebElements[i]];
     });

--- a/spec/basic/elements_spec.js
+++ b/spec/basic/elements_spec.js
@@ -12,6 +12,7 @@ describe('ElementFinder', function() {
         browser.findElement(by.binding('username')).getText());
   });
 
+
   it('should wait to grab the WebElement until a method is called', function() {
     // These should throw no error before a page is loaded.
     var usernameInput = element(by.model('username'));
@@ -109,6 +110,13 @@ describe('ElementFinder', function() {
       }, function(err) {
         expect(true).toEqual(true);
       });
+  });
+
+  it('isPresent() should be friendly with out of bounds error', function () {
+    browser.get('index.html#/form');
+    var elementsNotPresent = element.all(by.id('notPresentElementID'));
+    expect(elementsNotPresent.first().isPresent()).toBe(false);
+    expect(elementsNotPresent.last().isPresent()).toBe(false);
   });
 
   it('isPresent() should not raise error on chained finders', function() {


### PR DESCRIPTION
fixes #2917 
@juliemr worked around your comments in that issue,could you check these changes?. Modified ElementArrayFinder.prototype.get function, now it does't crash the flow when an out of bounds err is thrown, instead of that a warning is prompted in console.