### PR TITLE
chore(util): remove argument type for err

### DIFF
--- a/lib/util.ts
+++ b/lib/util.ts
@@ -48,19 +48,18 @@ export function runFilenameOrFn_(
       filenameOrFn = require(resolve(configDir, filenameOrFn));
     }
     if (typeof filenameOrFn === 'function') {
-      let results =
-          when(filenameOrFn.apply(null, args), null, (err: string | Error) => {
-            if (typeof err === 'string') {
-              err = new Error(err);
-            } else {
-              err = err as Error;
-              if (err.stack) {
-                err.stack = new Error().stack;
-              }
-            }
-            err.stack = exports.filterStackTrace(err.stack);
-            throw err;
-          });
+      let results = when(filenameOrFn.apply(null, args), null, (err) => {
+        if (typeof err === 'string') {
+          err = new Error(err);
+        } else {
+          err = err as Error;
+          if (err.stack) {
+            err.stack = new Error().stack;
+          }
+        }
+        err.stack = exports.filterStackTrace(err.stack);
+        throw err;
+      });
       resolvePromise(results);
     } else {
       resolvePromise(undefined);


### PR DESCRIPTION
- Fix argument of type 'string | Error' is not assignable to parameter of type 'string'.