### PR TITLE
docs(CONTRIBUTING.md): fix typo (submitted --> merged)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ Loosely, follow the [Angular contribution rules](https://github.com/angular/angu
  * If your PR changes any behavior or fixes an issue, it should have an associated test.
  * New features should be general and as simple as possible.
  * Breaking changes should be avoided if possible.
- * All pull requests require review. No PR will be submitted without a comment from a team member stating LGTM (Looks good to me).
+ * All pull requests require review. No PR will be merged without a comment from a team member stating LGTM (Looks good to me).
 
 Protractor specific rules
 -------------------------


### PR DESCRIPTION
This could be confusing for first-time contributors.