### PR TITLE
fix(types): fix types for element.all(...)

### DIFF
--- a/lib/browser.ts
+++ b/lib/browser.ts
@@ -97,7 +97,7 @@ function ptorMixin(to: any, from: any, fnName: string, setupFn?: Function) {
 
 export interface ElementHelper extends Function {
   (locator: Locator): ElementFinder;
-  all?: (locator: Locator) => ElementArrayFinder;
+  all: (locator: Locator) => ElementArrayFinder;
 }
 
 /**
@@ -108,9 +108,9 @@ export interface ElementHelper extends Function {
  * @returns {function(webdriver.Locator): ElementFinder}
  */
 function buildElementHelper(browser: ProtractorBrowser): ElementHelper {
-  let element: ElementHelper = (locator: Locator) => {
+  let element = ((locator: Locator) => {
     return new ElementArrayFinder(browser).all(locator).toElementFinder_();
-  };
+  }) as ElementHelper;
 
   element.all =
       (locator: Locator) => {


### PR DESCRIPTION
Currently. `all` is marked as optional. It means `all` can be `undefined`, which isn't true. For this reason, it's impossible now to use `element.all` with TS 2.x if `strictNullChecks` is `true`. Simple code like
```
element.all(by.css('.info'))
```
leads to an error: `Object is possibly 'undefined'`.