### PR TITLE
docs: timeouts: ignoreSynchronization example should be asynchronous

### DIFF
--- a/docs/timeouts.md
+++ b/docs/timeouts.md
@@ -45,12 +45,23 @@ If you need to navigate to a page which does not use Angular, you can turn off w
 `browser.ignoreSynchronization = true`. For example:
 
 ```js
+var runNonAngular = function(fn) {
+    var flow = protractor.promise.controlFlow();
+    flow.execute(function () {
+        browser.ignoreSynchronization = true;
+    });
+    flow.execute(fn);
+    flow.execute(function () {
+        browser.ignoreSynchronization = false;
+    });
+} 
+
 browser.get('page-containing-angular');
 navigateToVanillaPage.click();
-browser.ignoreSynchronization = true;
-otherButton.click();
-navigateToAngularPage.click();
-browser.ignoreSynchronization = false;
+runNonAngular(function () {
+    otherButton.click();
+    navigateToAngularPage.click();
+});
 ```
 
 


### PR DESCRIPTION
ignoreSynchronization is synchronous, whereas other flow commands are asynchronous (promise-based). Therefore, to use ignoreSynchronization correctly, you need to chain promises using the control flow.

As per this issue/comment:
https://github.com/angular/protractor/issues/2275#issuecomment-118135431