### PR TITLE
docs: Document that by.xpath will ignore parent if chaining

### DIFF
--- a/lib/element.js
+++ b/lib/element.js
@@ -783,6 +783,8 @@ ElementFinder.prototype.all = function(subLocator) {
 /**
  * Calls to {@code element} may be chained to find elements within a parent.
  *
+ * Please note {by.xpath} will ignore the parent and search from document root.
+ * 
  * @alias element(locator).element(locator)
  * @view
  * <div class="parent">
@@ -837,6 +839,8 @@ ElementFinder.prototype.$$ = function(selector) {
 
 /**
  * Calls to {@code $} may be chained to find elements within a parent.
+ * 
+ * Please note {by.xpath} will ignore the parent and search from document root.
  *
  * @alias element(locator).$(selector)
  * @view


### PR DESCRIPTION
docs(protractor) Mention by.xpath ignores parent context when using element chaining