### PR TITLE
chore(website): clean up documentation

### DIFF
--- a/lib/selenium-webdriver/locators.js
+++ b/lib/selenium-webdriver/locators.js
@@ -5,23 +5,13 @@
  * @fileoverview Factory methods for the supported locator strategies.
  */
 
-goog.provide('webdriver.By');
-goog.provide('webdriver.Locator');
-goog.provide('webdriver.Locator.Strategy');
-
-goog.require('goog.array');
-goog.require('goog.object');
-goog.require('goog.string');
-
+goog.provide('webdriver');
 
 /**
  * A collection of factory functions for creating {@link webdriver.Locator}
  * instances.
  */
 webdriver.By = {};
-// Exported to the global scope for legacy reasons.
-goog.exportSymbol('By', webdriver.By);
-
 
 /**
  * Locates elements that have a specific class name. The returned locator

--- a/lib/selenium-webdriver/webdriver.js
+++ b/lib/selenium-webdriver/webdriver.js
@@ -5,30 +5,7 @@
  * @fileoverview The heart of the WebDriver JavaScript API.
  */
 
-goog.provide('webdriver.Alert');
-goog.provide('webdriver.AlertPromise');
-goog.provide('webdriver.FileDetector');
-goog.provide('webdriver.UnhandledAlertError');
-goog.provide('webdriver.WebDriver');
-goog.provide('webdriver.WebElement');
-goog.provide('webdriver.WebElementPromise');
-
-goog.require('bot.Error');
-goog.require('bot.ErrorCode');
-goog.require('bot.response');
-goog.require('goog.array');
-goog.require('goog.object');
-goog.require('webdriver.ActionSequence');
-goog.require('webdriver.Command');
-goog.require('webdriver.CommandName');
-goog.require('webdriver.Key');
-goog.require('webdriver.Locator');
-goog.require('webdriver.Serializable');
-goog.require('webdriver.Session');
-goog.require('webdriver.TouchSequence');
-goog.require('webdriver.logging');
-goog.require('webdriver.promise');
-goog.require('webdriver.until');
+goog.provide('webdriver');
 
 // //////////////////////////////////////////////////////////////////////////////
 // //
@@ -560,41 +537,3 @@ webdriver.WebElement.prototype.isDisplayed = function() {};
  *     resolved to the screenshot as a base-64 encoded PNG.
  */
 webdriver.WebElement.prototype.takeScreenshot = function(opt_scroll) {};
-
-
-/**
- * Schedules a command to retrieve the outer HTML of this element.
- *
- * @view
- * <div id="parent">
- *   <div id="child">Text</div>
- * </div>
- *
- * @example
- * var child = element(by.id('child'));
- * expect(child.getOuterHtml()).toContain(
- *     '&lt;div id="child"&gt;Text&lt;/div&gt;');
- *
- * @returns {!webdriver.promise.Promise.<string>} A promise that will be
- *     resolved with the element's outer HTML.
- */
-webdriver.WebElement.prototype.getOuterHtml = function() {};
-
-
-/**
- * Schedules a command to retrieve the inner HTML of this element.
- *
- * @view
- * <div id="parent">
- *   <div id="child">Text</div>
- * </div>
- *
- * @example
- * var parent = element(by.id('parent'));
- * expect(parent.getInnerHtml()).toContain(
- *     '&lt;div id="child"&gt;Text&lt;/div&gt;');
- *
- * @returns {!webdriver.promise.Promise.<string>} A promise that will be
- *     resolved with the element's inner HTML.
- */
-webdriver.WebElement.prototype.getInnerHtml = function() {};


### PR DESCRIPTION
- Remove getInnerHtml and getOuterHtml from inherited WebElement docs.
- Remove some goog.provide. Only one is required to build the website.