### PR TITLE
fix(conditions) Explicitly remove newlines from getText()

### DIFF
--- a/lib/expectedConditions.ts
+++ b/lib/expectedConditions.ts
@@ -214,7 +214,8 @@ export class ProtractorExpectedConditions {
       Function {
     var hasText = () => {
       return elementFinder.getText().then((actualText: string): boolean => {
-        return actualText.indexOf(text) > -1;
+        // MSEdge does not properly remove newlines, which causes false negatives
+        return actualText.replace(/\r?\n|\r/g, '').indexOf(text) > -1;
       });
     };
     return this.and(this.presenceOf(elementFinder), hasText);


### PR DESCRIPTION
MSEdge does not properly remove newlines, which causes false negatives when using `textToBePresentInElement()`