### PR TITLE
docs(website): add links to selenium-webdriver documentation

### DIFF
--- a/lib/selenium-webdriver/webdriver.js
+++ b/lib/selenium-webdriver/webdriver.js
@@ -32,6 +32,109 @@ goog.require('webdriver.until');
 
 // //////////////////////////////////////////////////////////////////////////////
 // //
+// //  webdriver.WebDriver
+// //
+// //////////////////////////////////////////////////////////////////////////////
+/**
+ * Protractor's browser object is a wrapper for selenium-webdriver WebDriver.
+ * A full list of all functions available on WebDriver can be found
+ * in the selenium-webdriver
+ * <a href="http://seleniumhq.github.io/selenium/docs/api/javascript/module/selenium-webdriver/lib/webdriver_exports_WebDriver.html">documentation</a>
+ * @constructor
+ */
+webdriver.WebDriver = function() {};
+
+/**
+ * Creates a new action sequence using this driver. The sequence will not be
+ * scheduled for execution until {@link webdriver.ActionSequence#perform} is
+ * called. Example:
+ *
+ *     browser.actions().
+ *         mouseDown(element1).
+ *         mouseMove(element2).
+ *         mouseUp().
+ *         perform();
+ *
+ * See http://seleniumhq.github.io/selenium/docs/api/javascript/module/selenium-webdriver/lib/actions_exports_ActionSequence.html
+ * for more examples of action sequences.
+ *
+ * @return {!webdriver.ActionSequence} A new action sequence for this instance.
+ */
+webdriver.WebDriver.prototype.actions = function() {};
+
+/**
+ * Schedules a command to wait for a condition to hold. 
+ *
+ * This function may be used to block the command flow on the resolution
+ * of a {@link webdriver.promise.Promise promise}. When given a promise, the
+ * command will simply wait for its resolution before completing. A timeout may
+ * be provided to fail the command if the promise does not resolve before the
+ * timeout expires.
+ *
+ * *Example:* Suppose you have a function, `startTestServer`, that returns a
+ * promise for when a server is ready for requests. You can block a `WebDriver`
+ * client on this promise with:
+ *
+ *     var started = startTestServer();
+ *     browser.wait(started, 5 * 1000, 'Server should start within 5 seconds');
+ *     browser.get(getServerUrl());
+ *
+ *
+ * See also {@link ExpectedConditions}
+ * 
+ * @param {!(webdriver.promise.Promise<T>|
+ *           webdriver.until.Condition<T>|
+ *           function(!webdriver.WebDriver): T)} condition The condition to
+ *     wait on, defined as a promise, condition object, or  a function to
+ *     evaluate as a condition.
+ * @param {number=} opt_timeout How long to wait for the condition to be true.
+ * @param {string=} opt_message An optional message to use if the wait times
+ *     out.
+ * @return {!webdriver.promise.Promise<T>} A promise that will be fulfilled
+ *     with the first truthy value returned by the condition function, or
+ *     rejected if the condition times out.
+ */
+webdriver.WebDriver.prototype.wait = function() {};
+
+/**
+ * Schedules a command to make the driver sleep for the given amount of time.
+ * @param {number} ms The amount of time, in milliseconds, to sleep.
+ * @return {!webdriver.promise.Promise.<void>} A promise that will be resolved
+ *     when the sleep has finished.
+ */
+webdriver.WebDriver.prototype.sleep = function() {};
+
+/**
+ * Schedules a command to retrieve the URL of the current page.
+ * @return {!webdriver.promise.Promise.<string>} A promise that will be
+ *     resolved with the current URL.
+ */
+webdriver.WebDriver.prototype.getCurrentUrl = function() {};
+
+/**
+ * Schedules a command to retrieve the current page's title.
+ * @return {!webdriver.promise.Promise.<string>} A promise that will be
+ *     resolved with the current page's title.
+ */
+webdriver.WebDriver.prototype.getTitle = function() {};
+
+/**
+ * Schedule a command to take a screenshot. The driver makes a best effort to
+ * return a screenshot of the following, in order of preference:
+ * <ol>
+ *   <li>Entire page
+ *   <li>Current window
+ *   <li>Visible portion of the current frame
+ *   <li>The screenshot of the entire display containing the browser
+ * </ol>
+ *
+ * @return {!webdriver.promise.Promise.<string>} A promise that will be
+ *     resolved to the screenshot as a base-64 encoded PNG.
+ */
+webdriver.WebDriver.prototype.takeScreenshot = function() {};
+
+// //////////////////////////////////////////////////////////////////////////////
+// //
 // //  webdriver.WebElement
 // //
 // //////////////////////////////////////////////////////////////////////////////
@@ -39,25 +142,10 @@ goog.require('webdriver.until');
 //
 //
 /**
- * Represents a DOM element. WebElements can be found by searching from the
- * document root using a {@link Protractor} browser instance, or by searching
- * under another WebElement:
- *
- *     browser.get('http://www.google.com');
- *     var searchForm = browser.findElement(By.tagName('form'));
- *     var searchBox = searchForm.findElement(By.name('q'));
- *     searchBox.sendKeys('webdriver');
- *
- * The WebElement is implemented as a promise for compatibility with the promise
- * API. It will always resolve itself when its internal state has been fully
- * resolved and commands may be issued against the element. This can be used to
- * catch errors when an element cannot be located on the page:
- *
- *     browser.findElement(By.id('not-there')).then(function(element) {
- *       alert('Found an element that was not expected to be there!');
- *     }, function(error) {
- *       alert('The element was not found, as expected');
- *     });
+ * Protractor's ElementFinders are wrappers for selenium-webdriver WebElement.
+ * A full list of all functions available on WebElement can be found
+ * in the selenium-webdriver
+ * <a href="http://seleniumhq.github.io/selenium/docs/api/javascript/module/selenium-webdriver/lib/webdriver_exports_WebElement.html">documentation</a>.
  *
  * @param {!webdriver.WebDriver} driver The webdriver driver or the parent WebDriver instance for this
  *     element.
@@ -65,10 +153,8 @@ goog.require('webdriver.until');
  *           webdriver.WebElement.Id)} id The server-assigned opaque ID for the
  *     underlying DOM element.
  * @constructor
- * @extends {webdriver.Serializable.<webdriver.WebElement.Id>}
  */
 webdriver.WebElement = function(driver, id) {};
-goog.inherits(webdriver.WebElement, webdriver.Serializable);
 
 /**
  * Gets the parent web element of this web element.

--- a/website/docgen/dgeni-config.js
+++ b/website/docgen/dgeni-config.js
@@ -77,9 +77,6 @@ myPackage.config(function(readFilesProcessor, templateFinder, writeFilesProcesso
     {include: 'built/expectedConditions.js'},
     {include: 'lib/selenium-webdriver/locators.js'},
     {include: 'lib/selenium-webdriver/webdriver.js'}
-    // TODO: add in key & promise
-    // {include: 'node_modules/selenium-webdriver/lib/webdriver/key.js'},
-    // {include: 'node_modules/selenium-webdriver/lib/webdriver/promise.js'}
   ];
 
   // Add a folder to search for our own templates to use when rendering docs

--- a/website/docgen/processors/add-links.js
+++ b/website/docgen/processors/add-links.js
@@ -1,12 +1,5 @@
 var _ = require('lodash');
 
-var templateMapping = {
-  protractor: _.template('https://github.com/angular/protractor/blob/' +
-      '<%= linksHash %>/lib/<%= fileName %>.js#L<%= startingLine %>'),
-  webdriver: _.template('https://github.com/SeleniumHQ/selenium/blob/master/' +
-      'javascript/webdriver/<%= fileName %>.js#L<%= startingLine %>')
-};
-
 /**
  * A lookup table with all the types in the parsed files.
  * @type {Object.<string, Array.<Object>>}
@@ -23,13 +16,16 @@ var linksHash = require('../../../package.json').version;
  * @param {!Object} doc Current document.
  */
 var addLinkToSourceCode = function(doc) {
-  var template = doc.fileInfo.filePath.indexOf('selenium-webdriver') !== -1 ?
-      templateMapping.webdriver : templateMapping.protractor;
+  // Heuristic for the custom docs in the lib/selenium-webdriver/ folder.
+  if (doc.name && doc.name.startsWith('webdriver')) {
+    return;
+  }
+  var template = _.template('https://github.com/angular/protractor/blob/' +
+      '<%= linksHash %>/lib/<%= fileName %>.js');
 
   doc.sourceLink = template({
     linksHash: linksHash,
-    fileName: doc.fileName,
-    startingLine: doc.startingLine
+    fileName: doc.fileName
   });
 };
 

--- a/website/docgen/spec/add-links-spec.js
+++ b/website/docgen/spec/add-links-spec.js
@@ -22,18 +22,7 @@ describe('add-links', function() {
     addLinks([doc]);
     expect(doc.sourceLink).toBe('https://github.com/angular/protractor/' +
         'blob/' + require('../../../package.json').version + '/lib/' +
-        'protractor.js#L123');
-  });
-
-  it('should add webdriver link', function() {
-    var doc = {
-      fileName: 'webdriver',
-      fileInfo: { filePath: 'selenium-webdriver' },
-      startingLine: 123
-    };
-    addLinks([doc]);
-    expect(doc.sourceLink).toBe('https://github.com/SeleniumHQ/selenium/' +
-        'blob/master/javascript/webdriver/webdriver.js#L123');
+        'protractor.js');
   });
 
   it('should add links to types', function() {

--- a/website/js/api-controller.js
+++ b/website/js/api-controller.js
@@ -20,12 +20,7 @@
 
     $scope.items = [];
     $scope.isMenuVisible = false;
-    var defaultItem = {
-      title: 'Protractor API Docs',
-      description: 'Welcome to the Protractor API docs page. These pages ' +
-      'contain the Protractor reference materials.'
-    };
-    $scope.currentItem = defaultItem;
+    $scope.currentItem = null;
 
     // Watch for location changes to show the correct item.
     $scope.$on('$locationChangeSuccess', function() {
@@ -243,13 +238,15 @@
     return newList;
   };
 
+  // TODO: This is a hack for getting the 'Inherited from Webdriver...' stuff.
+  // Instead, move our extra docs to colocate with our fns, remove the selenium-webdriver
+  // folder, and remove this.
   ApiCtrl.prototype.addExtends = function(list) {
     var self = this;
     list.forEach(function(item) {
       if (!item.extends) {
         return;
       }
-
       // Remove braces from {type}.
       var parentName = item.extends.replace(/[{}]/g, '');
       var nameExpr = new RegExp(parentName + '\\.prototype');
@@ -261,7 +258,6 @@
           return item.name && item.name.match(nameExpr);
         })
       };
-
       if (self.itemsByName[parentName]) {
         self.itemsByName[parentName].extension = true;
       }

--- a/website/partials/api.html
+++ b/website/partials/api.html
@@ -1,7 +1,7 @@
 <div>
 
   <div class="row">
-    <h3 id="title">Protractor API <small>{{::version}}</small></h3>
+    <h3 ng-click="currentItem=null" id="title">Protractor API <small>{{::version}}</small></h3>
   </div>
 
   <!-- Search -->
@@ -78,8 +78,22 @@
       </div>
     </div>
 
+    <div ng-if="!currentItem" class="col-sm-9">
+      <h3 class="api-title">
+        Protractor API Docs
+      </h3>
+      <p>
+        Welcome to the Protractor API documentation. The menu lists all classes and methods
+        exposed by Protractor.
+      </p>
+      <p>
+        Note that Protractor is a wrapper around
+        <a href="http://seleniumhq.github.io/selenium/docs/api/javascript/index.html">selenium-webdriver</a>,
+        the Webdriver bindings for Node.js. See that documentation for advanced usage.
+      </p>
+    </div>
 
-    <div class="col-sm-9">
+    <div ng-if="currentItem" class="col-sm-9">
       <h3 class="api-title">
         {{currentItem.title}}
         <small ng-if="currentItem.sourceLink">
@@ -88,12 +102,6 @@
         <h4 ng-if="currentItem.alias != currentItem.displayName"
             class="text-muted">{{currentItem.name}}</h4>
       </h3>
-      <p ng-if="currentItem.sourceLink.indexOf('protractor') == -1"
-          class="api-webdriver">
-        This page is written using pure WebDriverJS syntax, instead of
-        Protractor syntax.  See <a href="#/webdriver-vs-protractor">
-        Protractor Syntax vs WebDriverJS Syntax</a> for details.
-      </p>
       <p ng-bind-html="trust(currentItem.description)"></p>
 
       <div ng-if="currentItem.example">

--- a/website/test/e2e/api_spec.js
+++ b/website/test/e2e/api_spec.js
@@ -105,7 +105,7 @@ describe('Api', function() {
     // Then ensure the child functions are shown.
     expect(apiPage.getChildFunctionNames()).toEqual([
       'then', 'clone', 'locator', 'getWebElement', 'all', 'element', '$$',
-      '$', 'isPresent', 'isElementPresent', 'evaluate', 'allowAnimations']);
+      '$', 'isPresent', 'isElementPresent', 'evaluate', 'allowAnimations', 'equals']);
   });
 
   it('should show browser functions', function() {
@@ -127,13 +127,13 @@ describe('Api', function() {
     apiPage.clickOnMenuItem('browser');
 
     // When you click on the 'executeAsyncScript' item of the extends table.
-    apiPage.clickOnExtendsType('executeAsyncScript');
+    apiPage.clickOnExtendsType('sleep');
 
     // Then ensure the type is shown.
     expect(apiPage.title.getText()).
-        toBe('webdriver.WebDriver.executeAsyncScript View code');
+        toBe('webdriver.WebDriver.sleep');
     expect(browser.getCurrentUrl()).
-        toMatch(/api\?view=webdriver.WebDriver.prototype.executeAsyncScript/);
+        toMatch(/api\?view=webdriver.WebDriver.prototype.sleep/);
   });
 
   it('should sort the menu to put webdriver docs next to the relevant ' +


### PR DESCRIPTION
Add docs for common inherited functions on browser.
Add links to selenium-webdriver documentation.
Clean up the docgen code a little bit.
Make website tests pass again.