### PR TITLE
fix(export): export selenium-webdriver

### DIFF
--- a/globals.ts
+++ b/globals.ts
@@ -4,25 +4,18 @@ import {
   ElementFinder,
   ElementHelper,
   ProtractorBy,
-  ProtractorExpectedConditions
+  ProtractorExpectedConditions,
+  Ptor
 } from 'protractor';
 
-export interface Protractor {
-  browser: ProtractorBrowser;
-  element: ElementHelper;
-  by: ProtractorBy;
-  By: ProtractorBy;
-  $: (search: string) => ElementFinder;
-  $$: (search: string) => ElementArrayFinder;
-  ExpectedConditions: ProtractorExpectedConditions;
-}
-interface global {};
-export var protractor: Protractor = global['protractor'];
-export var browser: ProtractorBrowser = global['protractor']['browser'];
-export var element: ElementHelper = global['protractor']['element'];
-export var by: ProtractorBy = global['protractor']['by'];
-export var By: ProtractorBy = global['protractor']['By'];
-export var $: (search: string) => ElementFinder = global['protractor']['$'];
-export var $$: (search: string) => ElementArrayFinder = global['protractor']['$$'];
-export var ExpectedConditions: ProtractorExpectedConditions =
-    global['protractor']['ExpectedConditions'];
+export let protractor: Ptor = global['protractor'];
+export let browser: ProtractorBrowser = global['protractor']['browser'];
+export let $: (search: string) => ElementFinder = global['protractor']['$'];
+export let $$: (search: string) => ElementArrayFinder = global['protractor']['$$'];
+export let element: ElementHelper = global['protractor']['element'];
+export let By: ProtractorBy = global['protractor']['By'];
+export let by: ProtractorBy = global['protractor']['by'];
+export let wrapDriver:
+    (webdriver: any, baseUrl?: string, rootElement?: string,
+     untrackOutstandingTimeouts?: boolean) => ProtractorBrowser = global['protractor']['wrapDriver'];
+export let ExpectedConditions: ProtractorExpectedConditions = global['protractor']['ExpectedConditions'];

--- a/globals.ts
+++ b/globals.ts
@@ -9,13 +9,13 @@ import {
 } from 'protractor';
 
 export let protractor: Ptor = global['protractor'];
-export let browser: ProtractorBrowser = global['protractor']['browser'];
-export let $: (search: string) => ElementFinder = global['protractor']['$'];
-export let $$: (search: string) => ElementArrayFinder = global['protractor']['$$'];
-export let element: ElementHelper = global['protractor']['element'];
-export let By: ProtractorBy = global['protractor']['By'];
-export let by: ProtractorBy = global['protractor']['by'];
+export let browser: ProtractorBrowser = protractor.browser;
+export let $: (search: string) => ElementFinder = protractor.$;
+export let $$: (search: string) => ElementArrayFinder = protractor.$$;
+export let element: ElementHelper = protractor.element;
+export let By: ProtractorBy = protractor.By;
+export let by: ProtractorBy = protractor.by;
 export let wrapDriver:
     (webdriver: any, baseUrl?: string, rootElement?: string,
-     untrackOutstandingTimeouts?: boolean) => ProtractorBrowser = global['protractor']['wrapDriver'];
-export let ExpectedConditions: ProtractorExpectedConditions = global['protractor']['ExpectedConditions'];
+     untrackOutstandingTimeouts?: boolean) => ProtractorBrowser = protractor.wrapDriver;
+export let ExpectedConditions: ProtractorExpectedConditions = protractor.ExpectedConditions;

--- a/globals.ts
+++ b/globals.ts
@@ -1,5 +1,5 @@
 import {
-  Browser,
+  ProtractorBrowser,
   ElementArrayFinder,
   ElementFinder,
   ElementHelper,
@@ -8,7 +8,7 @@ import {
 } from 'protractor';
 
 export interface Protractor {
-  browser: Browser;
+  browser: ProtractorBrowser;
   element: ElementHelper;
   by: ProtractorBy;
   By: ProtractorBy;
@@ -18,7 +18,7 @@ export interface Protractor {
 }
 interface global {};
 export var protractor: Protractor = global['protractor'];
-export var browser: Browser = global['protractor']['browser'];
+export var browser: ProtractorBrowser = global['protractor']['browser'];
 export var element: ElementHelper = global['protractor']['element'];
 export var by: ProtractorBy = global['protractor']['by'];
 export var By: ProtractorBy = global['protractor']['By'];

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -89,7 +89,7 @@ gulp.task('default',['prepublish']);
 gulp.task('types', function(done) {
   var folder = 'built';
   var files = ['browser', 'element', 'locators', 'expectedConditions',
-    'config', 'plugins'];
+    'config', 'plugins', 'ptor'];
   var outputFile = path.resolve(folder, 'index.d.ts');
   var contents = '';
   files.forEach(file => {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -43,7 +43,8 @@ gulp.task('webdriver:update', function(done) {
 
 gulp.task('jshint', function(done) {
   runSpawn(done, 'node', ['node_modules/jshint/bin/jshint', 'lib', 'spec', 'scripts',
-      '--exclude=lib/selenium-webdriver/**/*.js,spec/dependencyTest/*.js']);
+      '--exclude=lib/selenium-webdriver/**/*.js,spec/dependencyTest/*.js,' +
+      'spec/install/**/*.js']);
 });
 
 gulp.task('format:enforce', () => {

--- a/lib/browser.ts
+++ b/lib/browser.ts
@@ -80,7 +80,7 @@ export interface ElementHelper extends Function {
  * @param {Browser} browser A browser instance.
  * @returns {function(webdriver.Locator): ElementFinder}
  */
-function buildElementHelper(browser: Browser): ElementHelper {
+function buildElementHelper(browser: ProtractorBrowser): ElementHelper {
   let element: ElementHelper = (locator: Locator) => {
     return new ElementArrayFinder(browser).all(locator).toElementFinder_();
   };
@@ -104,7 +104,7 @@ function buildElementHelper(browser: Browser): ElementHelper {
  * @param {boolean=} opt_untrackOutstandingTimeouts Whether Protractor should
  *     stop tracking outstanding $timeouts.
  */
-export class Browser extends Webdriver {
+export class ProtractorBrowser extends Webdriver {
   /**
    * @type {ProtractorBy}
    */
@@ -329,7 +329,7 @@ export class Browser extends Webdriver {
    * @returns {Browser} A browser instance.
    */
   forkNewDriverInstance(
-      opt_useSameUrl?: boolean, opt_copyMockModules?: boolean): Browser {
+      opt_useSameUrl?: boolean, opt_copyMockModules?: boolean): ProtractorBrowser {
     return null;
   }
 
@@ -1242,8 +1242,8 @@ export class Browser extends Webdriver {
    */
   static wrapDriver(
       webdriver: webdriver.WebDriver, baseUrl?: string, rootElement?: string,
-      untrackOutstandingTimeouts?: boolean): Browser {
-    return new Browser(
+      untrackOutstandingTimeouts?: boolean): ProtractorBrowser {
+    return new ProtractorBrowser(
         webdriver, baseUrl, rootElement, untrackOutstandingTimeouts);
   }
 }

--- a/lib/browser.ts
+++ b/lib/browser.ts
@@ -329,7 +329,8 @@ export class ProtractorBrowser extends Webdriver {
    * @returns {Browser} A browser instance.
    */
   forkNewDriverInstance(
-      opt_useSameUrl?: boolean, opt_copyMockModules?: boolean): ProtractorBrowser {
+      opt_useSameUrl?: boolean,
+      opt_copyMockModules?: boolean): ProtractorBrowser {
     return null;
   }
 

--- a/lib/element.ts
+++ b/lib/element.ts
@@ -716,7 +716,8 @@ export class ElementFinder extends WebdriverWebElement {
        errorFn: Function) => webdriver.promise.Promise<any> = null;
 
   constructor(
-      public browser_: ProtractorBrowser, elementArrayFinder: ElementArrayFinder) {
+      public browser_: ProtractorBrowser,
+      elementArrayFinder: ElementArrayFinder) {
     super();
     if (!elementArrayFinder) {
       throw new Error('BUG: elementArrayFinder cannot be empty');

--- a/lib/element.ts
+++ b/lib/element.ts
@@ -2,7 +2,7 @@ let webdriver = require('selenium-webdriver');
 let clientSideScripts = require('./clientsidescripts');
 
 import {Logger} from './logger';
-import {Browser} from './browser';
+import {ProtractorBrowser} from './browser';
 import {Locator} from './locators';
 
 let logger = new Logger('element');
@@ -83,7 +83,7 @@ export class WebdriverWebElement {
  * });
  *
  * @constructor
- * @param {Browser} browser A browser instance.
+ * @param {ProtractorBrowser} browser A browser instance.
  * @param {function(): Array.<webdriver.WebElement>} getWebElements A function
  *    that returns a list of the underlying Web Elements.
  * @param {webdriver.Locator} locator The most relevant locator. It is only
@@ -97,7 +97,7 @@ export class ElementArrayFinder extends WebdriverWebElement {
   getWebElements: Function;
 
   constructor(
-      public browser_: Browser, getWebElements?: Function,
+      public browser_: ProtractorBrowser, getWebElements?: Function,
       public locator_?: any,
       public actionResults_: webdriver.promise.Promise<any> = null) {
     super();
@@ -703,7 +703,7 @@ export class ElementArrayFinder extends WebdriverWebElement {
  *
  * @constructor
  * @extends {webdriver.WebElement}
- * @param {Browser} browser_ A browser instance.
+ * @param {ProtractorBrowser} browser_ A browser instance.
  * @param {ElementArrayFinder} elementArrayFinder The ElementArrayFinder
  *     that this is branched from.
  * @returns {ElementFinder}
@@ -716,7 +716,7 @@ export class ElementFinder extends WebdriverWebElement {
        errorFn: Function) => webdriver.promise.Promise<any> = null;
 
   constructor(
-      public browser_: Browser, elementArrayFinder: ElementArrayFinder) {
+      public browser_: ProtractorBrowser, elementArrayFinder: ElementArrayFinder) {
     super();
     if (!elementArrayFinder) {
       throw new Error('BUG: elementArrayFinder cannot be empty');
@@ -785,7 +785,7 @@ export class ElementFinder extends WebdriverWebElement {
   }
 
   static fromWebElement_(
-      browser: Browser, webElem: webdriver.WebElement,
+      browser: ProtractorBrowser, webElem: webdriver.WebElement,
       locator: Locator): ElementFinder {
     let getWebElements =
         () => { return webdriver.promise.fulfilled([webElem]); };

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -3,4 +3,4 @@
  * namespace.
  */
 
-export = require('./ptor').protractor
+export = require('./ptor').Protractor;

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -3,4 +3,4 @@
  * namespace.
  */
 
-export = require('./ptor').Protractor;
+export = require('./ptor').protractor;

--- a/lib/ptor.ts
+++ b/lib/ptor.ts
@@ -1,4 +1,4 @@
-import {Browser, ElementHelper} from './browser';
+import {ProtractorBrowser, ElementHelper} from './browser';
 import {ElementArrayFinder, ElementFinder} from './element';
 import {ProtractorExpectedConditions} from './expectedConditions';
 import {ProtractorBy} from './locators';
@@ -7,7 +7,7 @@ let webdriver = require('selenium-webdriver');
 
 export namespace protractor {
   // Variables tied to the global namespace.
-  export let browser: Browser;
+  export let browser: ProtractorBrowser;
   export let $ = function(search: string): ElementFinder { return null;};
   export let $$ = function(search: string): ElementArrayFinder { return null;};
   export let element: ElementHelper;
@@ -15,11 +15,11 @@ export namespace protractor {
   export let by: ProtractorBy;
   export let wrapDriver:
       (webdriver: webdriver.WebDriver, baseUrl?: string, rootElement?: string,
-       untrackOutstandingTimeouts?: boolean) => Browser;
+       untrackOutstandingTimeouts?: boolean) => ProtractorBrowser;
   export let ExpectedConditions: ProtractorExpectedConditions;
 
   // Export protractor classes.
-  export let Browser = require('./browser').Browser;
+  export let ProtractorBrowser = require('./browser').ProtractorBrowser;
   export let ElementFinder = require('./element').ElementFinder;
   export let ElementArrayFinder = require('./element').ElementArrayFinder;
   export let ProtractorBy = require('./locators').ProtractorBy;

--- a/lib/ptor.ts
+++ b/lib/ptor.ts
@@ -5,45 +5,47 @@ import {ProtractorBy} from './locators';
 
 let webdriver = require('selenium-webdriver');
 
-export namespace protractor {
+export class Ptor {
   // Variables tied to the global namespace.
-  export let browser: ProtractorBrowser;
-  export let $ = function(search: string): ElementFinder { return null;};
-  export let $$ = function(search: string): ElementArrayFinder { return null;};
-  export let element: ElementHelper;
-  export let By: ProtractorBy;
-  export let by: ProtractorBy;
-  export let wrapDriver:
+  browser: ProtractorBrowser;
+  $ = function(search: string): ElementFinder { return null; };
+  $$ = function(search: string): ElementArrayFinder { return null; };
+  element: ElementHelper;
+  By: ProtractorBy;
+  by: ProtractorBy;
+  wrapDriver:
       (webdriver: webdriver.WebDriver, baseUrl?: string, rootElement?: string,
        untrackOutstandingTimeouts?: boolean) => ProtractorBrowser;
-  export let ExpectedConditions: ProtractorExpectedConditions;
+  ExpectedConditions: ProtractorExpectedConditions;
 
   // Export protractor classes.
-  export let ProtractorBrowser = require('./browser').ProtractorBrowser;
-  export let ElementFinder = require('./element').ElementFinder;
-  export let ElementArrayFinder = require('./element').ElementArrayFinder;
-  export let ProtractorBy = require('./locators').ProtractorBy;
-  export let ProtractorExpectedConditions =
+  ProtractorBrowser = require('./browser').ProtractorBrowser;
+  ElementFinder = require('./element').ElementFinder;
+  ElementArrayFinder = require('./element').ElementArrayFinder;
+  ProtractorBy = require('./locators').ProtractorBy;
+  ProtractorExpectedConditions =
       require('./expectedConditions').ProtractorExpectedConditions;
 
   // Export selenium webdriver.
-  export let ActionSequence = webdriver.ActionSequence;
-  export let Browser = webdriver.Browser;
-  export let Builder = webdriver.Builder;
-  export let Button = webdriver.Button;
-  export let Capabilities = webdriver.Capabilities;
-  export let Capability = webdriver.Capability;
-  export let EventEmitter = webdriver.EventEmitter;
-  export let FileDetector = webdriver.FileDetector;
-  export let Key = webdriver.Key;
-  export let Session = webdriver.Session;
-  export let WebDriver = webdriver.WebDriver;
-  export let WebElement = webdriver.WebElement;
-  export let WebElementPromise = webdriver.WebElementPromise;
-  export let error = webdriver.error;
-  export let logging = webdriver.logging;
-  export let promise = webdriver.promise;
-  export let util = webdriver.util;
-  export let Command = require('selenium-webdriver/lib/command').Command;
-  export let CommandName = require('selenium-webdriver/lib/command').Name;
+  ActionSequence = webdriver.ActionSequence;
+  Browser = webdriver.Browser;
+  Builder = webdriver.Builder;
+  Button = webdriver.Button;
+  Capabilities = webdriver.Capabilities;
+  Capability = webdriver.Capability;
+  EventEmitter = webdriver.EventEmitter;
+  FileDetector = webdriver.FileDetector;
+  Key = webdriver.Key;
+  Session = webdriver.Session;
+  WebDriver = webdriver.WebDriver;
+  WebElement = webdriver.WebElement;
+  WebElementPromise = webdriver.WebElementPromise;
+  error = webdriver.error;
+  logging = webdriver.logging;
+  promise = webdriver.promise;
+  util = webdriver.util;
+  Command = require('selenium-webdriver/lib/command').Command;
+  CommandName = require('selenium-webdriver/lib/command').Name;
 }
+
+export var Protractor = new Ptor();

--- a/lib/ptor.ts
+++ b/lib/ptor.ts
@@ -43,12 +43,14 @@ export class Ptor {
   error = webdriver.error;
   logging = webdriver.logging;
   promise = webdriver.promise;
-  util = webdriver.util;
+  until = webdriver.until;
   Command = require('selenium-webdriver/lib/command').Command;
   CommandName = require('selenium-webdriver/lib/command').Name;
-  firefox = require('selenium-webdriver/firefox');
-  http = require('selenium-webdriver/http');
-  remote = require('selenium-webdriver/remote');
+  utils = {
+    firefox: require('selenium-webdriver/firefox'),
+    http: require('selenium-webdriver/http'),
+    remote: require('selenium-webdriver/remote')
+  }
 }
 
 export var Protractor = new Ptor();

--- a/lib/ptor.ts
+++ b/lib/ptor.ts
@@ -1,4 +1,4 @@
-import {ProtractorBrowser, ElementHelper} from './browser';
+import {ElementHelper, ProtractorBrowser} from './browser';
 import {ElementArrayFinder, ElementFinder} from './element';
 import {ProtractorExpectedConditions} from './expectedConditions';
 import {ProtractorBy} from './locators';

--- a/lib/ptor.ts
+++ b/lib/ptor.ts
@@ -27,10 +27,23 @@ export namespace protractor {
       require('./expectedConditions').ProtractorExpectedConditions;
 
   // Export selenium webdriver.
-  export let promise = webdriver.promise;
-  export let WebElement = webdriver.WebElement;
   export let ActionSequence = webdriver.ActionSequence;
+  export let Browser = webdriver.Browser;
+  export let Builder = webdriver.Builder;
+  export let Button = webdriver.Button;
+  export let Capabilities = webdriver.Capabilities;
+  export let Capability = webdriver.Capability;
+  export let EventEmitter = webdriver.EventEmitter;
+  export let FileDetector = webdriver.FileDetector;
   export let Key = webdriver.Key;
+  export let Session = webdriver.Session;
+  export let WebDriver = webdriver.WebDriver;
+  export let WebElement = webdriver.WebElement;
+  export let WebElementPromise = webdriver.WebElementPromise;
+  export let error = webdriver.error;
+  export let logging = webdriver.logging;
+  export let promise = webdriver.promise;
+  export let util = webdriver.util;
   export let Command = require('selenium-webdriver/lib/command').Command;
   export let CommandName = require('selenium-webdriver/lib/command').Name;
 }

--- a/lib/ptor.ts
+++ b/lib/ptor.ts
@@ -46,6 +46,9 @@ export class Ptor {
   util = webdriver.util;
   Command = require('selenium-webdriver/lib/command').Command;
   CommandName = require('selenium-webdriver/lib/command').Name;
+  firefox = require('selenium-webdriver/firefox');
+  http = require('selenium-webdriver/http');
+  remote = require('selenium-webdriver/remote');
 }
 
 export var Protractor = new Ptor();

--- a/lib/ptor.ts
+++ b/lib/ptor.ts
@@ -53,4 +53,4 @@ export class Ptor {
   }
 }
 
-export var Protractor = new Ptor();
+export var protractor = new Ptor();

--- a/lib/runner.ts
+++ b/lib/runner.ts
@@ -9,7 +9,7 @@ import {DriverProvider} from './driverProviders';
 import {ProtractorBy} from './locators';
 import {Logger} from './logger';
 import {Plugins} from './plugins';
-import {Protractor} from './ptor';
+import {protractor} from './ptor';
 import * as helper from './util';
 
 var webdriver = require('selenium-webdriver');
@@ -153,13 +153,13 @@ export class Runner extends EventEmitter {
    */
   setupGlobals_(browser_: ProtractorBrowser) {
     // Keep $, $$, element, and by/By under the global protractor namespace
-    Protractor.browser = browser_;
-    Protractor.$ = browser_.$;
-    Protractor.$$ = browser_.$$;
-    Protractor.element = browser_.element;
-    Protractor.by = Protractor.By = ProtractorBrowser.By;
-    Protractor.wrapDriver = ProtractorBrowser.wrapDriver;
-    Protractor.ExpectedConditions = ProtractorBrowser.ExpectedConditions;
+    protractor.browser = browser_;
+    protractor.$ = browser_.$;
+    protractor.$$ = browser_.$$;
+    protractor.element = browser_.element;
+    protractor.by = protractor.By = ProtractorBrowser.By;
+    protractor.wrapDriver = ProtractorBrowser.wrapDriver;
+    protractor.ExpectedConditions = ProtractorBrowser.ExpectedConditions;
 
     if (!this.config_.noGlobals) {
       // Export protractor to the global namespace to be used in tests.
@@ -167,11 +167,11 @@ export class Runner extends EventEmitter {
       global.$ = browser_.$;
       global.$$ = browser_.$$;
       global.element = browser_.element;
-      global.by = global.By = Protractor.By;
-      global.ExpectedConditions = Protractor.ExpectedConditions;
+      global.by = global.By = protractor.By;
+      global.ExpectedConditions = protractor.ExpectedConditions;
     }
 
-    global.protractor = Protractor;
+    global.protractor = protractor;
 
     if (!this.config_.skipSourceMapSupport) {
       // Enable sourcemap support for stack traces.

--- a/lib/runner.ts
+++ b/lib/runner.ts
@@ -2,7 +2,7 @@ import {EventEmitter} from 'events';
 import * as q from 'q';
 import * as util from 'util';
 
-import {Browser} from './browser';
+import {ProtractorBrowser} from './browser';
 import {Config} from './config';
 import {AttachSession, BrowserStack, Direct, Hosted, Local, Mock, Sauce} from './driverProviders';
 import {DriverProvider} from './driverProviders';
@@ -151,15 +151,15 @@ export class Runner extends EventEmitter {
    * Sets up convenience globals for test specs
    * @private
    */
-  setupGlobals_(browser_: Browser) {
+  setupGlobals_(browser_: ProtractorBrowser) {
     // Keep $, $$, element, and by/By under the global protractor namespace
     protractor.browser = browser_;
     protractor.$ = browser_.$;
     protractor.$$ = browser_.$$;
     protractor.element = browser_.element;
-    protractor.by = protractor.By = Browser.By;
-    protractor.wrapDriver = Browser.wrapDriver;
-    protractor.ExpectedConditions = Browser.ExpectedConditions;
+    protractor.by = protractor.By = ProtractorBrowser.By;
+    protractor.wrapDriver = ProtractorBrowser.wrapDriver;
+    protractor.ExpectedConditions = ProtractorBrowser.ExpectedConditions;
 
     if (!this.config_.noGlobals) {
       // Export protractor to the global namespace to be used in tests.
@@ -197,7 +197,7 @@ export class Runner extends EventEmitter {
     var config = this.config_;
     var driver = this.driverprovider_.getNewDriver();
 
-    var browser_ = Browser.wrapDriver(
+    var browser_ = ProtractorBrowser.wrapDriver(
         driver, config.baseUrl, config.rootElement,
         config.untrackOutstandingTimeouts);
 

--- a/lib/runner.ts
+++ b/lib/runner.ts
@@ -9,7 +9,7 @@ import {DriverProvider} from './driverProviders';
 import {ProtractorBy} from './locators';
 import {Logger} from './logger';
 import {Plugins} from './plugins';
-import {protractor} from './ptor';
+import {Protractor} from './ptor';
 import * as helper from './util';
 
 var webdriver = require('selenium-webdriver');
@@ -153,13 +153,13 @@ export class Runner extends EventEmitter {
    */
   setupGlobals_(browser_: ProtractorBrowser) {
     // Keep $, $$, element, and by/By under the global protractor namespace
-    protractor.browser = browser_;
-    protractor.$ = browser_.$;
-    protractor.$$ = browser_.$$;
-    protractor.element = browser_.element;
-    protractor.by = protractor.By = ProtractorBrowser.By;
-    protractor.wrapDriver = ProtractorBrowser.wrapDriver;
-    protractor.ExpectedConditions = ProtractorBrowser.ExpectedConditions;
+    Protractor.browser = browser_;
+    Protractor.$ = browser_.$;
+    Protractor.$$ = browser_.$$;
+    Protractor.element = browser_.element;
+    Protractor.by = Protractor.By = ProtractorBrowser.By;
+    Protractor.wrapDriver = ProtractorBrowser.wrapDriver;
+    Protractor.ExpectedConditions = ProtractorBrowser.ExpectedConditions;
 
     if (!this.config_.noGlobals) {
       // Export protractor to the global namespace to be used in tests.
@@ -167,11 +167,11 @@ export class Runner extends EventEmitter {
       global.$ = browser_.$;
       global.$$ = browser_.$$;
       global.element = browser_.element;
-      global.by = global.By = protractor.By;
-      global.ExpectedConditions = protractor.ExpectedConditions;
+      global.by = global.By = Protractor.By;
+      global.ExpectedConditions = Protractor.ExpectedConditions;
     }
 
-    global.protractor = protractor;
+    global.protractor = Protractor;
 
     if (!this.config_.skipSourceMapSupport) {
       // Enable sourcemap support for stack traces.

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -41,8 +41,9 @@ var passingTests = [
   // Unit tests
   'node node_modules/jasmine/bin/jasmine.js JASMINE_CONFIG_PATH=scripts/unit_test.json',
   // Dependency tests
-  'node node_modules/jasmine/bin/jasmine.js JASMINE_CONFIG_PATH=scripts/dependency_test.json'
+  'node node_modules/jasmine/bin/jasmine.js JASMINE_CONFIG_PATH=scripts/dependency_test.json',
   // Typings tests
+  'node spec/install/test.js'
   // FIX THIS: 'node scripts/typings_tests/test_typings.js'
 ];
 

--- a/spec/dependencyTest/protractor_spec.js
+++ b/spec/dependencyTest/protractor_spec.js
@@ -8,25 +8,39 @@ describe('require(\'protractor\')', () => {
 
   describe('exported protractor classes', () => {
     it('should be defined', () => {
-      var protractorClasses = ['Browser', 'ElementFinder', 'ElementArrayFinder',
+      var protractorClasses = ['ProtractorBrowser', 'ElementFinder', 'ElementArrayFinder',
         'ProtractorBy', 'ProtractorExpectedConditions'];
       for (var pos in protractorClasses) {
         var property = protractorClasses[pos];
         expect(typeof protractor[property]).toEqual('function');
       }
     });
+    var seleniumClasses = ['ActionSequence', 'Browser', 'Builder', 'Button',
+      'Capabilities', 'Capability', 'EventEmitter', 'FileDetector', 'Key',
+      'Session', 'WebDriver', 'WebElement', 'WebElementPromise', 'Command',
+      'CommandName'];
+    for (var pos in seleniumClasses) {
+      var propertyObj = seleniumClasses[pos];
+      it('should have selenium-webdriver defined: ' + propertyObj, () => {
+          expect(typeof protractor[propertyObj]).toEqual('object');
+      });
+    }
+
+    it('should have selenium-webdriver promise.Promise', function() {
+      expect(typeof protractor['promise']['Promise']).toEqual('function');
+    });
 
     describe('browser class', () => {
       it('should have static method defined', () => {
         var staticMethod = 'wrapDriver';
-        expect(typeof protractor.Browser['wrapDriver']).toEqual('function');
+        expect(typeof protractor.ProtractorBrowser['wrapDriver']).toEqual('function');
       });
 
       it('should have static variables defined', () => {
         var staticVariables = ['By', 'ExpectedConditions'];
         for (var pos in staticVariables) {
           var property = staticVariables[pos];
-          expect(typeof protractor.Browser[property]).toEqual('object');
+          expect(typeof protractor.ProtractorBrowser[property]).toEqual('object');
         }
       });
     });

--- a/spec/install/.gitignore
+++ b/spec/install/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+typings
+conf.js
+typescript_spec.js

--- a/spec/install/conf.ts
+++ b/spec/install/conf.ts
@@ -1,7 +1,7 @@
 import {Config} from 'protractor';
 
 export let config: Config = {
-  seleniumAddress: 'http://127.0.0.1:4444/wd/hub',
+  mockSelenium: true,
   specs: ['*_spec.js'],
   framework: 'jasmine'
 }

--- a/spec/install/conf.ts
+++ b/spec/install/conf.ts
@@ -1,0 +1,7 @@
+import {Config} from 'protractor';
+
+export let config: Config = {
+  seleniumAddress: 'http://127.0.0.1:4444/wd/hub',
+  specs: ['*_spec.js'],
+  framework: 'jasmine'
+}

--- a/spec/install/javascript_spec.js
+++ b/spec/install/javascript_spec.js
@@ -26,11 +26,12 @@ describe('javascript', function () {
         expect(typeof protractor.error).toEqual('object');
         expect(typeof protractor.logging).toEqual('object');
         expect(typeof protractor.promise).toEqual('object');
+        expect(typeof protractor.until).toEqual('object');
         expect(typeof protractor.Command).toEqual('function');
         expect(typeof protractor.CommandName).toEqual('object');
-        expect(typeof protractor.firefox).toEqual('object');
-        expect(typeof protractor.http).toEqual('object');
-        expect(typeof protractor.remote).toEqual('object');
+        expect(typeof protractor.utils.firefox).toEqual('object');
+        expect(typeof protractor.utils.http).toEqual('object');
+        expect(typeof protractor.utils.remote).toEqual('object');
     });
     it('should have protractor class definitions', function () {
         expect(typeof protractor.ProtractorBrowser).toBe('function');

--- a/spec/install/javascript_spec.js
+++ b/spec/install/javascript_spec.js
@@ -1,0 +1,39 @@
+describe('javascript', function () {
+    it('should have global objects that match the protractor namespace', function () {
+        expect(protractor.browser === browser).toBeTruthy();
+        expect(protractor.by === by).toBeTruthy();
+        expect(protractor.By === By).toBeTruthy();
+        expect(protractor.$ === $).toBeTruthy();
+        expect(protractor.$$ === $$).toBeTruthy();
+        expect(protractor.ExpectedConditions === ExpectedConditions).toBeTruthy();
+    });
+    it('should have selenium-webdriver components for the protractor namespace', function () {
+        expect(typeof protractor.promise.all).toEqual('function');
+        expect(typeof protractor.promise.defer).toEqual('function');
+        expect(typeof protractor.promise.Promise).toEqual('function');
+        expect(typeof protractor.ActionSequence).toEqual('function');
+        expect(typeof protractor.Browser).toEqual('object');
+        expect(typeof protractor.Builder).toEqual('function');
+        expect(typeof protractor.Capabilities).toEqual('function');
+        expect(typeof protractor.Capability).toEqual('object');
+        expect(typeof protractor.EventEmitter).toEqual('function');
+        expect(typeof protractor.FileDetector).toEqual('function');
+        expect(typeof protractor.Key).toEqual('object');
+        expect(typeof protractor.Session).toEqual('function');
+        expect(typeof protractor.WebDriver).toEqual('function');
+        expect(typeof protractor.WebElement).toEqual('function');
+        expect(typeof protractor.WebElementPromise).toEqual('function');
+        expect(typeof protractor.error).toEqual('object');
+        expect(typeof protractor.logging).toEqual('object');
+        expect(typeof protractor.promise).toEqual('object');
+        expect(typeof protractor.Command).toEqual('function');
+        expect(typeof protractor.CommandName).toEqual('object');
+    });
+    it('should have protractor class definitions', function () {
+        expect(typeof protractor.ProtractorBrowser).toBe('function');
+        expect(typeof protractor.ElementFinder).toBe('function');
+        expect(typeof protractor.ElementArrayFinder).toBe('function');
+        expect(typeof protractor.ProtractorBy).toBe('function');
+        expect(typeof protractor.ProtractorExpectedConditions).toBe('function');
+    });
+});

--- a/spec/install/javascript_spec.js
+++ b/spec/install/javascript_spec.js
@@ -28,6 +28,9 @@ describe('javascript', function () {
         expect(typeof protractor.promise).toEqual('object');
         expect(typeof protractor.Command).toEqual('function');
         expect(typeof protractor.CommandName).toEqual('object');
+        expect(typeof protractor.firefox).toEqual('object');
+        expect(typeof protractor.http).toEqual('object');
+        expect(typeof protractor.remote).toEqual('object');
     });
     it('should have protractor class definitions', function () {
         expect(typeof protractor.ProtractorBrowser).toBe('function');

--- a/spec/install/package.json
+++ b/spec/install/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "protractor-install",
+  "version": "1.0.0",
+  "description": "e2e typescript => javascript => running",
+  "main": "index.js",
+  "scripts": {
+    "postinstall": "npm run typings",
+    "typings": "typings install",
+    "test": "protractor conf.js"
+  },
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "protractor": "file:../../",
+    "rimraf": "^2.5.4"
+  }
+}

--- a/spec/install/package.json
+++ b/spec/install/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "postinstall": "npm run typings",
     "typings": "typings install",
+    "tsc": "tsc",
     "test": "protractor conf.js"
   },
   "author": "",

--- a/spec/install/test.js
+++ b/spec/install/test.js
@@ -1,0 +1,63 @@
+"use strict";
+var path = require('path');
+var child_process = require('child_process');
+var rimraf = require('rimraf');
+var spawnSync = child_process.spawnSync;
+
+class TestUtils {
+  static runCommand(task, args, options) {
+    var child = spawnSync(task, args, options);
+    return child.output;
+  };
+};
+
+function install() {
+  rimraf.sync(path.resolve(__dirname, 'node_modules'));
+  var options = {cwd: __dirname};
+  var output = TestUtils.runCommand('npm', ['install'], options);
+  if (output && output[1]) {
+    console.log(output[1].toString());
+  } else {
+    throw new Error('Something went wrong in function install.')
+  }
+}
+
+function tsc() {
+  var options = {cwd: __dirname};
+  var output = TestUtils.runCommand('npm', ['run', 'tsc'], options);
+  if (output && output[1]) {
+    var options = {cwd: path.resolve('.')};
+    console.log(output[1].toString());
+    if (output[1].toString().indexOf('error') >= 0) {
+      throw new Error('tsc failed.');
+    }
+  } else {
+    throw new Error('Something went wrong in function tsc.')
+  }
+}
+
+function test() {
+  var options = {cwd: __dirname};
+  var output = TestUtils.runCommand('node',
+      ['node_modules/protractor/bin/protractor','conf.js'],
+      options);
+  if (output && output[1]) {
+    console.log(output[1].toString());
+    var lines = output[1].toString().split('\n');
+    for (var pos in lines) {
+      var line = lines[pos];
+      if (line.indexOf(' specs, ') >= 0) {
+        var failures = line.split(' specs, ')[1].charAt(0);
+        if (failures !== '0') {
+          throw new Error('Failed with ' + failures + ' failure(s).');
+        }
+      }
+    }
+  } else {
+    throw new Error('Something went wrong in function test.')
+  }
+}
+
+install();
+tsc();
+test();

--- a/spec/install/tsconfig.json
+++ b/spec/install/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "sourceMap": false,
+    "declaration": false,
+    "noImplicitAny": false
+  },
+  "exclude": [
+    "node_modules",
+    "typings/globals"
+  ]
+}

--- a/spec/install/typescript_spec.ts
+++ b/spec/install/typescript_spec.ts
@@ -1,0 +1,42 @@
+import {browser, by, By, element, $, $$, ExpectedConditions, protractor} from 'protractor/globals';
+import {ProtractorBrowser} from 'protractor';
+describe('typescript imports', () => {
+  it('should have global objects that match the protractor namespace', () => {
+    expect(protractor.browser === browser).toBeTruthy();
+    expect(protractor.by === by).toBeTruthy();
+    expect(protractor.By === By).toBeTruthy();
+    expect(protractor.$ === $).toBeTruthy();
+    expect(protractor.$$ === $$).toBeTruthy();
+    expect(protractor.ExpectedConditions === ExpectedConditions).toBeTruthy();
+    expect(typeof protractor.wrapDriver).toEqual('function');
+  });
+  it('should have selenium-webdriver components for the protractor namespace', () => {
+    expect(typeof protractor.promise.all).toEqual('function');
+    expect(typeof protractor.promise.defer).toEqual('function');
+    expect(typeof protractor.promise.Promise).toEqual('function');
+    expect(typeof protractor.ActionSequence).toEqual('function');
+    expect(typeof protractor.Browser).toEqual('object');
+    expect(typeof protractor.Builder).toEqual('function');
+    expect(typeof protractor.Capabilities).toEqual('function');
+    expect(typeof protractor.Capability).toEqual('object');
+    expect(typeof protractor.EventEmitter).toEqual('function');
+    expect(typeof protractor.FileDetector).toEqual('function');
+    expect(typeof protractor.Key).toEqual('object');
+    expect(typeof protractor.Session).toEqual('function');
+    expect(typeof protractor.WebDriver).toEqual('function');
+    expect(typeof protractor.WebElement).toEqual('function');
+    expect(typeof protractor.WebElementPromise).toEqual('function');
+    expect(typeof protractor.error).toEqual('object');
+    expect(typeof protractor.logging).toEqual('object');
+    expect(typeof protractor.promise).toEqual('object');
+    expect(typeof protractor.Command).toEqual('function');
+    expect(typeof protractor.CommandName).toEqual('object');
+  });
+  it('should have protractor class definitions', () => {
+    expect(typeof protractor.ProtractorBrowser).toBe('function');
+    expect(typeof protractor.ElementFinder).toBe('function');
+    expect(typeof protractor.ElementArrayFinder).toBe('function');
+    expect(typeof protractor.ProtractorBy).toBe('function');
+    expect(typeof protractor.ProtractorExpectedConditions).toBe('function');
+  });
+});

--- a/spec/install/typescript_spec.ts
+++ b/spec/install/typescript_spec.ts
@@ -31,6 +31,9 @@ describe('typescript imports', () => {
     expect(typeof protractor.promise).toEqual('object');
     expect(typeof protractor.Command).toEqual('function');
     expect(typeof protractor.CommandName).toEqual('object');
+    expect(typeof protractor.firefox).toEqual('object');
+    expect(typeof protractor.http).toEqual('object');
+    expect(typeof protractor.remote).toEqual('object');
   });
   it('should have protractor class definitions', () => {
     expect(typeof protractor.ProtractorBrowser).toBe('function');

--- a/spec/install/typescript_spec.ts
+++ b/spec/install/typescript_spec.ts
@@ -29,11 +29,12 @@ describe('typescript imports', () => {
     expect(typeof protractor.error).toEqual('object');
     expect(typeof protractor.logging).toEqual('object');
     expect(typeof protractor.promise).toEqual('object');
+    expect(typeof protractor.until).toEqual('object');
     expect(typeof protractor.Command).toEqual('function');
     expect(typeof protractor.CommandName).toEqual('object');
-    expect(typeof protractor.firefox).toEqual('object');
-    expect(typeof protractor.http).toEqual('object');
-    expect(typeof protractor.remote).toEqual('object');
+    expect(typeof protractor.utils.firefox).toEqual('object');
+    expect(typeof protractor.utils.http).toEqual('object');
+    expect(typeof protractor.utils.remote).toEqual('object');
   });
   it('should have protractor class definitions', () => {
     expect(typeof protractor.ProtractorBrowser).toBe('function');

--- a/spec/install/typings.json
+++ b/spec/install/typings.json
@@ -3,7 +3,6 @@
   "dependencies": {},
   "globalDependencies": {
     "jasmine": "registry:dt/jasmine#2.2.0+20160621224255",
-    "node": "registry:dt/node#6.0.0+20160802155038",
-    "rimraf": "registry:dt/rimraf#0.0.0+20160317120654"
+    "node": "registry:dt/node#6.0.0+20160802155038"
   }
 }

--- a/spec/install/typings.json
+++ b/spec/install/typings.json
@@ -1,0 +1,9 @@
+{
+  "name": "protractor-install",
+  "dependencies": {},
+  "globalDependencies": {
+    "jasmine": "registry:dt/jasmine#2.2.0+20160621224255",
+    "node": "registry:dt/node#6.0.0+20160802155038",
+    "rimraf": "registry:dt/rimraf#0.0.0+20160317120654"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     "typings/globals",
     "scripts",
     "globals.ts",
-    "exampleTypescript"
+    "exampleTypescript",
+    "spec"
   ]
 }


### PR DESCRIPTION
- rename to ProtractorBrowser to be able to export selenium-webdriver Browser as Browser
- export all selenium-webdriver items and subfolders in ptor
- update dependency tests for selenium
- add tests when protractor is installed

closes #3427 
closes #2092