### PR TITLE
feat(driverProvider/sauce) Add build Id as configurable option

### DIFF
--- a/docs/referenceConf.js
+++ b/docs/referenceConf.js
@@ -72,6 +72,8 @@ exports.config = {
   // Use sauceAgent if you need customize agent for https connection to
   // saucelabs.com (i.e. your computer behind corporate proxy)
   sauceAgent: null,
+  // Use sauceBuild if you want to group test capabilites by a build ID
+  sauceBuild: null,
   // Use sauceSeleniumAddress if you need to customize the URL Protractor
   // uses to connect to sauce labs (for example, if you are tunneling selenium
   // traffic through a sauce connect tunnel). Default is

--- a/lib/driverProviders/sauce.js
+++ b/lib/driverProviders/sauce.js
@@ -61,6 +61,7 @@ SauceDriverProvider.prototype.setupEnv = function() {
   });
   this.config_.capabilities.username = this.config_.sauceUser;
   this.config_.capabilities.accessKey = this.config_.sauceKey;
+  this.config_.capabilities.build = this.config_.sauceBuild;
   var auth = 'http://' + this.config_.sauceUser + ':' +
     this.config_.sauceKey + '@';
   this.config_.seleniumAddress = auth +

--- a/spec/driverprovider_test.js
+++ b/spec/driverprovider_test.js
@@ -17,7 +17,7 @@ var env = require('./environment');
 
 var testDriverProvider = function(driverProvider) {
   return driverProvider.setupEnv().then(function() {
-    var driver = driverProvider.getDriver();
+    var driver = driverProvider.getNewDriver();
     var deferred = q.defer();
     driver.get('about:blank');
     driver.getCurrentUrl().then(function(url) {
@@ -45,7 +45,7 @@ var chromeConfig = {
     browserName: 'chrome'
   }
 };
-testDriverProvider(require('../lib/driverProviders/direct')(chromeConfig)).
+testDriverProvider(require('../built/driverProviders/direct')(chromeConfig)).
     then(function() {
       console.log('direct.dp with chrome working!');
     }, function(err) {
@@ -57,7 +57,7 @@ var firefoxConfig = {
     browserName: 'firefox'
   }
 };
-testDriverProvider(require('../lib/driverProviders/direct')(firefoxConfig)).
+testDriverProvider(require('../built/driverProviders/direct')(firefoxConfig)).
     then(function() {
       console.log('direct.dp with firefox working!');
     }, function(err) {
@@ -70,7 +70,7 @@ var hostedConfig = {
     browserName: 'firefox'
   }
 };
-testDriverProvider(require('../lib/driverProviders/hosted')(hostedConfig)).
+testDriverProvider(require('../built/driverProviders/hosted')(hostedConfig)).
     then(function() {
       console.log('hosted.dp working!');
     }, function(err) {
@@ -83,7 +83,7 @@ var hostedPromisedConfig = {
     browserName: 'firefox'
   }
 };
-testDriverProvider(require('../lib/driverProviders/hosted')(hostedPromisedConfig)).
+testDriverProvider(require('../built/driverProviders/hosted')(hostedPromisedConfig)).
     then(function() {
       console.log('hosted.dp with promises working!');
     }, function(err) {
@@ -96,7 +96,7 @@ var localConfig = {
     browserName: 'chrome'
   }
 };
-testDriverProvider(require('../lib/driverProviders/local')(localConfig)).
+testDriverProvider(require('../built/driverProviders/local')(localConfig)).
     then(function() {
       console.log('local.dp working!');
     }, function(err) {
@@ -107,11 +107,12 @@ if (argv.sauceUser && argv.sauceKey) {
   var sauceConfig = {
     sauceUser: argv.sauceUser,
     sauceKey: argv.sauceKey,
+    sauceBuild: argv.sauceBuild,
     capabilities: {
       browserName: 'chrome'
     }
   };
-  testDriverProvider(require('../lib/driverProviders/sauce')(sauceConfig)).
+  testDriverProvider(require('../built/driverProviders/sauce')(sauceConfig)).
       then(function() {
         console.log('sauce.dp working!');
       }, function(err) {


### PR DESCRIPTION
* Add build Id as a configurable option for sauce users
* Update sanity tests to run on the built dir
* Update sanity tests to call getNewDriver() function

closes #2240

Tested by running sanity tests locally. Attached are screen shots of the execution, and the build shown at sauce labs.

![test_execution](https://cloud.githubusercontent.com/assets/5282872/14037427/9685a5d0-f211-11e5-8fb2-a0b58bb8b9ae.png)

![sauce_labs](https://cloud.githubusercontent.com/assets/5282872/14037444/d4fe5b90-f211-11e5-8a31-48b44fcae346.png)


Note: I've regenerated my sauce key so no worries about it showing in the screenshot