### PR TITLE
fix(docs): Change extension for docs links to .ts

### DIFF
--- a/website/docgen/processors/add-links.js
+++ b/website/docgen/processors/add-links.js
@@ -21,7 +21,7 @@ var addLinkToSourceCode = function(doc) {
     return;
   }
   var template = _.template('https://github.com/angular/protractor/blob/' +
-      '<%= linksHash %>/lib/<%= fileName %>.js');
+      '<%= linksHash %>/lib/<%= fileName %>.ts');
 
   doc.sourceLink = template({
     linksHash: linksHash,

--- a/website/docgen/spec/add-links-spec.js
+++ b/website/docgen/spec/add-links-spec.js
@@ -22,7 +22,7 @@ describe('add-links', function() {
     addLinks([doc]);
     expect(doc.sourceLink).toBe('https://github.com/angular/protractor/' +
         'blob/' + require('../../../package.json').version + '/lib/' +
-        'protractor.js');
+        'protractor.ts');
   });
 
   it('should add links to types', function() {
@@ -255,7 +255,7 @@ describe('add-links', function() {
         toBe('A promise located {@code Web Elements}.');
   });
 
-  it('should remove extraneous chatacters from @link links', function() {
+  it('should remove extraneous characters from @link links', function() {
     // Given a doc with a @link annotation.
     var docs = [
       {


### PR DESCRIPTION
This fixes #3170. The doc "view source" links are still pointing to `.js` files. This changes the extension to `.ts` (which should be all right given the recent js -> ts switchover. 

This [test](https://github.com/angular/protractor/blob/master/website/test/e2e/api_spec.js#L101) is failing for me locally, but also fails when I run it against master. I'll investigate more but I don't think it is affected by my changes.

![screen shot 2016-04-29 at 8 22 32 am](https://cloud.githubusercontent.com/assets/1290336/14919123/e6676a60-0dec-11e6-841b-ac13f5186995.png)