### PR TITLE
refactor(plugins): short-circuit `skipAngularStability` check

### DIFF
--- a/lib/plugins.ts
+++ b/lib/plugins.ts
@@ -182,10 +182,9 @@ export class Plugins {
    * @return {boolean}
    */
   skipAngularStability() {
-    var result =
-        this.pluginObjs.reduce((skip: boolean, pluginObj: ProtractorPlugin) => {
-          return pluginObj.skipAngularStability || skip;
-        }, false);
+    var result = this.pluginObjs.some((pluginObj: ProtractorPlugin) => {
+      return pluginObj.skipAngularStability;
+    });
     return result;
   };
 


### PR DESCRIPTION
There is no need to loop through all plugins, once we have found one the wants to "skipAngularStability".
(Theoretically, this is a performance improvement :stuck_out_tongue: )