### PR TITLE
Fix 'mark test suite as failed/passed on BrowserStack': fixes #3256

### DIFF
--- a/lib/driverProviders/browserStack.ts
+++ b/lib/driverProviders/browserStack.ts
@@ -67,26 +67,21 @@ export class BrowserStack extends DriverProvider {
         });
         let jobStatus = update.passed ? 'completed' : 'error';
         options.method = 'PUT';
-        https
-            .request(
-                options,
-                (res) => {
-                  let responseStr = '';
-                  res.on('data', (data: Buffer) => {
-                    responseStr += data.toString();
-                  });
-                  res.on('end', () => {
-                    logger.info(responseStr);
-                    deferred.resolve();
-                  });
-                  res.on('error', (e: Error) => {
-                    throw new BrowserError(
-                        logger,
-                        'Error updating BrowserStack pass/fail status: ' +
-                            util.inspect(e));
-                  });
-                })
-            .write('{\'status\': ' + jobStatus + '}');
+        let update_req = https.request(options, (res) => {
+          let responseStr = '';
+          res.on('data', (data: Buffer) => { responseStr += data.toString(); });
+          res.on('end', () => {
+            logger.info(responseStr);
+            deferred.resolve();
+          });
+          res.on('error', (e: Error) => {
+            throw new BrowserError(
+                logger, 'Error updating BrowserStack pass/fail status: ' +
+                    util.inspect(e));
+          });
+        });
+        update_req.write('{"status":"' + jobStatus + '"}');
+        update_req.end();
       });
       return deferred.promise;
     });


### PR DESCRIPTION
The `end()` method on `https.request` object needs to be called.