### PR TITLE
chore(launcher): clean up multicapabilities typing error

### DIFF
--- a/lib/launcher.ts
+++ b/lib/launcher.ts
@@ -128,7 +128,7 @@ let initFn = function(configFile: string, additionalConfig: Config) {
                 q.when(config.getMultiCapabilities(), (multiCapabilities) => {
                    config.multiCapabilities = multiCapabilities;
                    config.capabilities = null;
-                 }).then(resolve);
+                 }).then(() => resolve());
               } else {
                 resolve();
               }


### PR DESCRIPTION
fix for tsc error: "Argument of type 'Function' is not assignable to parameter"