### PR TITLE
Use resetUrl about:blank for MicrosoftEdge

### DIFF
--- a/lib/browser.ts
+++ b/lib/browser.ts
@@ -270,7 +270,7 @@ export class Browser {
       // PhantomJS produces a "Detected a page unload event" if we use data urls
       var browserName = caps.get('browserName');
       if (browserName === 'internet explorer' || browserName === 'safari' ||
-          browserName === 'phantomjs') {
+          browserName === 'phantomjs' || browserName === 'MicrosoftEdge') {
         this.resetUrl = 'about:blank';
       }
     });


### PR DESCRIPTION
Currently protractor opens 'data:text/html' page on Edge browser on test start for angular websites.

Edge redirects 'data:text/html' to an error page 'Thats odd: Microsoft Edge cant find this page' with url 'ms-appx-web://microsoft.microsoftedge/assets/errorpages/unknownprotocol.htm#data:text/html,<html></html>'. Run/Inject javascript on this page sometimes returns 'Javascript execution context no longer exists' error.

Using 'about:blank' does not show this page.