### PR TITLE
fix(NoSuchElementError): add 'new' keyword for creating class

### DIFF
--- a/lib/element.js
+++ b/lib/element.js
@@ -340,7 +340,7 @@ ElementArrayFinder.prototype.count = function() {
   return this.getWebElements().then(function(arr) {
     return arr.length;
   }, function(err) {
-    if (err.code == webdriver.error.NoSuchElementError()) {
+    if (err.code == new webdriver.error.NoSuchElementError()) {
       return 0;
     } else {
       throw err;


### PR DESCRIPTION
Prevent the following error if an element isn't found in the dom : `Class constructors cannot be invoked without 'new'`