### PR TITLE
Refactor the debugger out of browser.ts

### DIFF
--- a/lib/browser.ts
+++ b/lib/browser.ts
@@ -995,7 +995,7 @@ export class ProtractorBrowser extends Webdriver {
    * process
    */
   pause(opt_debugPort?: number): webdriver.promise.Promise<any> {
-    if (!this.debugHelper.isAttached()) {
+    if (this.debugHelper.isAttached()) {
       logger.info(
           'Encountered browser.pause(), but debugger already attached.');
       return webdriver.promise.fulfilled(true);

--- a/lib/browser.ts
+++ b/lib/browser.ts
@@ -264,7 +264,7 @@ export class ProtractorBrowser extends Webdriver {
   ng12Hybrid: boolean;
 
   /**
-   * A helper manages debugging.
+   * A helper that manages debugging tests.
    */
   debugHelper: DebugHelper;
 
@@ -387,8 +387,7 @@ export class ProtractorBrowser extends Webdriver {
    * @param {string} description A description of the command for debugging.
    * @param {...*} var_args The arguments to pass to the script.
    * @returns {!webdriver.promise.Promise.<T>} A promise that will resolve to
-   * the
-   *    scripts return value.
+   * the scripts return value.
    * @template T
    */
   public executeScriptWithDescription(

--- a/lib/browser.ts
+++ b/lib/browser.ts
@@ -1,18 +1,14 @@
-// Util from NodeJs
 import * as net from 'net';
-import {ActionSequence, Capabilities, Command as WdCommand, FileDetector, Options, promise as wdpromise, Session, TargetLocator, TouchSequence, until, WebDriver, WebElement} from 'selenium-webdriver';
-
 import * as url from 'url';
-import * as util from 'util';
 
+import {ActionSequence, Capabilities, Command as WdCommand, FileDetector, Options, promise as wdpromise, Session, TargetLocator, TouchSequence, until, WebDriver, WebElement} from 'selenium-webdriver';
 import {build$, build$$, ElementArrayFinder, ElementFinder} from './element';
 import {IError} from './exitCodes';
 import {ProtractorExpectedConditions} from './expectedConditions';
 import {Locator, ProtractorBy} from './locators';
 import {Logger} from './logger';
 import {Plugins} from './plugins';
-import {Ptor} from './ptor';
-import * as helper from './util';
+import {Debugger} from './debugger';
 
 declare var global: any;
 declare var process: any;
@@ -1000,191 +996,7 @@ export class ProtractorBrowser extends Webdriver {
    */
   private initDebugger_(
       debuggerClientPath: string, onStartFn: Function, opt_debugPort?: number) {
-    // Patch in a function to help us visualize what's going on in the control
-    // flow.
-    webdriver.promise.ControlFlow.prototype.getControlFlowText = function() {
-      let controlFlowText = this.getSchedule(/* opt_includeStackTraces */ true);
-      // This filters the entire control flow text, not just the stack trace, so
-      // unless we maintain a good (i.e. non-generic) set of keywords in
-      // STACK_SUBSTRINGS_TO_FILTER, we run the risk of filtering out non stack
-      // trace. The alternative though, which is to reimplement
-      // webdriver.promise.ControlFlow.prototype.getSchedule() here is much
-      // hackier, and involves messing with the control flow's internals /
-      // private
-      // variables.
-      return helper.filterStackTrace(controlFlowText);
-    };
-
-    let vm_ = require('vm');
-    let flow = webdriver.promise.controlFlow();
-
-    interface Context {
-      require: any;
-      [key: string]: any;
-    }
-    let context: Context = {require: require};
-    global.list = (locator: Locator) => {
-      return (<Ptor>global.protractor)
-          .browser.findElements(locator)
-          .then((arr: webdriver.WebElement[]) => {
-            let found: string[] = [];
-            for (let i = 0; i < arr.length; ++i) {
-              arr[i].getText().then((text: string) => {
-                found.push(text);
-              });
-            }
-            return found;
-          });
-    };
-    for (let key in global) {
-      context[key] = global[key];
-    }
-    let sandbox = vm_.createContext(context);
-
-    let browserUnderDebug = this;
-    let debuggerReadyPromise = webdriver.promise.defer();
-    flow.execute(() => {
-      process['debugPort'] = opt_debugPort || process['debugPort'];
-      browserUnderDebug.validatePortAvailability_(process['debugPort'])
-          .then((firstTime: boolean) => {
-            onStartFn(firstTime);
-
-            let args = [process.pid, process['debugPort']];
-            if (browserUnderDebug.debuggerServerPort_) {
-              args.push(browserUnderDebug.debuggerServerPort_);
-            }
-            let nodedebug =
-                require('child_process').fork(debuggerClientPath, args);
-            process.on('exit', function() {
-              nodedebug.kill('SIGTERM');
-            });
-            nodedebug
-                .on('message',
-                    (m: string) => {
-                      if (m === 'ready') {
-                        debuggerReadyPromise.fulfill();
-                      }
-                    })
-                .on('exit', () => {
-                  logger.info('Debugger exiting');
-                  // Clear this so that we know it's ok to attach a debugger
-                  // again.
-                  this.dbgCodeExecutor_ = null;
-                });
-          });
-    });
-
-    let pausePromise = flow.execute(function() {
-      return debuggerReadyPromise.then(function() {
-        // Necessary for backward compatibility with node < 0.12.0
-        return browserUnderDebug.executeScript_('', 'empty debugger hook');
-      });
-    });
-
-    // Helper used only by debuggers at './debugger/modes/*.js' to insert code
-    // into the control flow.
-    // In order to achieve this, we maintain a promise at the top of the control
-    // flow, so that we can insert frames into it.
-    // To be able to simulate callback/asynchronous code, we poll this object
-    // for an result at every run of DeferredExecutor.execute.
-    this.dbgCodeExecutor_ = {
-      execPromise_: pausePromise,  // Promise pointing to current stage of flow.
-      execPromiseResult_: undefined,  // Return value of promise.
-      execPromiseError_: undefined,   // Error from promise.
-
-      // A dummy repl server to make use of its completion function.
-      replServer_: require('repl').start({
-        input: {
-          on: function() {},
-          resume: function() {}
-        },                               // dummy readable stream
-        output: {write: function() {}},  // dummy writable stream
-        useGlobal: true
-      }),
-
-      // Execute a function, which could yield a value or a promise,
-      // and allow its result to be accessed synchronously
-      execute_: function(execFn_: Function) {
-        this.execPromiseResult_ = this.execPromiseError_ = undefined;
-
-        this.execPromise_ = this.execPromise_.then(execFn_).then(
-            (result: Object) => {
-              this.execPromiseResult_ = result;
-            },
-            (err: Error) => {
-              this.execPromiseError_ = err;
-            });
-
-        // This dummy command is necessary so that the DeferredExecutor.execute
-        // break point can find something to stop at instead of moving on to the
-        // next real command.
-        this.execPromise_.then(() => {
-          return browserUnderDebug.executeScript_('', 'empty debugger hook');
-        });
-      },
-
-      // Execute a piece of code.
-      // Result is a string representation of the evaluation.
-      execute: function(code: Function) {
-        let execFn_ = () => {
-          // Run code through vm so that we can maintain a local scope which is
-          // isolated from the rest of the execution.
-          let res = vm_.runInContext(code, sandbox);
-          if (!webdriver.promise.isPromise(res)) {
-            res = webdriver.promise.fulfilled(res);
-          }
-
-          return res.then((res: any) => {
-            if (res === undefined) {
-              return undefined;
-            } else {
-              // The '' forces res to be expanded into a string instead of just
-              // '[Object]'. Then we remove the extra space caused by the ''
-              // using
-              // substring.
-              return util.format.apply(this, ['', res]).substring(1);
-            }
-          });
-        };
-        this.execute_(execFn_);
-      },
-
-      // Autocomplete for a line.
-      // Result is a JSON representation of the autocomplete response.
-      complete: function(line: string) {
-        let execFn_ = () => {
-          let deferred = webdriver.promise.defer();
-          this.replServer_.complete(line, (err: any, res: any) => {
-            if (err) {
-              deferred.reject(err);
-            } else {
-              deferred.fulfill(JSON.stringify(res));
-            }
-          });
-          return deferred;
-        };
-        this.execute_(execFn_);
-      },
-
-      // Code finished executing.
-      resultReady: function() {
-        return !this.execPromise_.isPending();
-      },
-
-      // Get asynchronous results synchronously.
-      // This will throw if result is not ready.
-      getResult: function() {
-        if (!this.resultReady()) {
-          throw new Error('Result not ready');
-        }
-        if (this.execPromiseError_) {
-          throw this.execPromiseError_;
-        }
-        return this.execPromiseResult_;
-      }
-    };
-
-    return pausePromise;
+    return Debugger.init(debuggerClientPath, onStartFn, opt_debugPort);
   }
 
   /**

--- a/lib/browser.ts
+++ b/lib/browser.ts
@@ -251,7 +251,7 @@ export class ProtractorBrowser extends Webdriver {
   /**
    * If specified, start a debugger server at specified port instead of repl
    * when running element explorer.
-   * @private {number}
+   * @public {number}
    */
   public debuggerServerPort: number;
 
@@ -923,25 +923,6 @@ export class ProtractorBrowser extends Webdriver {
   }
 
   /**
-   * Helper function to:
-   *  1) Set up helper functions for debugger clients to call on (e.g.
-   *     getControlFlowText, execute code, get autocompletion).
-   *  2) Enter process into debugger mode. (i.e. process._debugProcess).
-   *  3) Invoke the debugger client specified by debuggerClientPath.
-   *
-   * @param {string} debuggerClientPath Absolute path of debugger client to use
-   * @param {Function} onStartFn Function to call when the debugger starts. The
-   *     function takes a single parameter, which represents whether this is the
-   *     first time that the debugger is called.
-   * @param {number=} opt_debugPort Optional port to use for the debugging
-   * process
-   */
-  private initDebugger_(
-      debuggerClientPath: string, onStartFn: Function, opt_debugPort?: number) {
-    return this.debugHelper.init(debuggerClientPath, onStartFn, opt_debugPort);
-  }
-
-  /**
    * Beta (unstable) enterRepl function for entering the repl loop from
    * any point in the control flow. Use browser.enterRepl() in your test.
    * Does not require changes to the command line (no need to add 'debug').
@@ -973,7 +954,7 @@ export class ProtractorBrowser extends Webdriver {
       logger.info('  e.g., list(by.binding(\'\')) gets all bindings.');
       logger.info();
     };
-    this.initDebugger_(debuggerClientPath, onStartFn, opt_debugPort);
+    this.debugHelper.init(debuggerClientPath, onStartFn, opt_debugPort);
   }
 
   /**
@@ -1005,7 +986,7 @@ export class ProtractorBrowser extends Webdriver {
       logger.info('Encountered browser.pause(). Attaching debugger...');
       if (firstTime) {
         logger.info();
-        logger.info('------- WebDriver DebugHelper -------');
+        logger.info('------- WebDriver Debugger -------');
         logger.info(
             'Starting WebDriver debugger in a child process. Pause is ' +
             'still beta, please report issues at github.com/angular/protractor');
@@ -1017,7 +998,7 @@ export class ProtractorBrowser extends Webdriver {
         logger.info();
       }
     };
-    return this.initDebugger_(debuggerClientPath, onStartFn, opt_debugPort);
+    this.debugHelper.init(debuggerClientPath, onStartFn, opt_debugPort);
   }
 
   /**

--- a/lib/debugger.ts
+++ b/lib/debugger.ts
@@ -24,7 +24,7 @@ export class DebugHelper {
    */
   debuggerValidated_: boolean;
 
-  dbgCodeExecutor_: any;
+  dbgCodeExecutor: any;
 
   constructor(browser: ProtractorBrowser) {
     this.browser = browser;
@@ -98,7 +98,7 @@ export class DebugHelper {
                   logger.info('Debugger exiting');
                   // Clear this so that we know it's ok to attach a debugger
                   // again.
-                  this.dbgCodeExecutor_ = null;
+                  this.dbgCodeExecutor = null;
                 });
           });
     });
@@ -117,7 +117,7 @@ export class DebugHelper {
     // flow, so that we can insert frames into it.
     // To be able to simulate callback/asynchronous code, we poll this object
     // for a result at every run of DeferredExecutor.execute.
-    this.dbgCodeExecutor_ = {
+    this.dbgCodeExecutor = {
       execPromise_: pausePromise,  // Promise pointing to current stage of flow.
       execPromiseResult_: undefined,  // Return value of promise.
       execPromiseError_: undefined,   // Error from promise.
@@ -268,6 +268,6 @@ export class DebugHelper {
   }
 
   public isAttached(): boolean {
-    return !!this.dbgCodeExecutor_;
+    return !!this.dbgCodeExecutor;
   }
 }

--- a/lib/debugger.ts
+++ b/lib/debugger.ts
@@ -1,0 +1,202 @@
+// Util from NodeJs
+import * as util from 'util'
+
+import {ProtractorBrowser} from './browser';
+import {Logger} from './logger';
+import {Locator} from './locators';
+import * as helper from './util';
+
+let logger = new Logger('protractor');
+
+export class Debugger {
+  static init(browser: ProtractorBrowser, debuggerClientPath: string, onStartFn: Function, opt_debugPort?: number) {
+  webdriver.promise.ControlFlow.prototype.getControlFlowText = function () {
+    let controlFlowText = this.getSchedule(/* opt_includeStackTraces */ true);
+    // This filters the entire control flow text, not just the stack trace, so
+    // unless we maintain a good (i.e. non-generic) set of keywords in
+    // STACK_SUBSTRINGS_TO_FILTER, we run the risk of filtering out non stack
+    // trace. The alternative though, which is to reimplement
+    // webdriver.promise.ControlFlow.prototype.getSchedule() here is much
+    // hackier, and involves messing with the control flow's internals /
+    // private
+    // variables.
+    return helper.filterStackTrace(controlFlowText);
+  };
+
+  let vm_ = require('vm');
+  let flow = webdriver.promise.controlFlow();
+
+  interface Context {
+    require: any;
+    [key: string]: any;
+  }
+  let context: Context = {require: require};
+  global.list = (locator: Locator) => {
+    return (<Ptor>global.protractor)
+        .browser.findElements(locator)
+        .then((arr: webdriver.WebElement[]) => {
+          let found: string[] = [];
+          for (let i = 0; i < arr.length; ++i) {
+            arr[i].getText().then((text: string) => {
+              found.push(text);
+            });
+          }
+          return found;
+        });
+  };
+  for (let key in global) {
+    context[key] = global[key];
+  }
+  let sandbox = vm_.createContext(context);
+
+  let browserUnderDebug = browser;
+  let debuggerReadyPromise = webdriver.promise.defer();
+  flow.execute(() => {
+    process['debugPort'] = opt_debugPort || process['debugPort'];
+    browserUnderDebug.validatePortAvailability_(process['debugPort'])
+        .then((firstTime: boolean) => {
+          onStartFn(firstTime);
+
+          let args = [process.pid, process['debugPort']];
+          if (browserUnderDebug.debuggerServerPort_) {
+            args.push(browserUnderDebug.debuggerServerPort_);
+          }
+          let nodedebug =
+              require('child_process').fork(debuggerClientPath, args);
+          process.on('exit', function () {
+            nodedebug.kill('SIGTERM');
+          });
+          nodedebug
+              .on('message',
+                  (m: string) => {
+                    if (m === 'ready') {
+                      debuggerReadyPromise.fulfill();
+                    }
+                  })
+              .on('exit', () => {
+                logger.info('Debugger exiting');
+                // Clear this so that we know it's ok to attach a debugger
+                // again.
+                this.dbgCodeExecutor_ = null;
+              });
+        });
+  });
+
+  let pausePromise = flow.execute(function () {
+    return debuggerReadyPromise.then(function () {
+      // Necessary for backward compatibility with node < 0.12.0
+      return browserUnderDebug.executeScript_('', 'empty debugger hook');
+    });
+  });
+
+  // Helper used only by debuggers at './debugger/modes/*.js' to insert code
+  // into the control flow.
+  // In order to achieve this, we maintain a promise at the top of the control
+  // flow, so that we can insert frames into it.
+  // To be able to simulate callback/asynchronous code, we poll this object
+  // for an result at every run of DeferredExecutor.execute.
+  this.dbgCodeExecutor_ = {
+    execPromise_: pausePromise,  // Promise pointing to current stage of flow.
+    execPromiseResult_: undefined,  // Return value of promise.
+    execPromiseError_: undefined,   // Error from promise.
+
+    // A dummy repl server to make use of its completion function.
+    replServer_: require('repl').start({
+      input: {
+        on: function () {
+        },
+        resume: function () {
+        }
+      },                               // dummy readable stream
+      output: {
+        write: function () {
+        }
+      },  // dummy writable stream
+      useGlobal: true
+    }),
+
+    // Execute a function, which could yield a value or a promise,
+    // and allow its result to be accessed synchronously
+    execute_: function (execFn_: Function) {
+      this.execPromiseResult_ = this.execPromiseError_ = undefined;
+
+      this.execPromise_ = this.execPromise_.then(execFn_).then(
+          (result: Object) => {
+            this.execPromiseResult_ = result;
+          },
+          (err: Error) => {
+            this.execPromiseError_ = err;
+          });
+
+      // This dummy command is necessary so that the DeferredExecutor.execute
+      // break point can find something to stop at instead of moving on to the
+      // next real command.
+      this.execPromise_.then(() => {
+        return browserUnderDebug.executeScript_('', 'empty debugger hook');
+      });
+    },
+
+    // Execute a piece of code.
+    // Result is a string representation of the evaluation.
+    execute: function (code: Function) {
+      let execFn_ = () => {
+        // Run code through vm so that we can maintain a local scope which is
+        // isolated from the rest of the execution.
+        let res = vm_.runInContext(code, sandbox);
+        if (!webdriver.promise.isPromise(res)) {
+          res = webdriver.promise.fulfilled(res);
+        }
+
+        return res.then((res: any) => {
+          if (res === undefined) {
+            return undefined;
+          } else {
+            // The '' forces res to be expanded into a string instead of just
+            // '[Object]'. Then we remove the extra space caused by the ''
+            // using
+            // substring.
+            return util.format.apply(this, ['', res]).substring(1);
+          }
+        });
+      };
+      this.execute_(execFn_);
+    },
+
+    // Autocomplete for a line.
+    // Result is a JSON representation of the autocomplete response.
+    complete: function (line: string) {
+      let execFn_ = () => {
+        let deferred = webdriver.promise.defer();
+        this.replServer_.complete(line, (err: any, res: any) => {
+          if (err) {
+            deferred.reject(err);
+          } else {
+            deferred.fulfill(JSON.stringify(res));
+          }
+        });
+        return deferred;
+      };
+      this.execute_(execFn_);
+    },
+
+    // Code finished executing.
+    resultReady: function () {
+      return !this.execPromise_.isPending();
+    },
+
+    // Get asynchronous results synchronously.
+    // This will throw if result is not ready.
+    getResult: function () {
+      if (!this.resultReady()) {
+        throw new Error('Result not ready');
+      }
+      if (this.execPromiseError_) {
+        throw this.execPromiseError_;
+      }
+      return this.execPromiseResult_;
+    }
+  };
+
+  return pausePromise;
+}
+

--- a/lib/debugger.ts
+++ b/lib/debugger.ts
@@ -1,202 +1,273 @@
 // Util from NodeJs
+import * as net from 'net';
 import * as util from 'util'
 
 import {ProtractorBrowser} from './browser';
-import {Logger} from './logger';
 import {Locator} from './locators';
+import {Logger} from './logger';
+import {Ptor} from './ptor';
 import * as helper from './util';
 
+declare var global: any;
+declare var process: any;
+
 let logger = new Logger('protractor');
+let webdriver = require('selenium-webdriver');
 
-export class Debugger {
-  static init(browser: ProtractorBrowser, debuggerClientPath: string, onStartFn: Function, opt_debugPort?: number) {
-  webdriver.promise.ControlFlow.prototype.getControlFlowText = function () {
-    let controlFlowText = this.getSchedule(/* opt_includeStackTraces */ true);
-    // This filters the entire control flow text, not just the stack trace, so
-    // unless we maintain a good (i.e. non-generic) set of keywords in
-    // STACK_SUBSTRINGS_TO_FILTER, we run the risk of filtering out non stack
-    // trace. The alternative though, which is to reimplement
-    // webdriver.promise.ControlFlow.prototype.getSchedule() here is much
-    // hackier, and involves messing with the control flow's internals /
-    // private
-    // variables.
-    return helper.filterStackTrace(controlFlowText);
-  };
+export class DebugHelper {
+  browser: ProtractorBrowser;
 
-  let vm_ = require('vm');
-  let flow = webdriver.promise.controlFlow();
+  /**
+   * Set to true when we validate that the debug port is open. Since the debug
+   * port is held open forever once the debugger is attached, it's important
+   * we only do validation once.
+   */
+  debuggerValidated_: boolean;
 
-  interface Context {
-    require: any;
-    [key: string]: any;
+  dbgCodeExecutor_: any;
+
+  constructor(browser: ProtractorBrowser) {
+    this.browser = browser;
   }
-  let context: Context = {require: require};
-  global.list = (locator: Locator) => {
-    return (<Ptor>global.protractor)
-        .browser.findElements(locator)
-        .then((arr: webdriver.WebElement[]) => {
-          let found: string[] = [];
-          for (let i = 0; i < arr.length; ++i) {
-            arr[i].getText().then((text: string) => {
-              found.push(text);
-            });
-          }
-          return found;
-        });
-  };
-  for (let key in global) {
-    context[key] = global[key];
-  }
-  let sandbox = vm_.createContext(context);
 
-  let browserUnderDebug = browser;
-  let debuggerReadyPromise = webdriver.promise.defer();
-  flow.execute(() => {
-    process['debugPort'] = opt_debugPort || process['debugPort'];
-    browserUnderDebug.validatePortAvailability_(process['debugPort'])
-        .then((firstTime: boolean) => {
-          onStartFn(firstTime);
+  init(
+      debuggerClientPath: string, onStartFn: Function, opt_debugPort?: number) {
+    webdriver.promise.ControlFlow.prototype.getControlFlowText = function() {
+      let controlFlowText = this.getSchedule(/* opt_includeStackTraces */ true);
+      // This filters the entire control flow text, not just the stack trace, so
+      // unless we maintain a good (i.e. non-generic) set of keywords in
+      // STACK_SUBSTRINGS_TO_FILTER, we run the risk of filtering out non stack
+      // trace. The alternative though, which is to reimplement
+      // webdriver.promise.ControlFlow.prototype.getSchedule() here is much
+      // hackier, and involves messing with the control flow's internals /
+      // private variables.
+      return helper.filterStackTrace(controlFlowText);
+    };
 
-          let args = [process.pid, process['debugPort']];
-          if (browserUnderDebug.debuggerServerPort_) {
-            args.push(browserUnderDebug.debuggerServerPort_);
-          }
-          let nodedebug =
-              require('child_process').fork(debuggerClientPath, args);
-          process.on('exit', function () {
-            nodedebug.kill('SIGTERM');
-          });
-          nodedebug
-              .on('message',
-                  (m: string) => {
-                    if (m === 'ready') {
-                      debuggerReadyPromise.fulfill();
-                    }
-                  })
-              .on('exit', () => {
-                logger.info('Debugger exiting');
-                // Clear this so that we know it's ok to attach a debugger
-                // again.
-                this.dbgCodeExecutor_ = null;
-              });
-        });
-  });
+    let vm_ = require('vm');
+    let flow = webdriver.promise.controlFlow();
 
-  let pausePromise = flow.execute(function () {
-    return debuggerReadyPromise.then(function () {
-      // Necessary for backward compatibility with node < 0.12.0
-      return browserUnderDebug.executeScript_('', 'empty debugger hook');
-    });
-  });
-
-  // Helper used only by debuggers at './debugger/modes/*.js' to insert code
-  // into the control flow.
-  // In order to achieve this, we maintain a promise at the top of the control
-  // flow, so that we can insert frames into it.
-  // To be able to simulate callback/asynchronous code, we poll this object
-  // for an result at every run of DeferredExecutor.execute.
-  this.dbgCodeExecutor_ = {
-    execPromise_: pausePromise,  // Promise pointing to current stage of flow.
-    execPromiseResult_: undefined,  // Return value of promise.
-    execPromiseError_: undefined,   // Error from promise.
-
-    // A dummy repl server to make use of its completion function.
-    replServer_: require('repl').start({
-      input: {
-        on: function () {
-        },
-        resume: function () {
-        }
-      },                               // dummy readable stream
-      output: {
-        write: function () {
-        }
-      },  // dummy writable stream
-      useGlobal: true
-    }),
-
-    // Execute a function, which could yield a value or a promise,
-    // and allow its result to be accessed synchronously
-    execute_: function (execFn_: Function) {
-      this.execPromiseResult_ = this.execPromiseError_ = undefined;
-
-      this.execPromise_ = this.execPromise_.then(execFn_).then(
-          (result: Object) => {
-            this.execPromiseResult_ = result;
-          },
-          (err: Error) => {
-            this.execPromiseError_ = err;
-          });
-
-      // This dummy command is necessary so that the DeferredExecutor.execute
-      // break point can find something to stop at instead of moving on to the
-      // next real command.
-      this.execPromise_.then(() => {
-        return browserUnderDebug.executeScript_('', 'empty debugger hook');
-      });
-    },
-
-    // Execute a piece of code.
-    // Result is a string representation of the evaluation.
-    execute: function (code: Function) {
-      let execFn_ = () => {
-        // Run code through vm so that we can maintain a local scope which is
-        // isolated from the rest of the execution.
-        let res = vm_.runInContext(code, sandbox);
-        if (!webdriver.promise.isPromise(res)) {
-          res = webdriver.promise.fulfilled(res);
-        }
-
-        return res.then((res: any) => {
-          if (res === undefined) {
-            return undefined;
-          } else {
-            // The '' forces res to be expanded into a string instead of just
-            // '[Object]'. Then we remove the extra space caused by the ''
-            // using
-            // substring.
-            return util.format.apply(this, ['', res]).substring(1);
-          }
-        });
-      };
-      this.execute_(execFn_);
-    },
-
-    // Autocomplete for a line.
-    // Result is a JSON representation of the autocomplete response.
-    complete: function (line: string) {
-      let execFn_ = () => {
-        let deferred = webdriver.promise.defer();
-        this.replServer_.complete(line, (err: any, res: any) => {
-          if (err) {
-            deferred.reject(err);
-          } else {
-            deferred.fulfill(JSON.stringify(res));
-          }
-        });
-        return deferred;
-      };
-      this.execute_(execFn_);
-    },
-
-    // Code finished executing.
-    resultReady: function () {
-      return !this.execPromise_.isPending();
-    },
-
-    // Get asynchronous results synchronously.
-    // This will throw if result is not ready.
-    getResult: function () {
-      if (!this.resultReady()) {
-        throw new Error('Result not ready');
-      }
-      if (this.execPromiseError_) {
-        throw this.execPromiseError_;
-      }
-      return this.execPromiseResult_;
+    interface Context {
+      require: any;
+      [key: string]: any;
     }
-  };
+    let context: Context = {require: require};
+    global.list = (locator: Locator) => {
+      return (<Ptor>global.protractor)
+          .browser.findElements(locator)
+          .then((arr: webdriver.WebElement[]) => {
+            let found: string[] = [];
+            for (let i = 0; i < arr.length; ++i) {
+              arr[i].getText().then((text: string) => {
+                found.push(text);
+              });
+            }
+            return found;
+          });
+    };
+    for (let key in global) {
+      context[key] = global[key];
+    }
+    let sandbox = vm_.createContext(context);
 
-  return pausePromise;
+    let browserUnderDebug = this.browser;
+    let debuggerReadyPromise = webdriver.promise.defer();
+    flow.execute(() => {
+      process['debugPort'] = opt_debugPort || process['debugPort'];
+      this.validatePortAvailability_(process['debugPort'])
+          .then((firstTime: boolean) => {
+            onStartFn(firstTime);
+
+            let args = [process.pid, process['debugPort']];
+            if (browserUnderDebug.debuggerServerPort) {
+              args.push(browserUnderDebug.debuggerServerPort);
+            }
+            let nodedebug =
+                require('child_process').fork(debuggerClientPath, args);
+            process.on('exit', function() {
+              nodedebug.kill('SIGTERM');
+            });
+            nodedebug
+                .on('message',
+                    (m: string) => {
+                      if (m === 'ready') {
+                        debuggerReadyPromise.fulfill();
+                      }
+                    })
+                .on('exit', () => {
+                  logger.info('Debugger exiting');
+                  // Clear this so that we know it's ok to attach a debugger
+                  // again.
+                  this.dbgCodeExecutor_ = null;
+                });
+          });
+    });
+
+    let pausePromise = flow.execute(function() {
+      return debuggerReadyPromise.then(function() {
+        // Necessary for backward compatibility with node < 0.12.0
+        return browserUnderDebug.executeScriptWithDescription(
+            '', 'empty debugger hook');
+      });
+    });
+
+    // Helper used only by debuggers at './debugger/modes/*.js' to insert code
+    // into the control flow.
+    // In order to achieve this, we maintain a promise at the top of the control
+    // flow, so that we can insert frames into it.
+    // To be able to simulate callback/asynchronous code, we poll this object
+    // for a result at every run of DeferredExecutor.execute.
+    this.dbgCodeExecutor_ = {
+      execPromise_: pausePromise,  // Promise pointing to current stage of flow.
+      execPromiseResult_: undefined,  // Return value of promise.
+      execPromiseError_: undefined,   // Error from promise.
+
+      // A dummy repl server to make use of its completion function.
+      replServer_: require('repl').start({
+        input: {on: function() {}, resume: function() {}},
+        // dummy readable stream
+        output: {write: function() {}},  // dummy writable stream
+        useGlobal: true
+      }),
+
+      // Execute a function, which could yield a value or a promise,
+      // and allow its result to be accessed synchronously
+      execute_: function(execFn_: Function) {
+        this.execPromiseResult_ = this.execPromiseError_ = undefined;
+
+        this.execPromise_ = this.execPromise_.then(execFn_).then(
+            (result: Object) => {
+              this.execPromiseResult_ = result;
+            },
+            (err: Error) => {
+              this.execPromiseError_ = err;
+            });
+
+        // This dummy command is necessary so that the DeferredExecutor.execute
+        // break point can find something to stop at instead of moving on to the
+        // next real command.
+        this.execPromise_.then(() => {
+          return browserUnderDebug.executeScriptWithDescription(
+              '', 'empty debugger hook');
+        });
+      },
+
+      // Execute a piece of code.
+      // Result is a string representation of the evaluation.
+      execute: function(code: Function) {
+        let execFn_ = () => {
+          // Run code through vm so that we can maintain a local scope which is
+          // isolated from the rest of the execution.
+          let res = vm_.runInContext(code, sandbox);
+          if (!webdriver.promise.isPromise(res)) {
+            res = webdriver.promise.fulfilled(res);
+          }
+
+          return res.then((res: any) => {
+            if (res === undefined) {
+              return undefined;
+            } else {
+              // The '' forces res to be expanded into a string instead of just
+              // '[Object]'. Then we remove the extra space caused by the ''
+              // using
+              // substring.
+              return util.format.apply(this, ['', res]).substring(1);
+            }
+          });
+        };
+        this.execute_(execFn_);
+      },
+
+      // Autocomplete for a line.
+      // Result is a JSON representation of the autocomplete response.
+      complete: function(line: string) {
+        let execFn_ = () => {
+          let deferred = webdriver.promise.defer();
+          this.replServer_.complete(line, (err: any, res: any) => {
+            if (err) {
+              deferred.reject(err);
+            } else {
+              deferred.fulfill(JSON.stringify(res));
+            }
+          });
+          return deferred;
+        };
+        this.execute_(execFn_);
+      },
+
+      // Code finished executing.
+      resultReady: function() {
+        return !this.execPromise_.isPending();
+      },
+
+      // Get asynchronous results synchronously.
+      // This will throw if result is not ready.
+      getResult: function() {
+        if (!this.resultReady()) {
+          throw new Error('Result not ready');
+        }
+        if (this.execPromiseError_) {
+          throw this.execPromiseError_;
+        }
+        return this.execPromiseResult_;
+      }
+    };
+
+    return pausePromise;
+  }
+
+  /**
+   * Validates that the port is free to use. This will only validate the first
+   * time it is called. The reason is that on subsequent calls, the port will
+   * already be bound to the debugger, so it will not be available, but that is
+   * okay.
+   *
+   * @returns {Promise<boolean>} A promise that becomes ready when the
+   * validation
+   *     is done. The promise will resolve to a boolean which represents whether
+   *     this is the first time that the debugger is called.
+   */
+  private validatePortAvailability_(port: number):
+      webdriver.promise.Promise<any> {
+    if (this.debuggerValidated_) {
+      return webdriver.promise.fulfilled(false);
+    }
+
+    let doneDeferred = webdriver.promise.defer();
+
+    // Resolve doneDeferred if port is available.
+    let tester = net.connect({port: port}, () => {
+      doneDeferred.reject(
+          'Port ' + port + ' is already in use. Please specify ' +
+          'another port to debug.');
+    });
+    tester.once('error', (err: NodeJS.ErrnoException) => {
+      if (err.code === 'ECONNREFUSED') {
+        tester
+            .once(
+                'close',
+                () => {
+                  doneDeferred.fulfill(true);
+                })
+            .end();
+      } else {
+        doneDeferred.reject(
+            'Unexpected failure testing for port ' + port + ': ' +
+            JSON.stringify(err));
+      }
+    });
+
+    return doneDeferred.then(
+        () => {
+          this.debuggerValidated_ = true;
+        },
+        (err: string) => {
+          console.error(err);
+          process.exit(1);
+        });
+  }
+
+  public isAttached(): boolean {
+    return !!this.dbgCodeExecutor_;
+  }
 }
-

--- a/lib/debugger/modes/commandRepl.js
+++ b/lib/debugger/modes/commandRepl.js
@@ -30,7 +30,7 @@ var CommandRepl = function(client) {
 CommandRepl.prototype.stepEval = function(expression, callback) {
   expression = expression.replace(/"/g, '\\\"');
 
-  var expr = 'browser.dbgCodeExecutor_.execute("' + expression + '")';
+  var expr = 'browser.debugHelper.dbgCodeExecutor.execute("' + expression + '")';
   this.evaluate_(expr, callback);
 };
 
@@ -47,7 +47,7 @@ CommandRepl.prototype.complete = function(line, callback) {
     callback(null, [REPL_INITIAL_SUGGESTIONS, '']);
   } else {
     line = line.replace(/"/g, '\\\"');
-    var expr = 'browser.dbgCodeExecutor_.complete("' + line + '")';
+    var expr = 'browser.debugHelper.dbgCodeExecutor.complete("' + line + '")';
     this.evaluate_(expr, function(err, res) {
       // Result is a JSON representation of the autocomplete response. 
       var result = res === undefined ? undefined : JSON.parse(res);
@@ -73,7 +73,7 @@ CommandRepl.prototype.evaluate_ = function(expression, callback) {
       arguments: {
         frame: 0,
         maxStringLength: 1000,
-        expression: 'browser.dbgCodeExecutor_.resultReady()'
+        expression: 'browser.debugHelper.dbgCodeExecutor.resultReady()'
       }
     }, function(err, res) {
       // If code finished executing, get result.
@@ -83,7 +83,7 @@ CommandRepl.prototype.evaluate_ = function(expression, callback) {
           arguments: {
             frame: 0,
             maxStringLength: -1,
-            expression: 'browser.dbgCodeExecutor_.getResult()'
+            expression: 'browser.debugHelper.dbgCodeExecutor.getResult()'
           }
         }, function(err, res) {
           try {

--- a/lib/frameworks/explorer.js
+++ b/lib/frameworks/explorer.js
@@ -14,7 +14,7 @@ exports.run = function(runner) {
       browser.get(runner.getConfig().baseUrl);
     }
     browser.enterRepl();
-    browser.executeScript_('', 'empty debugger hook').then(function() {
+    browser.executeScriptWithDescription('', 'empty debugger hook').then(function() {
       resolve({
         failedCount: 0
       });

--- a/lib/runner.ts
+++ b/lib/runner.ts
@@ -226,7 +226,7 @@ export class Runner extends EventEmitter {
       browser_.allScriptsTimeout = config.allScriptsTimeout;
     }
     if (config.debuggerServerPort) {
-      browser_.debuggerServerPort_ = config.debuggerServerPort;
+      browser_.debuggerServerPort = config.debuggerServerPort;
     }
     if (config.useAllAngular2AppRoots) {
       browser_.useAllAngular2AppRoots();


### PR DESCRIPTION
This pulls the debugger out of browser.ts and into a separate module. This is the first step in porting the debugger to typescript and adding unit testing around it.