### PR TITLE
Chore(conf): Refactor npm tests to run the tests in a unique task.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,10 @@ Clone the github repository:
     npm install
     cd ..
 
-Start up a selenium server. By default, the tests expect the selenium server to be running at `http://localhost:4444/wd/hub`. A selenium server can be started with `webdriver-manager`.
-
-    bin/webdriver-manager start
-
-Protractor's test suite runs against the included test application. Start that up with
-
-    npm start
-
-Then run the tests with
+###Running tests
 
     npm test
+
+This task will execute all the required steps to run the tests on your local environment.
+The selenium server by default will be running at `http://localhost:4444/wd/hub`. 
+

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -39,6 +39,10 @@ gulp.task('jshint', function(done) {
       'spec', 'scripts', '--exclude=lib/selenium-webdriver/**/*.js']);
 });
 
+gulp.task('start webdriver', function(done) {
+  runSpawn(done,'npm start');
+});
+
 gulp.task('clang', function() {
   return gulp.src(['lib/**/*.ts'])
       .pipe(gulpFormat.checkFormat('file', clangFormat))
@@ -61,7 +65,8 @@ gulp.task('prepublish', function(done) {
 
 gulp.task('pretest', function(done) {
   runSequence(
-    ['webdriver:update', 'typings', 'jshint', 'clang'], 'tsc', 'built:copy', done);
+    ['webdriver:update', 'typings', 'jshint', 'clang','start webdriver'],
+     'tsc', 'built:copy', done);
 });
 
 gulp.task('default',['prepublish']);

--- a/lib/configParser.ts
+++ b/lib/configParser.ts
@@ -117,7 +117,8 @@ export class ConfigParser {
 
     if (patterns) {
       for (let fileName of patterns) {
-        let matches = glob.hasMagic(fileName) ? glob.sync(fileName, {cwd}) : [fileName];
+        let matches =
+            glob.hasMagic(fileName) ? glob.sync(fileName, {cwd}) : [fileName];
         if (!matches.length && !opt_omitWarnings) {
           logger.warn('pattern ' + fileName + ' did not match any files.');
         }

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   "scripts": {
     "prepublish": "gulp prepublish",
     "pretest": "gulp pretest",
+    "prestart": "webdriver-manager start > /dev/null 2>&1 &",
     "start": "node testapp/scripts/web-server.js",
     "test": "node scripts/test.js",
     "tsc": "./node_modules/typescript/bin/tsc",

--- a/website/gulpfile.js
+++ b/website/gulpfile.js
@@ -5,8 +5,7 @@ var Dgeni = require('dgeni');
 var gulp = require('gulp');
 var less = require('gulp-less');
 var markdown = require('gulp-markdown');
-var minifyCSS = require('gulp-minify-css');
-var path = require('path');
+var cleanCSS = require('gulp-clean-css');
 var rename = require('gulp-rename');
 var replace = require('gulp-replace');
 
@@ -65,7 +64,7 @@ gulp.task('js', function() {
 gulp.task('less', function() {
   gulp.src(paths.less)
       .pipe(less())
-      .pipe(minifyCSS())
+      .pipe(cleanCSS())
       .pipe(gulp.dest(paths.outputDir + '/css'));
 });
 

--- a/website/js/api-controller.js
+++ b/website/js/api-controller.js
@@ -132,12 +132,12 @@
       // Add short description.
       if (item.description) {
         // Find the correct portion of the description
-        
+
         // The following parsing is OK most of the time
         var sentenceEnd = item.description.search(/\.\s|\.$/) + 1 || Infinity;
         var paragraphEnd = item.description.indexOf('</p>') + 4;
         if (paragraphEnd == 3) {
-          paragraphEnd = Infinity
+          paragraphEnd = Infinity;
         }
         var shortDescription = item.description.substring(0, Math.min(
             item.description.length, sentenceEnd, paragraphEnd)).trim();
@@ -217,7 +217,7 @@
         }
       }
     };
-    
+
     var prevFileName;
     list.forEach(function(item) {
       if ((item.type !== 'child') && !item.extension) {

--- a/website/js/directives.js
+++ b/website/js/directives.js
@@ -43,7 +43,7 @@
           if (shouldPaint) {
             element.html(prettyHtml);
           }
-        }
+        };
       }
     };
   });

--- a/website/package.json
+++ b/website/package.json
@@ -12,7 +12,7 @@
     "gulp-connect": "^2.0.6",
     "gulp-less": "^1.3.3",
     "gulp-markdown": "^1.0.0",
-    "gulp-minify-css": "^0.3.7",
+    "gulp-clean-css": "2.0.6",
     "gulp-rename": "^1.2.0",
     "gulp-replace": "^0.4.0",
     "jasmine": "2.3.2",


### PR DESCRIPTION
Hey guys, I made some refactor on how the tests are running with npm/gulp.
Basically, before this PR, to run the tests the user needs to run manually three tasks:

- bin/webdriver-manager start
- npm start
- npm test

So, I change this putting the **npm start** as dependency of **gulp pretest** and also **bin/webdriver-manager start** is a dependency task of **npm start**. With these changes, the user just need to run the task **npm test** to run the tests on your local environment. 

Another important thing is that I put the **webdriver-manager start** to run on background.

Please, give me some feedbacks about this change and how I can improve it. 👍 
 