### PR TITLE
fix(bootstrap): fix bootstrap for older versions of angular

### DIFF
--- a/lib/protractor.js
+++ b/lib/protractor.js
@@ -402,8 +402,8 @@ Protractor.prototype.waitForAngular = function(opt_description) {
         var errMsg = 'Timed out waiting for Protractor to synchronize with ' +
         'the page after ' + timeout + '. Please see ' +
         'https://github.com/angular/protractor/blob/master/docs/faq.md';
-        if(description.startsWith(' - Locator: ')){
-            errMsg += '\n' + description;
+        if (description.startsWith(' - Locator: ')) {
+            errMsg += '\nWhile waiting for element with locator' + description;
         }
         var pendingTimeoutsPromise;
         if (self.trackOutstandingTimeouts_) {

--- a/lib/protractor.js
+++ b/lib/protractor.js
@@ -19,7 +19,6 @@ var ExpectedConditions = require('./expectedConditions').ExpectedConditions;
 /* global angular */
 
 var DEFER_LABEL = 'NG_DEFER_BOOTSTRAP!';
-var ENABLE_DEBUG_INFO_LABEL = 'NG_ENABLE_DEBUG_INFO!';
 var DEFAULT_RESET_URL = 'data:text/html,<html></html>';
 var DEFAULT_GET_PAGE_TIMEOUT = 10000;
 
@@ -640,7 +639,7 @@ Protractor.prototype.get = function(destination, opt_timeout) {
 
   this.driver.get(this.resetUrl).then(null, deferred.reject);
   this.executeScript_(
-      'window.name = "' + ENABLE_DEBUG_INFO_LABEL + DEFER_LABEL + '" + window.name;' +
+      'window.name = "' + DEFER_LABEL + '" + window.name;' +
 
       'window.location.replace("' + destination + '");',
       msg('reset url'))

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -125,7 +125,7 @@ executor.addCommandlineTest('node built/cli.js spec/errorTest/slowHttpAndTimeout
     .expectExitCode(1)
     .expectErrors([
       {message: 'The following tasks were pending[\\s\\S]*\\$http: slowcall'},
-      {message: '^((?!The following tasks were pending).)*$'}
+      {message: 'While waiting for element with locator - Locator: by.binding\\(\\"slowAngularTimeoutStatus\\"\\)$'}
     ]);
 
 executor.execute();


### PR DESCRIPTION
Trying to use the debug label for window.name fails for versions
of angular older than 1.2.24. See #3115