### PR TITLE
chore(ptor): properly export typings on ptor

### DIFF
--- a/lib/ptor.ts
+++ b/lib/ptor.ts
@@ -1,3 +1,8 @@
+import {ActionSequence, Browser, Builder, Button, Capabilities, Capability, Command, CommandName, error, EventEmitter, FileDetector, Key, logging, promise, Session, until, WebDriver, WebElement, WebElementPromise} from 'selenium-webdriver';
+import * as chrome from 'selenium-webdriver/firefox';
+import * as http from 'selenium-webdriver/http';
+import * as remote from 'selenium-webdriver/remote';
+
 import {ElementHelper, ProtractorBrowser} from './browser';
 import {ElementArrayFinder, ElementFinder} from './element';
 import {ProtractorExpectedConditions} from './expectedConditions';

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@types/jasmine": "^2.2.31",
     "@types/node": "^6.0.35",
     "@types/q": "^0.0.30",
-    "@types/selenium-webdriver": "~2.53.30",
+    "@types/selenium-webdriver": "~2.53.31",
     "adm-zip": "0.4.7",
     "chalk": "^1.1.3",
     "glob": "^7.0.3",


### PR DESCRIPTION
This PR should fail until https://github.com/DefinitelyTyped/DefinitelyTyped/pull/11657 is merged and published to `@types`.