### PR TITLE
fix(config): Add jasmine option to clear reporters

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -516,6 +516,10 @@ export interface Config {
        * Inverts 'grep' matches
        */
       invertGrep?: boolean;
+      /**
+       * Clears default reporters
+       */
+      clearReporters?: boolean;
     };
 
     /**

--- a/lib/frameworks/jasmine.js
+++ b/lib/frameworks/jasmine.js
@@ -67,6 +67,13 @@ exports.run = function(runner, specs) {
 
   var jasmineNodeOpts = runner.getConfig().jasmineNodeOpts;
 
+  // Clear existing reporters if specified.  This prevents things like
+  // the default dot reporter from getting in the way of user specified
+  // reporters
+  if (jasmineNodeOpts && jasmineNodeOpts.clearReporters) {
+    jasmine.getEnv().clearReporters();
+  }
+
   // On timeout, the flow should be reset. This will prevent webdriver tasks
   // from overflowing into the next test and causing it to fail or timeout
   // as well. This is done in the reporter instead of an afterEach block


### PR DESCRIPTION
This adds an option in jasmineNodeOpts to clear all reporters
before protractor registers it's own lifecycle reporter.

This addresses an issue where the default jasmine
reporter conflicts with user registered reporters
#3609
