### PR TITLE
fix(jasmine): Pass control flow to JasmineWd

### DIFF
--- a/lib/frameworks/jasmine.js
+++ b/lib/frameworks/jasmine.js
@@ -1,4 +1,5 @@
 var q = require('q');
+var webdriver = require('selenium-webdriver');
 
 var RunnerReporter = function(emitter) {
   this.emitter = emitter;
@@ -62,7 +63,7 @@ exports.run = function(runner, specs) {
   var jrunner = new JasmineRunner();
   /* global jasmine */
 
-  require('jasminewd2');
+  require('jasminewd2').init(webdriver.promise.controlFlow());
 
   var jasmineNodeOpts = runner.getConfig().jasmineNodeOpts;
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "chalk": "^1.1.3",
     "glob": "^7.0.3",
     "jasmine": "2.4.1",
-    "jasminewd2": "0.0.9",
+    "jasminewd2": "0.0.10",
     "optimist": "~0.6.0",
     "q": "1.4.1",
     "saucelabs": "~1.3.0",


### PR DESCRIPTION
Fixes #3505 and #2790, which is caused by JasmineWd and Protractor using different
controlflow instances