### PR TITLE
Fix Configuration option getMultiCapabilities when configured as a promise.

### DIFF
--- a/lib/launcher.ts
+++ b/lib/launcher.ts
@@ -127,7 +127,7 @@ let initFn = function(configFile: string, additionalConfig: Config) {
                 q.when(config.getMultiCapabilities(), (multiCapabilities) => {
                    config.multiCapabilities = multiCapabilities;
                    config.capabilities = null;
-                 }).then((resolve) => {});
+                 }).then(resolve);
               } else {
                 resolve();
               }


### PR DESCRIPTION
Fix for #3191

Since the rewrite to typescript the getMultiCapabilities promise configuration did not resolve.
This fix will resolve the promise like it used to before the rewrite