### PR TITLE
chore(typings): remove ptor from gulp types

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -72,12 +72,14 @@ gulp.task('default',['prepublish']);
 
 gulp.task('types', function(done) {
   var folder = 'built';
-  var files = ['ptor', 'browser', 'element', 'locators', 'expectedConditions'];
+  var files = ['browser', 'element', 'locators', 'expectedConditions'];
   var outputFile = path.resolve(folder, 'index.d.ts');
   var contents = '';
+  contents += 'declare namespace protractor {\n';
   files.forEach(file => {
     contents += parseTypingsFile(folder, file);
   });
+  contents += '}\n';
 
   // add module declaration
   contents += 'declare module "protractor" {\n';
@@ -104,6 +106,9 @@ var parseTypingsFile = function(folder, file) {
       if (line.indexOf('export') !== -1) {
         line = line.replace('export', '').trim();
       }
+      if (line.indexOf('declare') !== -1) {
+        line = line.replace('declare', '').trim();
+      }
 
       // Remove webdriver types and plugins for now
       line = removeTypes(line,'webdriver.ActionSequence');
@@ -115,7 +120,6 @@ var parseTypingsFile = function(folder, file) {
       line = removeTypes(line,'Plugins');
       contents += line + '\n';
     }
-
   }
   return contents;
 }

--- a/scripts/typings_tests/test_fail_browser.ts
+++ b/scripts/typings_tests/test_fail_browser.ts
@@ -1,5 +1,6 @@
 /// <reference path="../../built/index.d.ts" />
-import {browser} from 'protractor';
+import {Browser} from 'protractor';
+let browser: Browser;
 browser.getProcessedConfig(0);
 browser.getProcessedConfig('1');
 browser.getProcessedConfig(true);

--- a/scripts/typings_tests/test_fail_by.ts
+++ b/scripts/typings_tests/test_fail_by.ts
@@ -1,5 +1,7 @@
 /// <reference path="../../built/index.d.ts" />
-import {by, By} from 'protractor';
+import {ProtractorBy} from 'protractor';
+let by: ProtractorBy;
+let By: ProtractorBy;
 by.addLocator(0, () => {});
 by.addLocator(() => {}, () => {});
 by.addLocator('', () => {}, () => {});

--- a/scripts/typings_tests/test_fail_elements.ts
+++ b/scripts/typings_tests/test_fail_elements.ts
@@ -1,5 +1,9 @@
 /// <reference path="../../built/index.d.ts" />
-import {element, by, $, $$} from 'protractor';
+import {ElementArrayFinder, ElementFinder, ElementHelper, ProtractorBy} from 'protractor';
+let element: ElementHelper;
+let by: ProtractorBy;
+let $: (search: string) => ElementFinder;
+let $$: (search: string) => ElementArrayFinder;
 element.all(by.css('')).clone('clone');
 element.all(by.css('')).clone(1);
 element.all(by.css('')).clone(false);

--- a/scripts/typings_tests/test_fail_expected_conditions.ts
+++ b/scripts/typings_tests/test_fail_expected_conditions.ts
@@ -1,5 +1,6 @@
 /// <reference path="../../built/index.d.ts" />
-import {element, by, ExpectedConditions} from 'protractor';
+import {ExpectedConditions_} from 'protractor';
+let ExpectedConditions: ExpectedConditions_;
 ExpectedConditions.not(0);
 ExpectedConditions.not('1');
 ExpectedConditions.not(true);

--- a/scripts/typings_tests/test_pass.ts
+++ b/scripts/typings_tests/test_pass.ts
@@ -1,5 +1,12 @@
 /// <reference path="../../built/index.d.ts" />
-import {browser, element, by, By, $, $$, ExpectedConditions} from 'protractor';
+import {Browser, ElementArrayFinder, ElementFinder, ElementHelper, ExpectedConditions_, ProtractorBy} from 'protractor';
+let browser: Browser;
+let by: ProtractorBy;
+let By: ProtractorBy;
+let element: ElementHelper;
+let $: (search: string) => ElementFinder;
+let $$: (search: string) => ElementArrayFinder;
+let ExpectedConditions: ExpectedConditions_;
 element.all(by.css('')).clone();
 element.all(by.css('')).then(() => {}, () => {});  // this is not appearing on the website
 element.all(by.css('')).filter(() => {});

--- a/scripts/typings_tests/test_typings.js
+++ b/scripts/typings_tests/test_typings.js
@@ -75,10 +75,10 @@ var testPassing = function(file) {
 
 
 // The tests:
-testFailures('test_fail_elements.ts', 3, 478);
-testFailures('test_fail_browser.ts', 3, 93);
-testFailures('test_fail_expected_conditions.ts', 3, 24);
-testFailures('test_fail_by.ts', 3, 207);
+testFailures('test_fail_browser.ts', 4, 94);
+testFailures('test_fail_by.ts', 5, 209);
+testFailures('test_fail_elements.ts', 7, 482);
+testFailures('test_fail_expected_conditions.ts', 4, 25);
 testPassing('test_pass.ts');
 
 // Test evaluation and exiting:


### PR DESCRIPTION
- after investigation, variables in the namespace cannot be assigned a value
- types will require import of the classes and then setting the value from global

  ```
  import {Browser} from 'protractor';
  var browser: Browser = global['browser'];
  ```