### PR TITLE
chore(types): clean up TypeScript support

### DIFF
--- a/exampleTypescript/.gitignore
+++ b/exampleTypescript/.gitignore
@@ -1,2 +1,3 @@
 *.js
 node_modules
+tmp/

--- a/exampleTypescript/conf.ts
+++ b/exampleTypescript/conf.ts
@@ -16,5 +16,9 @@ export let config: Config = {
     browserName: 'chrome'
   },
   specs: [ 'spec.js' ],
-  seleniumAddress: 'http://localhost:4444/wd/hub'
+  seleniumAddress: 'http://localhost:4444/wd/hub',
+
+  // You could set no globals to true to avoid jQuery '$' and protractor '$'
+  // collisions on the global namespace.
+  noGlobals: true
 };

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -49,9 +49,10 @@ gulp.task('checkVersion', function(done) {
   }
 });
 
-gulp.task('built:copy', function() {
-  return gulp.src(['lib/**/*.js','lib/globals.d.ts'])
+gulp.task('built:copy', function(done) {
+  return gulp.src(['lib/**/*.js','lib/globals.d.ts','lib/index.d.ts'])
       .pipe(gulp.dest('built/'));
+  done();
 });
 
 gulp.task('webdriver:update', function(done) {
@@ -88,29 +89,14 @@ gulp.task('tsc:globals', function(done) {
 });
 
 gulp.task('prepublish', function(done) {
-  runSequence('checkVersion', ['jshint', 'format'], 'tsc', 'tsc:globals', 'types',
+  runSequence('checkVersion', ['jshint', 'format'], 'tsc', 'tsc:globals',
     'built:copy', done);
 });
 
 gulp.task('pretest', function(done) {
   runSequence('checkVersion',
     ['webdriver:update', 'jshint', 'format'], 'tsc', 'tsc:globals',
-    'types', 'built:copy', done);
+    'built:copy', done);
 });
 
 gulp.task('default',['prepublish']);
-
-gulp.task('types', function(done) {
-  var outputFile = path.resolve('built', 'index.d.ts');
-  var contents = '';
-  contents += '/// <reference path="../typings/index.d.ts" />\n';
-  contents += '/// <reference path="./globals.d.ts" />\n';
-  contents += 'export { ElementHelper, ProtractorBrowser } from \'./browser\';\n';
-  contents += 'export { ElementArrayFinder, ElementFinder } from \'./element\';\n';
-  contents += 'export { ProtractorExpectedConditions } from \'./expectedConditions\';\n';
-  contents += 'export { ProtractorBy } from \'./locators\';\n';
-  contents += 'export { Config } from \'./config\';\n';
-  contents += 'export { Ptor } from \'./ptor\';\n';
-  fs.writeFileSync(outputFile, contents);
-  done();
-});

--- a/lib/browser.ts
+++ b/lib/browser.ts
@@ -34,6 +34,7 @@ for (let foo in webdriver) {
 }
 
 // Explicitly define webdriver.WebDriver
+// TODO: extend WebDriver from selenium-webdriver typings
 export class Webdriver {
   actions: () => ActionSequence;
   call:
@@ -508,7 +509,7 @@ export class ProtractorBrowser extends Webdriver {
                     'Timed out waiting for Protractor to synchronize with ' +
                     'the page after ' + timeout + '. Please see ' +
                     'https://github.com/angular/protractor/blob/master/docs/faq.md';
-                if (description.startsWith(' - Locator: ')) {
+                if (description.indexOf(' - Locator: ') == 0) {
                   errMsg +=
                       '\nWhile waiting for element with locator' + description;
                 }
@@ -773,17 +774,14 @@ export class ProtractorBrowser extends Webdriver {
                       'return window.location.href;', msg('get url'))
                   .then(
                       (url: any) => { return url !== this.resetUrl; },
-                      (err: webdriver.ErrorCode) => {
+                      (err: IError) => {
                         if (err.code == 13) {
                           // Ignore the error, and continue trying. This is
-                          // because IE
-                          // driver sometimes (~1%) will throw an unknown error
-                          // from this
-                          // execution. See
+                          // because IE driver sometimes (~1%) will throw an
+                          // unknown error from this execution. See
                           // https://github.com/angular/protractor/issues/841
                           // This shouldn't mask errors because it will fail
-                          // with the timeout
-                          // anyway.
+                          // with the timeout anyway.
                           return false;
                         } else {
                           throw err;

--- a/lib/browser.ts
+++ b/lib/browser.ts
@@ -1,6 +1,7 @@
 // Util from NodeJs
 import * as net from 'net';
-import {ActionSequence, promise as wdpromise, until, WebDriver, WebElement} from 'selenium-webdriver';
+import {ActionSequence, Capabilities, Command as WdCommand, FileDetector, Options, promise as wdpromise, Session, TargetLocator, TouchSequence, until, WebDriver, WebElement} from 'selenium-webdriver';
+
 import * as url from 'url';
 import * as util from 'util';
 
@@ -32,20 +33,36 @@ for (let foo in webdriver) {
   exports[foo] = webdriver[foo];
 }
 
-// Explicitly define webdriver.WebDriver.
+// Explicitly define webdriver.WebDriver
 export class Webdriver {
-  actions: () => ActionSequence = webdriver.WebDriver.actions;
+  actions: () => ActionSequence;
+  call:
+      (fn: (...var_args: any[]) => any, opt_scope?: any,
+       ...var_args: any[]) => wdpromise.Promise<any>;
+  close: () => void;
+  controlFlow: () => wdpromise.ControlFlow;
+  executeScript:
+      (script: string|Function, ...var_args: any[]) => wdpromise.Promise<any>;
+  executeAsyncScript:
+      (script: string|Function, ...var_args: any[]) => wdpromise.Promise<any>;
+  getCapabilities: () => Capabilities;
+  getCurrentUrl: () => wdpromise.Promise<string>;
+  getPageSource: () => wdpromise.Promise<string>;
+  getSession: () => wdpromise.Promise<Session>;
+  getTitle: () => wdpromise.Promise<string>;
+  getWindowHandle: () => wdpromise.Promise<string>;
+  getAllWindowHandles: () => wdpromise.Promise<string[]>;
+  manage: () => Options;
+  quit: () => void;
+  schedule: (command: WdCommand, description: string) => wdpromise.Promise<any>;
+  setFileDetector: (detector: FileDetector) => void;
+  sleep: (ms: number) => wdpromise.Promise<void>;
+  switchTo: () => TargetLocator;
+  takeScreenshot: () => wdpromise.Promise<any>;
+  touchActions: () => TouchSequence;
   wait:
       (condition: wdpromise.Promise<any>|until.Condition<any>|Function,
-       opt_timeout?: number,
-       opt_message?:
-           string) => wdpromise.Promise<any> = webdriver.WebDriver.wait;
-  sleep: (ms: number) => wdpromise.Promise<any> = webdriver.WebDriver.sleep;
-  getCurrentUrl:
-      () => wdpromise.Promise<any> = webdriver.WebDriver.getCurrentUrl;
-  getTitle: () => wdpromise.Promise<any> = webdriver.WebDriver.getTitle;
-  takeScreenshot:
-      () => wdpromise.Promise<any> = webdriver.WebDriver.takeScreenshot;
+       opt_timeout?: number, opt_message?: string) => wdpromise.Promise<any>;
 }
 
 /**
@@ -268,7 +285,6 @@ export class ProtractorBrowser extends Webdriver {
     // include functions which are overridden by protractor below.
     let methodsToSync = ['getCurrentUrl', 'getPageSource', 'getTitle'];
 
-
     // Mix all other driver functionality into Protractor.
     Object.getOwnPropertyNames(webdriver.WebDriver.prototype)
         .forEach((method: string) => {
@@ -298,7 +314,7 @@ export class ProtractorBrowser extends Webdriver {
     this.resetUrl = DEFAULT_RESET_URL;
     this.ng12Hybrid = false;
 
-    this.driver.getCapabilities().then((caps: webdriver.Capabilities) => {
+    this.driver.getCapabilities().then((caps: Capabilities) => {
       // Internet Explorer does not accept data URLs, which are the default
       // reset URL for Protractor.
       // Safari accepts data urls, but SafariDriver fails after one is used.
@@ -572,7 +588,7 @@ export class ProtractorBrowser extends Webdriver {
    * @returns {!webdriver.promise.Promise} A promise that will resolve to whether
    *     the element is present on the page.
    */
-  isElementPresent(locatorOrElement: webdriver.Locator|
+  isElementPresent(locatorOrElement: ProtractorBy|
                    webdriver.WebElement): webdriver.promise.Promise<any> {
     let element = ((locatorOrElement as any).isPresent) ?
         locatorOrElement :

--- a/lib/element.ts
+++ b/lib/element.ts
@@ -18,6 +18,7 @@ let WEB_ELEMENT_FUNCTIONS = [
 ];
 
 // Explicitly define webdriver.WebElement.
+// TODO: extend WebElement from selenium-webdriver typings
 export class WebdriverWebElement {
   getDriver: () => WebDriver;
   getId: () => wdpromise.Promise<any>;

--- a/lib/element.ts
+++ b/lib/element.ts
@@ -1,4 +1,4 @@
-import {By, error, promise, WebDriver, WebElement, WebElementPromise} from 'selenium-webdriver';
+import {By, error, ILocation, ISize, promise as wdpromise, WebDriver, WebElement, WebElementPromise} from 'selenium-webdriver';
 
 import {ElementHelper} from './browser';
 import {ProtractorBrowser} from './browser';
@@ -20,25 +20,25 @@ let WEB_ELEMENT_FUNCTIONS = [
 // Explicitly define webdriver.WebElement.
 export class WebdriverWebElement {
   getDriver: () => WebDriver;
-  getId: () => promise.Promise<any>;
-  getRawId: () => promise.Promise<string>;
-  serialize: () => promise.Promise<any>;
-  findElement: (subLocator: Locator) => promise.Promise<any>;
-  click: () => promise.Promise<void>;
-  sendKeys:
-      (...args: (string|promise.Promise<string>)[]) => promise.Promise<void>;
-  getTagName: () => promise.Promise<string>;
-  getCssValue: (cssStyleProperty: string) => promise.Promise<string>;
-  getAttribute: (attributeName: string) => promise.Promise<string>;
-  getText: () => promise.Promise<string>;
-  getSize: () => promise.Promise<{width: number, height: number}>;
-  getLocation: () => promise.Promise<{x: number, y: number}>;
-  isEnabled: () => promise.Promise<boolean>;
-  isSelected: () => promise.Promise<boolean>;
-  submit: () => promise.Promise<void>;
-  clear: () => promise.Promise<void>;
-  isDisplayed: () => promise.Promise<boolean>;
-  takeScreenshot: (opt_scroll?: boolean) => promise.Promise<string>;
+  getId: () => wdpromise.Promise<any>;
+  getRawId: () => wdpromise.Promise<string>;
+  serialize: () => wdpromise.Promise<any>;
+  findElement: (subLocator: Locator) => wdpromise.Promise<any>;
+  click: () => wdpromise.Promise<void>;
+  sendKeys: (...args: (string|
+                       wdpromise.Promise<string>)[]) => wdpromise.Promise<void>;
+  getTagName: () => wdpromise.Promise<string>;
+  getCssValue: (cssStyleProperty: string) => wdpromise.Promise<string>;
+  getAttribute: (attributeName: string) => wdpromise.Promise<string>;
+  getText: () => wdpromise.Promise<string>;
+  getSize: () => wdpromise.Promise<ISize>;
+  getLocation: () => wdpromise.Promise<ILocation>;
+  isEnabled: () => wdpromise.Promise<boolean>;
+  isSelected: () => wdpromise.Promise<boolean>;
+  submit: () => wdpromise.Promise<void>;
+  clear: () => wdpromise.Promise<void>;
+  isDisplayed: () => wdpromise.Promise<boolean>;
+  takeScreenshot: (opt_scroll?: boolean) => wdpromise.Promise<string>;
 }
 
 /**
@@ -97,14 +97,13 @@ export class WebdriverWebElement {
 export class ElementArrayFinder extends WebdriverWebElement {
   constructor(
       public browser_: ProtractorBrowser,
-      public getWebElements: () => promise.Promise<WebElement[]> = null,
+      public getWebElements: () => wdpromise.Promise<WebElement[]> = null,
       public locator_?: any,
-      public actionResults_: promise.Promise<any> = null) {
+      public actionResults_: wdpromise.Promise<any> = null) {
     super();
 
     // TODO(juliemr): might it be easier to combine this with our docs and just
-    // wrap each
-    // one explicity with its own documentation?
+    // wrap each one explicity with its own documentation?
     WEB_ELEMENT_FUNCTIONS.forEach((fnName: string) => {
       this[fnName] = (...args: any[]) => {
         let actionFn =
@@ -163,11 +162,11 @@ export class ElementArrayFinder extends WebdriverWebElement {
    */
   all(locator: Locator): ElementArrayFinder {
     let ptor = this.browser_;
-    let getWebElements = (): promise.Promise<WebElement[]> => {
+    let getWebElements = (): wdpromise.Promise<WebElement[]> => {
       if (this.getWebElements === null) {
         // This is the first time we are looking for an element
         return ptor.waitForAngular('Locator: ' + locator)
-            .then((): promise.Promise<webdriver.WebElement[]> => {
+            .then((): wdpromise.Promise<webdriver.WebElement[]> => {
               if (locator.findElementsOverride) {
                 return locator.findElementsOverride(
                     ptor.driver, null, ptor.rootEl);
@@ -192,7 +191,7 @@ export class ElementArrayFinder extends WebdriverWebElement {
               // Resolve the list of Promise<List<child_web_elements>> and merge
               // into
               // a single list
-              return promise.all(childrenPromiseList)
+              return wdpromise.all(childrenPromiseList)
                   .then((resolved: webdriver.WebElement[]) => {
                     return resolved.reduce(
                         (childrenList: webdriver.WebElement[],
@@ -239,7 +238,7 @@ export class ElementArrayFinder extends WebdriverWebElement {
    *     of element that satisfy the filter function.
    */
   filter(filterFn: Function): ElementArrayFinder {
-    let getWebElements = (): promise.Promise<WebElement[]> => {
+    let getWebElements = (): wdpromise.Promise<WebElement[]> => {
       return this.getWebElements().then((parentWebElements: WebElement[]) => {
         let list = parentWebElements.map(
             (parentWebElement: WebElement, index: number) => {
@@ -385,7 +384,7 @@ export class ElementArrayFinder extends WebdriverWebElement {
    * @returns {!webdriver.promise.Promise} A promise which resolves to the
    *     number of elements matching the locator.
    */
-  count(): promise.Promise<number> {
+  count(): wdpromise.Promise<number> {
     return this.getWebElements().then(
         (arr: WebElement[]) => { return arr.length; },
         (err: IError) => {
@@ -458,7 +457,7 @@ export class ElementArrayFinder extends WebdriverWebElement {
    * @returns {Array.<ElementFinder>} Return a promise, which resolves to a list
    *     of ElementFinders specified by the locator.
    */
-  asElementFinders_(): promise.Promise<any> {
+  asElementFinders_(): wdpromise.Promise<any> {
     return this.getWebElements().then((arr: WebElement[]) => {
       return arr.map((webElem: WebElement) => {
         return ElementFinder.fromWebElement_(
@@ -491,7 +490,7 @@ export class ElementArrayFinder extends WebdriverWebElement {
    * @returns {!webdriver.promise.Promise} A promise which will resolve to
    *     an array of ElementFinders represented by the ElementArrayFinder.
    */
-  then(fn: Function, errorFn: Function): promise.Promise<any> {
+  then(fn: Function, errorFn: Function): wdpromise.Promise<any> {
     if (this.actionResults_) {
       return this.actionResults_.then(fn, errorFn);
     } else {
@@ -526,7 +525,7 @@ export class ElementArrayFinder extends WebdriverWebElement {
    *     resolve to null.
    */
   each(fn: (elementFinder: ElementFinder, index: number) => any):
-      promise.Promise<any> {
+      wdpromise.Promise<any> {
     return this.map(fn).then((): any => { return null; });
   }
 
@@ -563,14 +562,14 @@ export class ElementArrayFinder extends WebdriverWebElement {
    *     of values returned by the map function.
    */
   map(mapFn: (elementFinder: ElementFinder, index: number) => any):
-      promise.Promise<any> {
+      wdpromise.Promise<any> {
     return this.asElementFinders_().then((arr: ElementFinder[]) => {
       let list = arr.map((elementFinder: ElementFinder, index: number) => {
         let mapResult = mapFn(elementFinder, index);
         // All nested arrays and objects will also be fully resolved.
-        return promise.fullyResolved(mapResult);
+        return wdpromise.fullyResolved(mapResult);
       });
-      return promise.all(list);
+      return wdpromise.all(list);
     });
   };
 
@@ -606,8 +605,8 @@ export class ElementArrayFinder extends WebdriverWebElement {
    * @returns {!webdriver.promise.Promise} A promise that resolves to the final
    *     value of the accumulator.
    */
-  reduce(reduceFn: Function, initialValue: any): promise.Promise<any> {
-    let valuePromise = promise.fulfilled(initialValue);
+  reduce(reduceFn: Function, initialValue: any): wdpromise.Promise<any> {
+    let valuePromise = wdpromise.fulfilled(initialValue);
     return this.asElementFinders_().then((arr: ElementFinder[]) => {
       return arr.reduce(
           (valuePromise: any, elementFinder: ElementFinder, index: number) => {
@@ -714,7 +713,7 @@ export class ElementArrayFinder extends WebdriverWebElement {
 export class ElementFinder extends WebdriverWebElement {
   parentElementArrayFinder: ElementArrayFinder;
   elementArrayFinder_: ElementArrayFinder;
-  then: (fn: Function, errorFn: Function) => promise.Promise<any> = null;
+  then: (fn: Function, errorFn: Function) => wdpromise.Promise<any> = null;
 
   constructor(
       public browser_: ProtractorBrowser,
@@ -752,7 +751,7 @@ export class ElementFinder extends WebdriverWebElement {
     // This filter verifies that there is only 1 element returned by the
     // elementArrayFinder. It will warn if there are more than 1 element and
     // throw an error if there are no elements.
-    let getWebElements = (): promise.Promise<WebElement[]> => {
+    let getWebElements = (): wdpromise.Promise<WebElement[]> => {
       return elementArrayFinder.getWebElements().then(
           (webElements: WebElement[]) => {
             if (webElements.length === 0) {
@@ -790,7 +789,7 @@ export class ElementFinder extends WebdriverWebElement {
   static fromWebElement_(
       browser: ProtractorBrowser, webElem: WebElement,
       locator: Locator): ElementFinder {
-    let getWebElements = () => { return promise.fulfilled([webElem]); };
+    let getWebElements = () => { return wdpromise.fulfilled([webElem]); };
     return new ElementArrayFinder(browser, getWebElements, locator)
         .toElementFinder_();
   }
@@ -965,7 +964,7 @@ export class ElementFinder extends WebdriverWebElement {
    * @returns {webdriver.promise.Promise<boolean>} which resolves to whether
    *     the element is present on the page.
    */
-  isPresent(): promise.Promise<boolean> {
+  isPresent(): wdpromise.Promise<boolean> {
     return this.parentElementArrayFinder.getWebElements().then(
         (arr: any[]) => {
           if (arr.length === 0) {
@@ -1005,7 +1004,7 @@ export class ElementFinder extends WebdriverWebElement {
    * @returns {webdriver.promise.Promise<boolean>} which resolves to whether
    *     the subelement is present on the page.
    */
-  isElementPresent(subLocator: Locator): promise.Promise<boolean> {
+  isElementPresent(subLocator: Locator): wdpromise.Promise<boolean> {
     if (!subLocator) {
       throw new Error(
           'SubLocator is not supplied as a parameter to ' +
@@ -1051,7 +1050,7 @@ export class ElementFinder extends WebdriverWebElement {
    * @returns {!webdriver.promise.Promise.<boolean>} A promise that will be
    *     resolved to whether the two WebElements are equal.
    */
-  equals(element: ElementFinder|WebElement): promise.Promise<any> {
+  equals(element: ElementFinder|WebElement): wdpromise.Promise<any> {
     return WebElement.equals(
         this.getWebElement(), (element as any).getWebElement ?
             (element as ElementFinder).getWebElement() :

--- a/lib/globals.d.ts
+++ b/lib/globals.d.ts
@@ -25,7 +25,7 @@ declare namespace NodeJS {
     Command: any;
     CommandName: any;
     // Helper function added by the debugger in protractor.ps
-    list: (locator: webdriver.Locator) => string[];
+    list: (locator: any) => string[];
     [key: string]: any;
   }
 }
@@ -38,23 +38,8 @@ declare interface IError extends Error {
 declare interface String { startsWith: Function; }
 
 declare namespace webdriver {
-  namespace promise {
-    interface Promise<T> {
-      controlFlow: Function;
-    }
-  }
-
-  namespace util {
-    interface Condition {}
-  }
-
   class ErrorCode {
     code: number;
-  }
-
-  interface Locator {
-    toString(): string;
-    isPresent?: Function;
   }
 }
 

--- a/lib/globals.d.ts
+++ b/lib/globals.d.ts
@@ -13,6 +13,7 @@ declare namespace NodeJS {
   }
 
   interface Global {
+    // These are here because we tie these variables to the global namespace.
     browser: any;
     protractor: any;
     $: any;
@@ -24,7 +25,7 @@ declare namespace NodeJS {
     DartObject: any;
     Command: any;
     CommandName: any;
-    // Helper function added by the debugger in protractor.ps
+    // Helper function added by the debugger and element explorer
     list: (locator: any) => string[];
     [key: string]: any;
   }
@@ -33,14 +34,6 @@ declare namespace NodeJS {
 declare interface IError extends Error {
   code?: number;
   stack?: string;
-}
-
-declare interface String { startsWith: Function; }
-
-declare namespace webdriver {
-  class ErrorCode {
-    code: number;
-  }
 }
 
 declare interface HttpProxyAgent { constructor(opts: Object): HttpProxyAgent; }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,8 @@
+/// <reference path="../typings/index.d.ts" />
+/// <reference path="./globals.d.ts" />
+export {ElementHelper, ProtractorBrowser} from './browser';
+export {Config} from './config';
+export {ElementArrayFinder, ElementFinder} from './element';
+export {ProtractorExpectedConditions} from './expectedConditions';
+export {ProtractorBy} from './locators';
+export {Ptor} from './ptor';

--- a/lib/locators.ts
+++ b/lib/locators.ts
@@ -1,4 +1,4 @@
-import {By, promise, WebDriver, WebElement} from 'selenium-webdriver';
+import {By, promise as wdpromise, WebDriver, WebElement} from 'selenium-webdriver';
 import * as util from 'util';
 
 let webdriver = require('selenium-webdriver');
@@ -22,7 +22,7 @@ export class WebdriverBy {
 export interface Locator {
   findElementsOverride?:
       (driver: WebDriver, using: WebElement,
-       rootSelector: string) => promise.Promise<WebElement[]>;
+       rootSelector: string) => wdpromise.Promise<WebElement[]>;
   row?: (index: number) => Locator;
   column?: (index: string) => Locator;
 }
@@ -77,7 +77,7 @@ export class ProtractorBy extends WebdriverBy {
       return {
         findElementsOverride:
             (driver: WebDriver, using: WebElement, rootSelector: string):
-                promise.Promise<WebElement[]> => {
+                wdpromise.Promise<WebElement[]> => {
               let findElementArguments: any[] = [script];
               for (let i = 0; i < locatorArguments.length; i++) {
                 findElementArguments.push(locatorArguments[i]);
@@ -130,7 +130,7 @@ export class ProtractorBy extends WebdriverBy {
     return {
       findElementsOverride:
           (driver: WebDriver, using: WebElement, rootSelector: string):
-              promise.Promise<WebElement[]> => {
+              wdpromise.Promise<WebElement[]> => {
             return driver.findElements(webdriver.By.js(
                 clientSideScripts.findBindings, bindingDescriptor, false, using,
                 rootSelector));
@@ -163,7 +163,7 @@ export class ProtractorBy extends WebdriverBy {
     return {
       findElementsOverride:
           (driver: WebDriver, using: WebElement, rootSelector: string):
-              promise.Promise<WebElement[]> => {
+              wdpromise.Promise<WebElement[]> => {
             return driver.findElements(webdriver.By.js(
                 clientSideScripts.findBindings, bindingDescriptor, true, using,
                 rootSelector));
@@ -193,7 +193,7 @@ export class ProtractorBy extends WebdriverBy {
     return {
       findElementsOverride:
           (driver: WebDriver, using: WebElement, rootSelector: string):
-              promise.Promise<WebElement[]> => {
+              wdpromise.Promise<WebElement[]> => {
             return driver.findElements(webdriver.By.js(
                 clientSideScripts.findByModel, model, using, rootSelector));
           },
@@ -217,7 +217,7 @@ export class ProtractorBy extends WebdriverBy {
     return {
       findElementsOverride:
           (driver: WebDriver, using: WebElement, rootSelector: string):
-              promise.Promise<WebElement[]> => {
+              wdpromise.Promise<WebElement[]> => {
             return driver.findElements(webdriver.By.js(
                 clientSideScripts.findByButtonText, searchText, using,
                 rootSelector));
@@ -242,7 +242,7 @@ export class ProtractorBy extends WebdriverBy {
     return {
       findElementsOverride:
           (driver: WebDriver, using: WebElement, rootSelector: string):
-              promise.Promise<WebElement[]> => {
+              wdpromise.Promise<WebElement[]> => {
             return driver.findElements(webdriver.By.js(
                 clientSideScripts.findByPartialButtonText, searchText, using,
                 rootSelector));
@@ -258,7 +258,7 @@ export class ProtractorBy extends WebdriverBy {
     return {
       findElementsOverride:
           (driver: WebDriver, using: WebElement, rootSelector: string):
-              promise.Promise<WebElement[]> => {
+              wdpromise.Promise<WebElement[]> => {
             return driver.findElements(webdriver.By.js(
                 clientSideScripts.findAllRepeaterRows, repeatDescriptor, exact,
                 using, rootSelector));
@@ -268,7 +268,7 @@ export class ProtractorBy extends WebdriverBy {
         return {
           findElementsOverride:
               (driver: WebDriver, using: WebElement, rootSelector: string):
-                  promise.Promise<WebElement[]> => {
+                  wdpromise.Promise<WebElement[]> => {
                 return driver.findElements(webdriver.By.js(
                     clientSideScripts.findRepeaterRows, repeatDescriptor, exact,
                     index, using, rootSelector));
@@ -280,7 +280,7 @@ export class ProtractorBy extends WebdriverBy {
             return {
               findElementsOverride:
                   (driver: WebDriver, using: WebElement, rootSelector: string):
-                      promise.Promise<WebElement[]> => {
+                      wdpromise.Promise<WebElement[]> => {
                     return driver.findElements(webdriver.By.js(
                         clientSideScripts.findRepeaterElement, repeatDescriptor,
                         exact, index, binding, using, rootSelector));
@@ -297,7 +297,7 @@ export class ProtractorBy extends WebdriverBy {
         return {
           findElementsOverride:
               (driver: WebDriver, using: WebElement, rootSelector: string):
-                  promise.Promise<WebElement[]> => {
+                  wdpromise.Promise<WebElement[]> => {
                 return driver.findElements(webdriver.By.js(
                     clientSideScripts.findRepeaterColumn, repeatDescriptor,
                     exact, binding, using, rootSelector));
@@ -310,7 +310,7 @@ export class ProtractorBy extends WebdriverBy {
             return {
               findElementsOverride:
                   (driver: WebDriver, using: WebElement, rootSelector: string):
-                      promise.Promise<WebElement[]> => {
+                      wdpromise.Promise<WebElement[]> => {
                     return driver.findElements(webdriver.By.js(
                         clientSideScripts.findRepeaterElement, repeatDescriptor,
                         exact, index, binding, using, rootSelector));
@@ -427,7 +427,7 @@ export class ProtractorBy extends WebdriverBy {
     return {
       findElementsOverride:
           (driver: WebDriver, using: WebElement, rootSelector: string):
-              promise.Promise<WebElement[]> => {
+              wdpromise.Promise<WebElement[]> => {
             return driver.findElements(webdriver.By.js(
                 clientSideScripts.findByCssContainingText, cssSelector,
                 searchText, using, rootSelector));
@@ -462,7 +462,7 @@ export class ProtractorBy extends WebdriverBy {
     return {
       findElementsOverride:
           (driver: WebDriver, using: WebElement, rootSelector: string):
-              promise.Promise<WebElement[]> => {
+              wdpromise.Promise<WebElement[]> => {
             return driver.findElements(webdriver.By.js(
                 clientSideScripts.findByOptions, optionsDescriptor, using,
                 rootSelector));


### PR DESCRIPTION
- fix exampleTypescript to have noGlobals
- change the exampleTypescript tsconfig.json to include @types
- alias promise as wdpromise everywhere
- refactor gulpfile task 'types' to use multiple files from tsc
- add browser method types applied from webdriver

this closes #3430, closes #3477, and closes #3500