### PR TITLE
fix(debugger): Fix issues when calling pause() multiple times (#3501)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ chromedriver.log
 libpeerconnection.log
 xmloutput*
 npm-debug.log
+.idea/
 
 *.swp
 globals.js

--- a/lib/browser.ts
+++ b/lib/browser.ts
@@ -242,8 +242,12 @@ export class ProtractorBrowser extends Webdriver {
    */
   debuggerServerPort_: number;
 
+  /**
+   * Set to true when we validate that the debug port is open. Since the debug
+   * port is held open forever once the debugger is attached, it's important
+   * we only do validation once.
+   */
   debuggerValidated_: boolean;
-
 
   /**
    * If true, Protractor will interpret any angular apps it comes across as
@@ -979,10 +983,12 @@ export class ProtractorBrowser extends Webdriver {
       }
     });
 
-    return doneDeferred.then(null, (err: string) => {
-      console.error(err);
-      process.exit(1);
-    });
+    return doneDeferred.then(
+        () => { this.debuggerValidated_ = true; },
+        (err: string) => {
+          console.error(err);
+          process.exit(1);
+        });
   }
 
   private dbgCodeExecutor_: any;
@@ -1039,10 +1045,10 @@ export class ProtractorBrowser extends Webdriver {
 
     let browserUnderDebug = this;
     let debuggerReadyPromise = webdriver.promise.defer();
-    flow.execute(function() {
+    flow.execute(() => {
       process['debugPort'] = opt_debugPort || process['debugPort'];
       browserUnderDebug.validatePortAvailability_(process['debugPort'])
-          .then(function(firstTime: boolean) {
+          .then((firstTime: boolean) => {
             onStartFn(firstTime);
 
             let args = [process.pid, process['debugPort']];
@@ -1052,11 +1058,19 @@ export class ProtractorBrowser extends Webdriver {
             let nodedebug =
                 require('child_process').fork(debuggerClientPath, args);
             process.on('exit', function() { nodedebug.kill('SIGTERM'); });
-            nodedebug.on('message', function(m: string) {
-              if (m === 'ready') {
-                debuggerReadyPromise.fulfill();
-              }
-            });
+            nodedebug
+                .on('message',
+                    (m: string) => {
+                      if (m === 'ready') {
+                        debuggerReadyPromise.fulfill();
+                      }
+                    })
+                .on('exit', () => {
+                  logger.info('Debugger exiting');
+                  // Clear this so that we know it's ok to attach a debugger
+                  // again.
+                  this.dbgCodeExecutor_ = null;
+                });
           });
     });
 
@@ -1163,6 +1177,8 @@ export class ProtractorBrowser extends Webdriver {
         return this.execPromiseResult_;
       }
     };
+
+    return pausePromise;
   }
 
   /**
@@ -1217,7 +1233,12 @@ export class ProtractorBrowser extends Webdriver {
    * @param {number=} opt_debugPort Optional port to use for the debugging
    * process
    */
-  pause(opt_debugPort?: number) {
+  pause(opt_debugPort?: number): webdriver.promise.Promise<any> {
+    if (this.dbgCodeExecutor_) {
+      logger.info(
+          'Encountered browser.pause(), but debugger already attached.');
+      return webdriver.promise.fulfilled(true);
+    }
     let debuggerClientPath = __dirname + '/debugger/clients/wddebugger.js';
     let onStartFn = (firstTime: boolean) => {
       logger.info();
@@ -1236,7 +1257,7 @@ export class ProtractorBrowser extends Webdriver {
         logger.info();
       }
     };
-    this.initDebugger_(debuggerClientPath, onStartFn, opt_debugPort);
+    return this.initDebugger_(debuggerClientPath, onStartFn, opt_debugPort);
   }
 
   /**

--- a/lib/debugger/clients/wddebugger.js
+++ b/lib/debugger/clients/wddebugger.js
@@ -100,7 +100,7 @@ WdDebugger.prototype.initRepl_ = function() {
     self.replServer.on('exit', function() {
       console.log('Resuming code execution');
       self.client.req({command: 'disconnect'}, function() {
-        // Intentionally blank.
+        process.exit();
       });
     });
   });


### PR DESCRIPTION
There's still an issue when calling browser.pause() multiple times in the same test - the other pause statements are ignored. But it no longer exits due to the port being in use. Pausing in multiple tests also works now.