### PR TITLE
fix(element): make .count() work correctly on NoSuchElement exception

### DIFF
--- a/lib/element.ts
+++ b/lib/element.ts
@@ -392,7 +392,7 @@ export class ElementArrayFinder extends WebdriverWebElement {
     return this.getWebElements().then(
         (arr: any) => { return arr.length; },
         (err: any) => {
-          if (err.code == new webdriver.error.NoSuchElementError()) {
+          if (err.code == webdriver.error.NoSuchElementError.code) {
             return 0;
           } else {
             throw err;

--- a/lib/element.ts
+++ b/lib/element.ts
@@ -392,7 +392,7 @@ export class ElementArrayFinder extends WebdriverWebElement {
     return this.getWebElements().then(
         (arr: any) => { return arr.length; },
         (err: any) => {
-          if (err.code == webdriver.error.NoSuchElementError.code) {
+          if (err.code === webdriver.error.NoSuchElementError.code) {
             return 0;
           } else {
             throw err;


### PR DESCRIPTION
Unfortunately, 88dd568c5295234a5211a23e12666e199606e437 does not fix the issue #3079, but swaps one error with another.

The problem is that comparing integers to objects doesn't work, so the problem persists. We need to compare ```code``` to the corresponding ```code```, and this is what my patch does. It has been tested to work with tests of the project I'm working on; they were failing in 3.2.x and 4.0.0.