### PR TITLE
feat(config): Add 'random' and 'seed' Jasmine config options

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -519,6 +519,14 @@ export interface Config {
      * Inverts 'grep' matches
      */
     invertGrep?: boolean;
+    /**
+     * If true, run specs in semi-random order
+     */
+    random?: boolean,
+    /**
+     * Set the randomization seed if randomization is turned on
+     */
+     seed?: string,
   };
 
   /**

--- a/lib/frameworks/jasmine.js
+++ b/lib/frameworks/jasmine.js
@@ -87,6 +87,16 @@ exports.run = function(runner, specs) {
     return true;
   };
 
+  // Run specs in semi-random order
+  if (jasmineNodeOpts.random) {
+    jasmine.getEnv().randomizeTests(true);
+
+    // Sets the randomization seed if randomization is turned on
+    if (jasmineNodeOpts.seed) {
+      jasmine.getEnv().seed(jasmineNodeOpts.seed);
+    }
+  }
+
   return runner.runTestPreparer().then(function() {
     return q.promise(function(resolve, reject) {
       if (jasmineNodeOpts && jasmineNodeOpts.defaultTimeoutInterval) {


### PR DESCRIPTION
## Feature Request

This adds handling of `random` and `seed` options in `jasmineNodeOpts` and allows to run specs in random order. The descriptions for both options are taken from Jasmine [docs](http://jasmine.github.io/2.4/node.html#section-14).
- Reasons for adopting new feature
  Running specs in random order is usually preferable, as it ensures that the tests don't depend on each other and don't leak unwanted changes.
- Is this a breaking change? (How will this affect existing functionality)
  Nope.
