### PR TITLE
docs(dgeni): doc generation with typescript files instead of javascript files

### DIFF
--- a/website/docgen/dgeni-config.js
+++ b/website/docgen/dgeni-config.js
@@ -74,7 +74,7 @@ myPackage.config(function(readFilesProcessor, templateFinder, writeFilesProcesso
     {include: 'built/element.ts'},
     {include: 'built/protractor.ts'},
     {include: 'built/locators.ts'},
-    {include: 'built/expectedConditions.js'},
+    {include: 'built/expectedConditions.ts'},
     {include: 'lib/selenium-webdriver/locators.js'},
     {include: 'lib/selenium-webdriver/webdriver.js'}
   ];

--- a/website/docgen/dgeni-config.js
+++ b/website/docgen/dgeni-config.js
@@ -71,9 +71,9 @@ myPackage.config(function(readFilesProcessor, templateFinder, writeFilesProcesso
   readFilesProcessor.basePath = path.resolve(__dirname, '../..');
 
   readFilesProcessor.sourceFiles = [
-    {include: 'built/element.js'},
-    {include: 'built/protractor.js'},
-    {include: 'built/locators.js'},
+    {include: 'built/element.ts'},
+    {include: 'built/protractor.ts'},
+    {include: 'built/locators.ts'},
     {include: 'built/expectedConditions.js'},
     {include: 'lib/selenium-webdriver/locators.js'},
     {include: 'lib/selenium-webdriver/webdriver.js'}


### PR DESCRIPTION
Due to recent typescript file conversion, there are few number of 404 errors on links from the docs.

I am not 100% sure if this is the right place to change. I cloned this copy and ran on my local host - I could see only half of API but not the full API list say(e.g) [I was not able to see By locators of protractor, element module of protractor etc..] Hence submitting this patch using file edit from Github.