### PR TITLE
docs(webelement): Remove takeScreenshot from docs.

### DIFF
--- a/lib/selenium-webdriver/webdriver.js
+++ b/lib/selenium-webdriver/webdriver.js
@@ -455,19 +455,6 @@ webdriver.WebElement.prototype.isDisplayed = function() {};
 
 
 /**
- * Take a screenshot of the visible region encompassed by this element's
- * bounding rectangle.
- *
- * @param {boolean=} opt_scroll Optional argument that indicates whether the
- *     element should be scrolled into view before taking a screenshot. Defaults
- *     to false.
- * @return {!webdriver.promise.Promise.<string>} A promise that will be
- *     resolved to the screenshot as a base-64 encoded PNG.
- */
-webdriver.WebElement.prototype.takeScreenshot = function(opt_scroll) {};
-
-
-/**
  * Schedules a command to retrieve the outer HTML of this element.
  *
  * @view


### PR DESCRIPTION
We don't seem to wrap this for WebElements.