### PR TITLE
fix(hybrid): add flag specifying that an app is an ng1/ng2 hybrid

### DIFF
--- a/lib/browser.ts
+++ b/lib/browser.ts
@@ -237,6 +237,15 @@ export class Browser extends Webdriver {
 
   debuggerValidated_: boolean;
 
+
+  /**
+   * If true, Protractor will interpret any angular apps it comes across as
+   * hybrid angular1/angular2 apps.
+   *
+   * @type {boolean}
+   */
+  ng12Hybrid: boolean;
+
   // This index type allows looking up methods by name so we can do mixins.
   [key: string]: any;
 
@@ -276,6 +285,7 @@ export class Browser extends Webdriver {
     this.ready = null;
     this.plugins_ = new Plugins({});
     this.resetUrl = DEFAULT_RESET_URL;
+    this.ng12Hybrid = false;
 
     this.driver.getCapabilities().then((caps: webdriver.Capabilities) => {
       // Internet Explorer does not accept data URLs, which are the default
@@ -418,7 +428,8 @@ export class Browser extends Webdriver {
       } else if (this.rootEl) {
         return this.executeAsyncScript_(
             clientSideScripts.waitForAngular,
-            'Protractor.waitForAngular()' + description, this.rootEl);
+            'Protractor.waitForAngular()' + description, this.rootEl,
+            this.ng12Hybrid);
       } else {
         return this.executeAsyncScript_(
             clientSideScripts.waitForAllAngular2,
@@ -758,7 +769,7 @@ export class Browser extends Webdriver {
     // Make sure the page is an Angular page.
     this.executeAsyncScript_(
             clientSideScripts.testForAngular, msg('test for angular'),
-            Math.floor(timeout / 1000))
+            Math.floor(timeout / 1000), this.ng12Hybrid)
         .then(
             (angularTestResult: {ver: string, message: string}) => {
               let angularVersion = angularTestResult.ver;

--- a/lib/clientsidescripts.js
+++ b/lib/clientsidescripts.js
@@ -44,14 +44,15 @@ function wrapWithHelpers(fun) {
  * Asynchronous.
  *
  * @param {string} rootSelector The selector housing an ng-app
+ * @param {boolean} ng12Hybrid Flag set if app is a hybrid of angular 1 and 2
  * @param {function(string)} callback callback. If a failure occurs, it will
  *     be passed as a parameter.
  */
-functions.waitForAngular = function(rootSelector, callback) {
+functions.waitForAngular = function(rootSelector, ng12Hybrid, callback) {
   var el = document.querySelector(rootSelector);
 
   try {
-    if (window.getAngularTestability) {
+    if (!ng12Hybrid && window.getAngularTestability) {
       window.getAngularTestability(el).whenStable(callback);
       return;
     }
@@ -588,10 +589,11 @@ functions.findByCssContainingText = function(cssSelector, searchText, using) {
  * Asynchronous.
  *
  * @param {number} attempts Number of times to retry.
+ * @param {boolean} ng12Hybrid Flag set if app is a hybrid of angular 1 and 2
  * @param {function({version: ?number, message: ?string})} asyncCallback callback
  *
  */
-functions.testForAngular = function(attempts, asyncCallback) {
+functions.testForAngular = function(attempts, ng12Hybrid, asyncCallback) {
   var callback = function(args) {
     setTimeout(function() {
       asyncCallback(args);
@@ -599,7 +601,7 @@ functions.testForAngular = function(attempts, asyncCallback) {
   };
   var check = function(n) {
     try {
-      if (window.getAllAngularTestabilities) {
+      if (!ng12Hybrid && window.getAllAngularTestabilities) {
         callback({ver: 2});
       } else if (window.angular && window.angular.resumeBootstrap) {
         callback({ver: 1});

--- a/spec/hybrid/async_spec.js
+++ b/spec/hybrid/async_spec.js
@@ -1,6 +1,11 @@
 describe('async angular2 application', function() {
   beforeEach(function() {
+    this.ng12Hybrid = true;
     browser.get('/hybrid');
+  });
+
+  afterEach(function() {
+    this.ng12Hybrid = false;
   });
 
   it('should propertly load the page', function() {


### PR DESCRIPTION
Needed for angular2 after rc2

Basically, we've been testing for if an app is ng1 or ng2 based on if `window.getAngularTestability` exists.  After rc2, hybrid apps will have `window.getAngularTestability` set, so this will no longer work.