### PR TITLE
docs(webdriver): Add missing quotes in getAttribute doc.

### DIFF
--- a/lib/selenium-webdriver/webdriver.js
+++ b/lib/selenium-webdriver/webdriver.js
@@ -305,7 +305,7 @@ webdriver.WebDriver.prototype.takeScreenshot = function() {};
 
 /**
  * Used to switch WebDriver's focus to a frame or window (e.g. an alert, an
- * iframe, another window).  
+ * iframe, another window).
  *
  * See [WebDriver's TargetLocator Docs](http://seleniumhq.github.io/selenium/docs/api/javascript/module/selenium-webdriver/lib/webdriver_exports_TargetLocator.html)
  * for more information.
@@ -553,7 +553,7 @@ webdriver.WebElement.prototype.getCssValue = function(cssStyleProperty) {};
  *
  * @example
  * var foo = element(by.id('foo'));
- * expect(foo.getAttribute(class)).toEqual('bar');
+ * expect(foo.getAttribute('class')).toEqual('bar');
  *
  * @param {string} attributeName The name of the attribute to query.
  * @returns {!webdriver.promise.Promise.<?string>} A promise that will be


### PR DESCRIPTION
In getAttibute function documentation :

`expect(foo.getAttribute(class))...` was written.

This got me confused when getting a class attribute.

I just added quotes around the class word showing class as a string
and not a variable.

Close #3619