### PR TITLE
fix(mocha): Wrap it.only with the selenium adapter

### DIFF
--- a/lib/frameworks/mocha.js
+++ b/lib/frameworks/mocha.js
@@ -27,13 +27,8 @@ exports.run = function(runner, specs) {
       global.before = mochaAdapters.before;
       global.beforeEach = mochaAdapters.beforeEach;
 
-      // The implementation of mocha's it.only uses global.it, so since that has
-      // already been wrapped we must avoid wrapping it a second time.
-      // See Mocha.prototype.loadFiles and bdd's context.it.only for more details.
-      var originalOnly = global.it.only;
       global.it = mochaAdapters.it;
-      global.it.only = global.iit = originalOnly;
-
+      global.it.only = global.iit = mochaAdapters.iit;
       global.it.skip = global.xit = mochaAdapters.xit;
     } catch (err) {
       deferred.reject(err);

--- a/spec/mocha/lib_spec.js
+++ b/spec/mocha/lib_spec.js
@@ -34,4 +34,16 @@ describe('protractor library', function() {
     browser.get('index.html');
     expect(browser.getTitle()).to.eventually.equal('My AngularJS App');
   });
+
+  describe('with async tests', function() {
+    var finished = false;
+
+    it('should wait for async operations to finish', function() {
+      browser.get('index.html').then(() => { finished = true });
+    });
+
+    after('verify mocha waited', function() {
+      if(!finished) { throw new Error('Mocha did not wait for async!'); }
+    });
+  });
 });


### PR DESCRIPTION
Fixes #3045. Since mocha 2.4.1, we should be wrapping global.it.only.