### PR TITLE
fix(NoSuchElementError): add 'new' keyword to instantiate class

### DIFF
--- a/lib/element.js
+++ b/lib/element.js
@@ -340,7 +340,7 @@ ElementArrayFinder.prototype.count = function() {
   return this.getWebElements().then(function(arr) {
     return arr.length;
   }, function(err) {
-    if (err.code == webdriver.error.NoSuchElementError()) {
+    if (err.code == new webdriver.error.NoSuchElementError()) {
       return 0;
     } else {
       throw err;


### PR DESCRIPTION
The class NoSuchElementError is called without the new keyword in the `ElementArrayFinder.prototype.count` causing a `Class constructors cannot be invoked without 'new'`