### PR TITLE
fix(typescript): do not export our global helper

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -50,7 +50,7 @@ gulp.task('checkVersion', function(done) {
 });
 
 gulp.task('built:copy', function(done) {
-  return gulp.src(['lib/**/*.js','lib/globals.d.ts','lib/index.d.ts'])
+  return gulp.src(['lib/**/*.js', 'lib/index.d.ts'])
       .pipe(gulp.dest('built/'));
   done();
 });

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,5 +1,4 @@
 /// <reference path="../typings/index.d.ts" />
-/// <reference path="./globals.d.ts" />
 export {ElementHelper, ProtractorBrowser} from './browser';
 export {Config} from './config';
 export {ElementArrayFinder, ElementFinder} from './element';


### PR DESCRIPTION
lib/global.d.ts contains fixes necessary for Protractor to compile.
But it should not be shared with users - this change removes that.
It was problematic previously because it could conflict with
users' type definitions for global and others.