### PR TITLE
chore(types): make plugins.ts more strongly-typed

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,3 +1,5 @@
+import {PluginConfig} from './plugins';
+
 export interface Config {
   // ---------------------------------------------------------------------------
   // ----- How to connect to Browser Drivers -----------------------------------
@@ -563,7 +565,7 @@ export interface Config {
   /**
    * See docs/plugins.md
    */
-  plugins?: Array<any>;
+  plugins?: PluginConfig[];
 
   /**
    * Turns off source map support.  Stops protractor from registering global

--- a/lib/element.ts
+++ b/lib/element.ts
@@ -3,7 +3,7 @@ import {By, error, ILocation, ISize, promise as wdpromise, WebDriver, WebElement
 import {ElementHelper} from './browser';
 import {ProtractorBrowser} from './browser';
 import {IError} from './exitCodes';
-import {Locator, ProtractorBy} from './locators';
+import {Locator} from './locators';
 import {Logger} from './logger';
 
 let webdriver = require('selenium-webdriver');
@@ -1061,7 +1061,7 @@ export class ElementFinder extends WebdriverWebElement {
  * @returns {ElementFinder} which identifies the located
  *     {@link webdriver.WebElement}
  */
-export let build$ = (element: ElementHelper, by: ProtractorBy) => {
+export let build$ = (element: ElementHelper, by: typeof By) => {
   return (selector: string) => {
     return element(by.css(selector));
   };
@@ -1092,7 +1092,7 @@ export let build$ = (element: ElementHelper, by: ProtractorBy) => {
  * @returns {ElementArrayFinder} which identifies the
  *     array of the located {@link webdriver.WebElement}s.
  */
-export let build$$ = (element: ElementHelper, by: ProtractorBy) => {
+export let build$$ = (element: ElementHelper, by: typeof By) => {
   return (selector: string) => {
     return element.all(by.css(selector));
   };


### PR DESCRIPTION
Some code reformatting happened here because of changing `ColumnLimit` in `.clang-format`. I can extract it to a separate PR if needed. The main idea of this PR is to use the type definitions for the `selenium-webdriver` module and make the compiler infer better types for the members of the `Plugins` class.
