### PR TITLE
use phantomjs-prebuilt

### DIFF
--- a/docs/browser-setup.md
+++ b/docs/browser-setup.md
@@ -131,7 +131,7 @@ capabilities: {
    * Can be used to specify the phantomjs binary path.
    * This can generally be ommitted if you installed phantomjs globally.
    */
-  'phantomjs.binary.path': require('phantomjs').path,
+  'phantomjs.binary.path': require('phantomjs-prebuilt').path,
   
   /*
    * Command line args to pass to ghostdriver, phantomjs's browser driver.


### PR DESCRIPTION
`require('phantomjs')` is not working

![default](https://cloud.githubusercontent.com/assets/13535256/20037542/593fa4f2-a45c-11e6-82c5-ccf9a6525324.PNG)
