### PR TITLE
chore(cleanup): clean up with clang issues

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -42,12 +42,18 @@ gulp.task('jshint', function(done) {
       'spec', 'scripts', '--exclude=lib/selenium-webdriver/**/*.js']);
 });
 
-gulp.task('clang', function() {
-  return gulp.src(['lib/**/*.ts'])
-      .pipe(gulpFormat.checkFormat('file', clangFormat))
-      .on('warning', function(e) {
-    console.log(e);
-  });
+gulp.task('format:enforce', () => {
+  const format = require('gulp-clang-format');
+  const clangFormat = require('clang-format');
+  return gulp.src(['lib/**/*.ts']).pipe(
+    format.checkFormat('file', clangFormat, {verbose: true, fail: true}));
+});
+
+gulp.task('format', () => {
+  const format = require('gulp-clang-format');
+  const clangFormat = require('clang-format');
+  return gulp.src(['lib/**/*.ts'], { base: '.' }).pipe(
+    format.format('file', clangFormat)).pipe(gulp.dest('.'));
 });
 
 gulp.task('typings', function(done) {
@@ -59,12 +65,12 @@ gulp.task('tsc', function(done) {
 });
 
 gulp.task('prepublish', function(done) {
-  runSequence(['typings', 'jshint', 'clang'], 'tsc', 'types', 'built:copy', done);
+  runSequence(['typings', 'jshint', 'format'], 'tsc', 'types', 'built:copy', done);
 });
 
 gulp.task('pretest', function(done) {
   runSequence(
-    ['webdriver:update', 'typings', 'jshint', 'clang'], 'tsc', 'types',
+    ['webdriver:update', 'typings', 'jshint', 'format'], 'tsc', 'types',
     'built:copy', done);
 });
 

--- a/lib/browser.ts
+++ b/lib/browser.ts
@@ -301,7 +301,8 @@ export class Browser extends Webdriver {
    *
    * Set by the runner.
    *
-   * @returns {webdriver.promise.Promise} A promise which resolves to the capabilities object.
+   * @returns {webdriver.promise.Promise} A promise which resolves to the
+   * capabilities object.
    */
   getProcessedConfig: () => webdriver.promise.Promise<any>;
 
@@ -310,8 +311,10 @@ export class Browser extends Webdriver {
    *
    * Set by the runner.
    *
-   * @param {boolean} opt_useSameUrl Whether to navigate to current url on creation
-   * @param {boolean} opt_copyMockModules Whether to apply same mock modules on creation
+   * @param {boolean} opt_useSameUrl Whether to navigate to current url on
+   * creation
+   * @param {boolean} opt_copyMockModules Whether to apply same mock modules on
+   * creation
    * @returns {Protractor} a protractor instance.
    */
   forkNewDriverInstance:
@@ -343,7 +346,8 @@ export class Browser extends Webdriver {
    * @param {!(string|Function)} script The script to execute.
    * @param {string} description A description of the command for debugging.
    * @param {...*} var_args The arguments to pass to the script.
-   * @returns {!webdriver.promise.Promise.<T>} A promise that will resolve to the
+   * @returns {!webdriver.promise.Promise.<T>} A promise that will resolve to
+   * the
    *    scripts return value.
    * @template T
    */
@@ -369,7 +373,8 @@ export class Browser extends Webdriver {
    * @param {!(string|Function)} script The script to execute.
    * @param {string} description A description for debugging purposes.
    * @param {...*} var_args The arguments to pass to the script.
-   * @returns {!webdriver.promise.Promise.<T>} A promise that will resolve to the
+   * @returns {!webdriver.promise.Promise.<T>} A promise that will resolve to
+   * the
    *    scripts return value.
    * @template T
    */
@@ -923,7 +928,8 @@ export class Browser extends Webdriver {
    * already be bound to the debugger, so it will not be available, but that is
    * okay.
    *
-   * @returns {Promise<boolean>} A promise that becomes ready when the validation
+   * @returns {Promise<boolean>} A promise that becomes ready when the
+   * validation
    *     is done. The promise will resolve to a boolean which represents whether
    *     this is the first time that the debugger is called.
    */

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -1,6 +1,6 @@
-import * as path from 'path';
 import * as fs from 'fs';
 import * as optimist from 'optimist';
+import * as path from 'path';
 
 /**
  * The command line interface for interacting with the Protractor runner.

--- a/lib/configParser.ts
+++ b/lib/configParser.ts
@@ -1,9 +1,9 @@
-import * as path from 'path';
 import * as glob from 'glob';
+import * as path from 'path';
 
-import {Logger} from './logger2';
 import {ConfigError} from './exitCodes';
 import {Config} from './config';
+import {Logger} from './logger2';
 
 let logger = new Logger('configParser');
 

--- a/lib/driverProviders/attachSession.ts
+++ b/lib/driverProviders/attachSession.ts
@@ -4,6 +4,7 @@
  *  it down, and setting up the driver correctly.
  */
 import * as q from 'q';
+
 import {Config} from '../config';
 import {DriverProvider} from './driverProvider';
 import {Logger} from '../logger2';

--- a/lib/driverProviders/browserStack.ts
+++ b/lib/driverProviders/browserStack.ts
@@ -7,9 +7,9 @@ import * as https from 'https';
 import * as q from 'q';
 import * as util from 'util';
 
-import {BrowserError} from '../exitCodes';
 import {Config} from '../config';
 import {DriverProvider} from './driverProvider';
+import {BrowserError} from '../exitCodes';
 import {Logger} from '../logger2';
 
 let logger = new Logger('browserstack');
@@ -28,12 +28,12 @@ export class BrowserStack extends DriverProvider {
       let deferred = q.defer();
       driver.getSession().then((session: webdriver.Session) => {
         let headers: Object = {
-            'Content-Type': 'application/json',
-            'Authorization': 'Basic ' +
-                new Buffer(
-                    this.config_.browserstackUser + ':' +
-                    this.config_.browserstackKey)
-                    .toString('base64')
+          'Content-Type': 'application/json',
+          'Authorization': 'Basic ' +
+              new Buffer(
+                  this.config_.browserstackUser + ':' +
+                  this.config_.browserstackKey)
+                  .toString('base64')
         };
         let options = {
           hostname: 'www.browserstack.com',
@@ -46,25 +46,26 @@ export class BrowserStack extends DriverProvider {
         let req = https.request(options, (res) => {
           res.on('data', (data: Buffer) => {
             var info = JSON.parse(data.toString());
-            if (info && info.automation_session && info.automation_session.browser_url){
+            if (info && info.automation_session &&
+                info.automation_session.browser_url) {
               logger.info(
-                'BrowserStack results available at ' +
-                info.automation_session.browser_url);
+                  'BrowserStack results available at ' +
+                  info.automation_session.browser_url);
             } else {
               logger.info(
-                'BrowserStack results available at ' +
-                'https://www.browserstack.com/automate');
+                  'BrowserStack results available at ' +
+                  'https://www.browserstack.com/automate');
             }
           });
         });
         req.end();
         req.on('error', (e: Error) => {
           logger.info(
-            'BrowserStack results available at ' +
-            'https://www.browserstack.com/automate');
+              'BrowserStack results available at ' +
+              'https://www.browserstack.com/automate');
         });
         let jobStatus = update.passed ? 'completed' : 'error';
-        options.method  = 'PUT';
+        options.method = 'PUT';
         https
             .request(
                 options,

--- a/lib/driverProviders/direct.ts
+++ b/lib/driverProviders/direct.ts
@@ -3,22 +3,24 @@
  *  It is responsible for setting up the account object, tearing
  *  it down, and setting up the driver correctly.
  */
-import * as q from 'q';
 import * as fs from 'fs';
 import * as path from 'path';
+import * as q from 'q';
 import * as util from 'util';
 
-import {BrowserError} from '../exitCodes';
 import {Config} from '../config';
 import {DriverProvider} from './driverProvider';
+import {BrowserError} from '../exitCodes';
 import {Logger} from '../logger2';
 
 let webdriver = require('selenium-webdriver'),
     chrome = require('selenium-webdriver/chrome'),
     firefox = require('selenium-webdriver/firefox');
 let SeleniumConfig = require('webdriver-manager/built/lib/config').Config;
-let SeleniumChrome = require('webdriver-manager/built/lib/binaries/chrome_driver').ChromeDriver;
-let SeleniumStandAlone = require('webdriver-manager/built/lib/binaries/stand_alone').StandAlone;
+let SeleniumChrome =
+    require('webdriver-manager/built/lib/binaries/chrome_driver').ChromeDriver;
+let SeleniumStandAlone =
+    require('webdriver-manager/built/lib/binaries/stand_alone').StandAlone;
 
 
 let logger = new Logger('direct');
@@ -59,8 +61,8 @@ export class Direct extends DriverProvider {
     switch (this.config_.capabilities.browserName) {
       case 'chrome':
         let defaultChromeDriverPath = path.resolve(
-          SeleniumConfig.getSeleniumDir(),
-          new SeleniumChrome().executableFilename());
+            SeleniumConfig.getSeleniumDir(),
+            new SeleniumChrome().executableFilename());
 
         if (process.platform.indexOf('win') === 0) {
           defaultChromeDriverPath += '.exe';

--- a/lib/driverProviders/local.ts
+++ b/lib/driverProviders/local.ts
@@ -11,14 +11,17 @@ import * as path from 'path';
 import * as q from 'q';
 import * as util from 'util';
 
-import {BrowserError} from '../exitCodes';
+
 import {Config} from '../config';
 import {DriverProvider} from './driverProvider';
+import {BrowserError} from '../exitCodes';
 import {Logger} from '../logger2';
 
 let SeleniumConfig = require('webdriver-manager/built/lib/config').Config;
-let SeleniumChrome = require('webdriver-manager/built/lib/binaries/chrome_driver').ChromeDriver;
-let SeleniumStandAlone = require('webdriver-manager/built/lib/binaries/stand_alone').StandAlone;
+let SeleniumChrome =
+    require('webdriver-manager/built/lib/binaries/chrome_driver').ChromeDriver;
+let SeleniumStandAlone =
+    require('webdriver-manager/built/lib/binaries/stand_alone').StandAlone;
 let remote = require('selenium-webdriver/remote');
 
 let logger = new Logger('local');
@@ -39,8 +42,8 @@ export class Local extends DriverProvider {
           'Attempting to find the SeleniumServerJar in the default ' +
           'location used by webdriver-manager');
       this.config_.seleniumServerJar = path.resolve(
-        SeleniumConfig.getSeleniumDir(),
-        new SeleniumStandAlone().executableFilename());
+          SeleniumConfig.getSeleniumDir(),
+          new SeleniumStandAlone().executableFilename());
     }
     if (!fs.existsSync(this.config_.seleniumServerJar)) {
       throw new BrowserError(
@@ -54,8 +57,8 @@ export class Local extends DriverProvider {
             'Attempting to find the chromedriver binary in the default ' +
             'location used by webdriver-manager');
         this.config_.chromeDriver = path.resolve(
-          SeleniumConfig.getSeleniumDir(),
-          new SeleniumChrome().executableFilename());
+            SeleniumConfig.getSeleniumDir(),
+            new SeleniumChrome().executableFilename());
       }
 
       // Check if file exists, if not try .exe or fail accordingly

--- a/lib/element.ts
+++ b/lib/element.ts
@@ -130,7 +130,8 @@ export class ElementArrayFinder extends WebdriverWebElement {
 
   /**
    * Calls to ElementArrayFinder may be chained to find an array of elements
-   * using the current elements in this ElementArrayFinder as the starting point.
+   * using the current elements in this ElementArrayFinder as the starting
+   * point.
    * This function returns a new ElementArrayFinder which would contain the
    * children elements found (and could also be empty).
    *
@@ -154,7 +155,8 @@ export class ElementArrayFinder extends WebdriverWebElement {
    * expect(foo.getText()).toEqual(['1a', '2a'])
    * let baz = element.all(by.css('.parent')).all(by.css('.baz'))
    * expect(baz.getText()).toEqual(['1b'])
-   * let nonexistent = element.all(by.css('.parent')).all(by.css('.NONEXISTENT'))
+   * let nonexistent =
+   * element.all(by.css('.parent')).all(by.css('.NONEXISTENT'))
    * expect(nonexistent.getText()).toEqual([''])
    *
    * @param {webdriver.Locator} subLocator
@@ -205,8 +207,10 @@ export class ElementArrayFinder extends WebdriverWebElement {
   }
 
   /**
-   * Apply a filter function to each element within the ElementArrayFinder. Returns
-   * a new ElementArrayFinder with all elements that pass the filter function. The
+   * Apply a filter function to each element within the ElementArrayFinder.
+   * Returns
+   * a new ElementArrayFinder with all elements that pass the filter function.
+   * The
    * filter function receives the ElementFinder as the first argument
    * and the index as a second arg.
    * This does not actually retrieve the underlying list of elements, so it can
@@ -227,10 +231,13 @@ export class ElementArrayFinder extends WebdriverWebElement {
    *   });
    * }).first().click();
    *
-   * @param {function(ElementFinder, number): webdriver.WebElement.Promise} filterFn
+   * @param {function(ElementFinder, number): webdriver.WebElement.Promise}
+   * filterFn
    *     Filter function that will test if an element should be returned.
-   *     filterFn can either return a boolean or a promise that resolves to a boolean
-   * @returns {!ElementArrayFinder} A ElementArrayFinder that represents an array
+   *     filterFn can either return a boolean or a promise that resolves to a
+   * boolean
+   * @returns {!ElementArrayFinder} A ElementArrayFinder that represents an
+   * array
    *     of element that satisfy the filter function.
    */
   filter(filterFn: Function): ElementArrayFinder {
@@ -255,7 +262,8 @@ export class ElementArrayFinder extends WebdriverWebElement {
   }
 
   /**
-   * Get an element within the ElementArrayFinder by index. The index starts at 0.
+   * Get an element within the ElementArrayFinder by index. The index starts at
+   * 0.
    * Negative indices are wrapped (i.e. -i means ith element from last)
    * This does not actually retrieve the underlying element.
    *
@@ -352,7 +360,8 @@ export class ElementArrayFinder extends WebdriverWebElement {
 
   /**
    * Returns an ElementFinder representation of ElementArrayFinder. It ensures
-   * that the ElementArrayFinder resolves to one and only one underlying element.
+   * that the ElementArrayFinder resolves to one and only one underlying
+   * element.
    *
    * @returns {ElementFinder} An ElementFinder representation
    * @private
@@ -410,7 +419,8 @@ export class ElementArrayFinder extends WebdriverWebElement {
 
   /**
    * Apply an action function to every element in the ElementArrayFinder,
-   * and return a new ElementArrayFinder that contains the results of the actions.
+   * and return a new ElementArrayFinder that contains the results of the
+   * actions.
    *
    * @param {function(ElementFinder)} actionFn
    *
@@ -579,7 +589,8 @@ export class ElementArrayFinder extends WebdriverWebElement {
    * expect(value).toEqual('First Second Third ');
    *
    * @param {function(number, ElementFinder, number, Array.<ElementFinder>)}
-   *     reduceFn Reduce function that reduces every element into a single value.
+   *     reduceFn Reduce function that reduces every element into a single
+   * value.
    * @param {*} initialValue Initial value of the accumulator.
    * @returns {!webdriver.promise.Promise} A promise that resolves to the final
    *     value of the accumulator.
@@ -633,7 +644,8 @@ export class ElementArrayFinder extends WebdriverWebElement {
    * // Turns off ng-animate animations for all elements in the <body>
    * element(by.css('body')).allowAnimations(false);
    *
-   * @returns {ElementArrayFinder} which resolves to whether animation is allowed.
+   * @returns {ElementArrayFinder} which resolves to whether animation is
+   * allowed.
    */
   allowAnimations(value: boolean): ElementArrayFinder {
     let allowAnimationsTestFn = (webElem: webdriver.WebElement) => {
@@ -713,7 +725,8 @@ export class ElementFinder extends WebdriverWebElement {
        *     the value of the underlying actionResult.
        * @param {function(Error)} errorFn
        *
-       * @returns {webdriver.promise.Promise} Promise which contains the results of
+       * @returns {webdriver.promise.Promise} Promise which contains the results
+       * of
        *     evaluating fn.
        */
       this.then = (fn: Function, errorFn: Function) => {

--- a/lib/exitCodes.ts
+++ b/lib/exitCodes.ts
@@ -9,8 +9,9 @@ export class ProtractorError extends Error {
   static CODE = KITCHEN_SINK_CODE;
   static SUPRESS_EXIT_CODE = false;
 
-  message: string; // a one liner, if more than one line is sent, it will be cut off
-  stack: string;   // has the message with the stack trace
+  message:
+      string;  // a one liner, if more than one line is sent, it will be cut off
+  stack: string;  // has the message with the stack trace
   code: number;
 
   /**

--- a/lib/expectedConditions.ts
+++ b/lib/expectedConditions.ts
@@ -108,7 +108,8 @@ export class ProtractorExpectedConditions {
    * browser.wait(EC.and(titleContainsFoo, titleIsNotFooBar), 5000);
    *
    * @alias ExpectedConditions.and
-   * @param {Array.<Function>} fns An array of expected conditions to 'and' together.
+   * @param {Array.<Function>} fns An array of expected conditions to 'and'
+   * together.
    *
    * @returns {!function} An expected condition that returns a promise which
    *     evaluates to the result of the logical and.
@@ -127,7 +128,8 @@ export class ProtractorExpectedConditions {
    * // Waits for title to contain either 'Foo' or 'Bar'
    * browser.wait(EC.or(titleContainsFoo, titleContainsBar), 5000);
    *
-   * @param {Array.<Function>} fns An array of expected conditions to 'or' together.
+   * @param {Array.<Function>} fns An array of expected conditions to 'or'
+   * together.
    *
    * @returns {!function} An expected condition that returns a promise which
    *     evaluates to the result of the logical or.
@@ -366,7 +368,8 @@ export class ProtractorExpectedConditions {
   /**
    * An expectation for checking that an element is present on the DOM of a
    * page and visible. Visibility means that the element is not only displayed
-   * but also has a height and width that is greater than 0. This is the opposite
+   * but also has a height and width that is greater than 0. This is the
+   * opposite
    * of 'invisibilityOf'.
    *
    * @example

--- a/lib/globals.d.ts
+++ b/lib/globals.d.ts
@@ -70,7 +70,7 @@ declare namespace webdriver {
   }
 
   namespace util {
-  interface Condition {}
+    interface Condition {}
   }
   class Capabilities {
     get: Function;

--- a/lib/launcher.ts
+++ b/lib/launcher.ts
@@ -3,9 +3,10 @@
  * input configuration and launching test runners.
  */
 import * as q from 'q';
+
 import {Config} from './config';
 import {ConfigParser} from './configParser';
-import {ProtractorError, ConfigError, ErrorHandler} from './exitCodes';
+import {ConfigError, ErrorHandler, ProtractorError} from './exitCodes';
 import {Logger} from './logger2';
 import {Runner} from './runner';
 import {TaskRunner} from './taskRunner';
@@ -182,10 +183,13 @@ let initFn = function(configFile: string, additionalConfig: Config) {
           let errorCode = ErrorHandler.parseError(e);
           if (errorCode) {
             let protractorError = e as ProtractorError;
-            ProtractorError.log(logger, errorCode, protractorError.message, protractorError.stack);
+            ProtractorError.log(
+                logger, errorCode, protractorError.message,
+                protractorError.stack);
             process.exit(errorCode);
           } else {
-            logger.error('"process.on(\'uncaughtException\'" error, see launcher');
+            logger.error(
+                '"process.on(\'uncaughtException\'" error, see launcher');
             process.exit(ProtractorError.CODE);
           }
         });
@@ -226,7 +230,8 @@ let initFn = function(configFile: string, additionalConfig: Config) {
             1) {  // Start new processes only if there are >1 tasks.
           forkProcess = true;
           if (config.debug) {
-            throw new ConfigError(logger,
+            throw new ConfigError(
+                logger,
                 'Cannot run in debug mode with multiCapabilities, count > 1, or sharding');
           }
         }
@@ -256,7 +261,8 @@ let initFn = function(configFile: string, additionalConfig: Config) {
                       ' instance(s) of WebDriver still running');
                 })
                 .catch((err: Error) => {
-                  logger.error('Error:', (err as any).stack || err.message || err);
+                  logger.error(
+                      'Error:', (err as any).stack || err.message || err);
                   cleanUpAndExit(RUNNERS_FAILED_EXIT_CODE);
                 });
           }

--- a/lib/locators.ts
+++ b/lib/locators.ts
@@ -93,11 +93,14 @@ export class ProtractorBy extends WebdriverBy {
   };
 
   /**
-   * Find an element by text binding. Does a partial match, so any elements bound
+   * Find an element by text binding. Does a partial match, so any elements
+   * bound
    * to variables containing the input string will be returned.
    *
-   * Note: For AngularJS version 1.2, the interpolation brackets, (usually {{}}),
-   * are optionally allowed in the binding description string. For Angular version
+   * Note: For AngularJS version 1.2, the interpolation brackets, (usually
+   * {{}}),
+   * are optionally allowed in the binding description string. For Angular
+   * version
    * 1.3+, they are not allowed, and no elements will be found if they are used.
    *
    * @view
@@ -119,7 +122,8 @@ export class ProtractorBy extends WebdriverBy {
    * var deprecatedSyntax = element(by.binding('{{person.name}}'));
    *
    * @param {string} bindingDescriptor
-   * @returns {{findElementsOverride: findElementsOverride, toString: Function|string}}
+   * @returns {{findElementsOverride: findElementsOverride, toString:
+   * Function|string}}
    */
   binding(bindingDescriptor: string): Locator {
     return {
@@ -151,7 +155,8 @@ export class ProtractorBy extends WebdriverBy {
    * expect(element(by.exactBinding('phone')).isPresent()).toBe(false);
    *
    * @param {string} bindingDescriptor
-   * @returns {{findElementsOverride: findElementsOverride, toString: Function|string}}
+   * @returns {{findElementsOverride: findElementsOverride, toString:
+   * Function|string}}
    */
   exactBinding(bindingDescriptor: string): Locator {
     return {
@@ -200,7 +205,8 @@ export class ProtractorBy extends WebdriverBy {
    * element(by.buttonText('Save'));
    *
    * @param {string} searchText
-   * @returns {{findElementsOverride: findElementsOverride, toString: Function|string}}
+   * @returns {{findElementsOverride: findElementsOverride, toString:
+   * Function|string}}
    */
   buttonText(searchText: string): Locator {
     return {
@@ -225,7 +231,8 @@ export class ProtractorBy extends WebdriverBy {
    * element(by.partialButtonText('Save'));
    *
    * @param {string} searchText
-   * @returns {{findElementsOverride: findElementsOverride, toString: Function|string}}
+   * @returns {{findElementsOverride: findElementsOverride, toString:
+   * Function|string}}
    */
   partialButtonText(searchText: string): Locator {
     return {
@@ -336,11 +343,13 @@ export class ProtractorBy extends WebdriverBy {
    *     by.repeater('cat in pets').column('cat.age'));
    *
    * // Returns a promise that resolves to an array of WebElements containing
-   * // all top level elements repeated by the repeater. For 2 pets rows resolves
+   * // all top level elements repeated by the repeater. For 2 pets rows
+   * resolves
    * // to an array of 2 elements.
    * var rows = element.all(by.repeater('cat in pets'));
    *
-   * // Returns a promise that resolves to an array of WebElements containing all
+   * // Returns a promise that resolves to an array of WebElements containing
+   * all
    * // the elements with a binding to the book's name.
    * var divs = element.all(by.repeater('book in library').column('book.name'));
    *
@@ -358,7 +367,8 @@ export class ProtractorBy extends WebdriverBy {
    * var divs = element.all(by.repeater('book in library'));
    *
    * @param {string} repeatDescriptor
-   * @returns {{findElementsOverride: findElementsOverride, toString: Function|string}}
+   * @returns {{findElementsOverride: findElementsOverride, toString:
+   * Function|string}}
    */
   repeater(repeatDescriptor: string): Locator {
     return this.byRepeaterInner(false, repeatDescriptor);
@@ -372,13 +382,16 @@ export class ProtractorBy extends WebdriverBy {
    * <li ng-repeat="car in cars | orderBy:year"></li>
    *
    * @example
-   * expect(element(by.exactRepeater('person in peopleWithRedHair')).isPresent())
+   * expect(element(by.exactRepeater('person in
+   * peopleWithRedHair')).isPresent())
    *     .toBe(true);
-   * expect(element(by.exactRepeater('person in people')).isPresent()).toBe(false);
+   * expect(element(by.exactRepeater('person in
+   * people')).isPresent()).toBe(false);
    * expect(element(by.exactRepeater('car in cars')).isPresent()).toBe(true);
    *
    * @param {string} repeatDescriptor
-   * @returns {{findElementsOverride: findElementsOverride, toString: Function|string}}
+   * @returns {{findElementsOverride: findElementsOverride, toString:
+   * Function|string}}
    */
   exactRepeater(repeatDescriptor: string): Locator {
     return this.byRepeaterInner(true, repeatDescriptor);

--- a/lib/ptor.ts
+++ b/lib/ptor.ts
@@ -6,36 +6,32 @@ import {ProtractorBy} from './locators';
 let webdriver = require('selenium-webdriver');
 
 export namespace protractor {
-export let browser: Browser;
-export let $ = function(search: string): ElementFinder {
-  return null;
-};
-export let $$ = function(search: string): ElementArrayFinder {
-  return null;
-};
-export let element: ElementHelper;
-export let By: ProtractorBy;
-export let by: ProtractorBy;
-export let wrapDriver: Function;
-export let ExpectedConditions: ProtractorExpectedConditions;
+  export let browser: Browser;
+  export let $ = function(search: string): ElementFinder { return null;};
+  export let $$ = function(search: string): ElementArrayFinder { return null;};
+  export let element: ElementHelper;
+  export let By: ProtractorBy;
+  export let by: ProtractorBy;
+  export let wrapDriver: Function;
+  export let ExpectedConditions: ProtractorExpectedConditions;
 
-// Define selenium webdriver imports.
-export let promise = {
-  controlFlow: require('selenium-webdriver/lib/promise').controlFlow,
-  createFlow: require('selenium-webdriver/lib/promise').createFlow,
-  defer: require('selenium-webdriver/lib/promise').defer,
-  delayed: require('selenium-webdriver/lib/promise').delayed,
-  filter: require('selenium-webdriver/lib/promise').filter,
-  fulfilled: require('selenium-webdriver/lib/promise').fulfilled,
-  fullyResolved: require('selenium-webdriver/lib/promise').fullyResolved,
-  isPromise: require('selenium-webdriver/lib/promise').isPromise,
-  rejected: require('selenium-webdriver/lib/promise').rejected,
-  thenFinally: require('selenium-webdriver/lib/promise').thenFinally,
-  when: require('selenium-webdriver/lib/promise').when
-};
-export let ActionSequence =
-    require('selenium-webdriver/lib/actions').ActionSequence;
-export let Key = require('selenium-webdriver/lib/input').Key;
-export let Command = require('selenium-webdriver/lib/command').Command;
-export let CommandName = require('selenium-webdriver/lib/command').Name;
+  // Define selenium webdriver imports.
+  export let promise = {
+    controlFlow: require('selenium-webdriver/lib/promise').controlFlow,
+    createFlow: require('selenium-webdriver/lib/promise').createFlow,
+    defer: require('selenium-webdriver/lib/promise').defer,
+    delayed: require('selenium-webdriver/lib/promise').delayed,
+    filter: require('selenium-webdriver/lib/promise').filter,
+    fulfilled: require('selenium-webdriver/lib/promise').fulfilled,
+    fullyResolved: require('selenium-webdriver/lib/promise').fullyResolved,
+    isPromise: require('selenium-webdriver/lib/promise').isPromise,
+    rejected: require('selenium-webdriver/lib/promise').rejected,
+    thenFinally: require('selenium-webdriver/lib/promise').thenFinally,
+    when: require('selenium-webdriver/lib/promise').when
+  };
+  export let ActionSequence =
+      require('selenium-webdriver/lib/actions').ActionSequence;
+  export let Key = require('selenium-webdriver/lib/input').Key;
+  export let Command = require('selenium-webdriver/lib/command').Command;
+  export let CommandName = require('selenium-webdriver/lib/command').Name;
 }

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -1,5 +1,5 @@
-import {Promise, when} from 'q';
 import {resolve} from 'path';
+import {Promise, when} from 'q';
 
 let STACK_SUBSTRINGS_TO_FILTER = [
   'node_modules/jasmine/', 'node_modules/selenium-webdriver', 'at Module.',


### PR DESCRIPTION
- removed `gulp clang` from gulp file
- added `gulp format` - automatically clang formats typescript
- added `gulp format:enforce` - shows verbose clang errors
- updated the gulp tasks to use `gulp format` instead of the `gulp clang` task
- ran `gulp format` to clean up files