### PR TITLE
fix(logger): Set the log level based on the config at startup

### DIFF
--- a/lib/launcher.ts
+++ b/lib/launcher.ts
@@ -106,7 +106,7 @@ let initFn = function(configFile: string, additionalConfig: Config) {
     configParser.addConfig(additionalConfig);
   }
   let config = configParser.getConfig();
-
+  Logger.set(config);
   logger.debug('Running with --troubleshoot');
   logger.debug('Protractor version: ' + require('../package.json').version);
   logger.debug('Your base url for tests is ' + config.baseUrl);

--- a/spec/mocha/lib_spec.js
+++ b/spec/mocha/lib_spec.js
@@ -39,7 +39,7 @@ describe('protractor library', function() {
     var finished = false;
 
     it('should wait for async operations to finish', function() {
-      browser.get('index.html').then(() => { finished = true });
+      browser.get('index.html').then(function() { finished = true; });
     });
 
     after('verify mocha waited', function() {


### PR DESCRIPTION
Fixes #3522. Also fix the mocha spec to stop yelling at us about ES6
arrow functions.