### PR TITLE
chore(clang-format): increase ColumnLimit to 100

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,3 +1,3 @@
 Language:        JavaScript
 BasedOnStyle:    Google
-ColumnLimit:     80
+ColumnLimit:     100


### PR DESCRIPTION
Does anybody use an 80x25 hardware text-mode terminal to edit this code? Why is this value so low? It doesn't help the readability at all.

The Angular 2 project has [has](https://github.com/angular/angular/blob/master/.clang-format) `ColumnLimit: 100`.