### PR TITLE
chore(types): fix import of package.json typings

### DIFF
--- a/globals.ts
+++ b/globals.ts
@@ -1,0 +1,16 @@
+import {
+  Browser,
+  ElementArrayFinder,
+  ElementFinder,
+  ElementHelper,
+  ProtractorBy,
+  ProtractorExpectedConditions
+} from 'protractor';
+
+export var browser: Browser = global['browser'];
+export var element: ElementHelper = global['element'];
+export var by: ProtractorBy = global['by'];
+export var By: ProtractorBy = global['By'];
+export var $: (search: string) => ElementFinder = global['$'];
+export var $$: (search: string) => ElementArrayFinder = global['$$'];
+export var ExpectedConditions: ProtractorExpectedConditions = global['ExpectedConditions'];

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -75,16 +75,9 @@ gulp.task('types', function(done) {
   var files = ['browser', 'element', 'locators', 'expectedConditions'];
   var outputFile = path.resolve(folder, 'index.d.ts');
   var contents = '';
-  contents += 'declare namespace protractor {\n';
   files.forEach(file => {
     contents += parseTypingsFile(folder, file);
   });
-  contents += '}\n';
-
-  // add module declaration
-  contents += 'declare module "protractor" {\n';
-  contents += '  export = protractor\n';
-  contents += '}\n';
 
   // remove files with d.ts
   glob.sync(folder + '/**/*.d.ts').forEach(file => {
@@ -103,9 +96,6 @@ var parseTypingsFile = function(folder, file) {
   for (var linePos in lines) {
     var line = lines[linePos];
     if (!line.startsWith('import')) {
-      if (line.indexOf('export') !== -1) {
-        line = line.replace('export', '').trim();
-      }
       if (line.indexOf('declare') !== -1) {
         line = line.replace('declare', '').trim();
       }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "testapp",
     "website",
     "typings/globals",
-    "scripts"
+    "scripts",
+    "globals.ts"
   ]
 }


### PR DESCRIPTION
 - fixes Exported external package typings file is not a module
 - allows for users to `import {browser,element,by,$,$$,ExpectedConditions} from 'protractor/globals';`