### PR TITLE
fix(globals): Resolve exported globals dynamically.

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -526,7 +526,7 @@ export interface Config {
     /**
      * Set the randomization seed if randomization is turned on
      */
-     seed?: string,
+    seed?: string,
   };
 
   /**

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -23,7 +23,7 @@ export let utils = {
   firefox: require('selenium-webdriver/firefox'),
   http: require('selenium-webdriver/http'),
   remote: require('selenium-webdriver/remote')
-}
+};
 
 export let Command = require('selenium-webdriver/lib/command').Command;
 export let CommandName = require('selenium-webdriver/lib/command').Name;
@@ -32,12 +32,31 @@ export let CommandName = require('selenium-webdriver/lib/command').Name;
 // We base this on NodeJS `global` because we do not want to mask
 // with a different instance of Protractor if the module is
 // installed both globally and locally.
-export let protractor: Ptor = (global as any)['protractor'];
-export let browser: ProtractorBrowser = protractor ? protractor.browser : undefined;
-export let $: (search: string) => ElementFinder = protractor ? protractor.$ : undefined;
-export let $$: (search: string) => ElementArrayFinder = protractor ? protractor.$$ : undefined;
-export let element: ElementHelper = protractor ? protractor.element : undefined;
-export let By: ProtractorBy = protractor ? protractor.By : undefined;
-export let by: ProtractorBy = protractor ? protractor.by : undefined;
-export let ExpectedConditions: ProtractorExpectedConditions =
-    protractor ? protractor.ExpectedConditions : undefined;
+
+// Because these properties are set dynamically by the runner in setupGlobals_, they are not
+// guaranteed to be created at import time. Also, the browser object can change if browser.reset()
+// is called. Thus, we export these as properties so they will be resolved dynamically.
+export declare let protractor: Ptor;
+Object.defineProperty(exports, 'protractor', {get: () => (global as any)['protractor']});
+
+export declare let browser: ProtractorBrowser;
+Object.defineProperty(exports, 'browser', {get: () => exports.protractor.browser});
+
+export declare let $: (search: string) => ElementFinder;
+Object.defineProperty(exports, '$', {get: () => exports.protractor.$});
+
+export declare let $$: (search: string) => ElementArrayFinder;
+Object.defineProperty(exports, '$$', {get: () => exports.protractor.$$});
+
+export declare let element: ElementHelper;
+Object.defineProperty(exports, 'element', {get: () => exports.protractor.element});
+
+export declare let By: ProtractorBy;
+Object.defineProperty(exports, 'By', {get: () => exports.protractor.By});
+
+export declare let by: ProtractorBy;
+Object.defineProperty(exports, 'by', {get: () => exports.protractor.by});
+
+export declare let ExpectedConditions: ProtractorExpectedConditions;
+Object.defineProperty(
+    exports, 'ExpectedConditions', {get: () => exports.protractor.ExpectedConditions});

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -39,24 +39,24 @@ export let CommandName = require('selenium-webdriver/lib/command').Name;
 export declare let protractor: Ptor;
 Object.defineProperty(exports, 'protractor', {get: () => (global as any)['protractor']});
 
+function registerGlobal(name: string) {
+  Object.defineProperty(exports, name, {
+    get: () => exports.protractor ? exports.protractor[name] : undefined
+  });
+}
+
 export declare let browser: ProtractorBrowser;
-Object.defineProperty(exports, 'browser', {get: () => exports.protractor.browser});
-
 export declare let $: (search: string) => ElementFinder;
-Object.defineProperty(exports, '$', {get: () => exports.protractor.$});
-
 export declare let $$: (search: string) => ElementArrayFinder;
-Object.defineProperty(exports, '$$', {get: () => exports.protractor.$$});
-
 export declare let element: ElementHelper;
-Object.defineProperty(exports, 'element', {get: () => exports.protractor.element});
-
 export declare let By: ProtractorBy;
-Object.defineProperty(exports, 'By', {get: () => exports.protractor.By});
-
 export declare let by: ProtractorBy;
-Object.defineProperty(exports, 'by', {get: () => exports.protractor.by});
-
 export declare let ExpectedConditions: ProtractorExpectedConditions;
-Object.defineProperty(
-    exports, 'ExpectedConditions', {get: () => exports.protractor.ExpectedConditions});
+
+registerGlobal('browser');
+registerGlobal('$');
+registerGlobal('$$');
+registerGlobal('element');
+registerGlobal('By');
+registerGlobal('by');
+registerGlobal('ExpectedConditions');

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -40,9 +40,8 @@ export declare let protractor: Ptor;
 Object.defineProperty(exports, 'protractor', {get: () => (global as any)['protractor']});
 
 function registerGlobal(name: string) {
-  Object.defineProperty(exports, name, {
-    get: () => exports.protractor ? exports.protractor[name] : undefined
-  });
+  Object.defineProperty(
+      exports, name, {get: () => exports.protractor ? exports.protractor[name] : undefined});
 }
 
 export declare let browser: ProtractorBrowser;

--- a/lib/runner.ts
+++ b/lib/runner.ts
@@ -254,14 +254,7 @@ export class Runner extends EventEmitter {
       // Note: because tests are not paused at this point, any async
       // calls here are not guaranteed to complete before the tests resume.
       this.driverprovider_.quitDriver(browser_.driver);
-      // Copy mock modules, but do not navigate to previous URL.
-      let forkBrowser = browser_.forkNewDriverInstance(false, true);
-
-      // Replace the items in browser_ but do not create a new object
-      // since this will break typescript imports
-      for (let item in forkBrowser) {
-        browser_[item] = forkBrowser[item];
-      }
+      browser_ = browser_.forkNewDriverInstance(false, true);
       this.setupGlobals_(browser_);
     };
 

--- a/spec/basic/restart_spec.js
+++ b/spec/basic/restart_spec.js
@@ -1,10 +1,10 @@
-fdescribe('browser.restart', function() {
-  fit('doesn\'t break ignoreSynchronization', function() {
+describe('browser.restart', function() {
+  it('doesn\'t break ignoreSynchronization', function() {
     browser.get('index.html#/polling');
     browser.restart();
 
     browser.ignoreSynchronization = true;
     // Get a non-angular page. It shouldn't fail if ignoreSynchronization is on.
-    browser.get("https://google.com/");
+    browser.get('https://google.com/');
   });
 });

--- a/spec/basic/restart_spec.js
+++ b/spec/basic/restart_spec.js
@@ -1,16 +1,10 @@
-describe('browser.restart', function() {
-  it('doesn\'t break ignoreSynchronization', function() {
+fdescribe('browser.restart', function() {
+  fit('doesn\'t break ignoreSynchronization', function() {
     browser.get('index.html#/polling');
-
     browser.restart();
 
     browser.ignoreSynchronization = true;
-
     // Get a non-angular page. It shouldn't fail if ignoreSynchronization is on.
-    browser.driver.get("https://google.com/");
-
-    var EC = protractor.ExpectedConditions;
-
-    browser.driver.wait(EC.visibilityOf($("#start-of-content")));
+    browser.get("https://google.com/");
   });
 });

--- a/spec/basic/restart_spec.js
+++ b/spec/basic/restart_spec.js
@@ -1,0 +1,16 @@
+describe('browser.restart', function() {
+  it('doesn\'t break ignoreSynchronization', function() {
+    browser.get('index.html#/polling');
+
+    browser.restart();
+
+    browser.ignoreSynchronization = true;
+
+    // Get a non-angular page. It shouldn't fail if ignoreSynchronization is on.
+    browser.driver.get("https://google.com/");
+
+    var EC = protractor.ExpectedConditions;
+
+    browser.driver.wait(EC.visibilityOf($("#start-of-content")));
+  });
+});

--- a/spec/basic/restart_spec.js
+++ b/spec/basic/restart_spec.js
@@ -7,4 +7,8 @@ describe('browser.restart', function() {
     // Get a non-angular page. It shouldn't fail if ignoreSynchronization is on.
     browser.get('https://google.com/');
   });
+
+  afterAll(() => {
+    browser.ignoreSynchronization = false;
+  });
 });


### PR DESCRIPTION
Because globals are set in the runner, they may be undefined at import time. Also, the `browser` global object will change if `browser.reset()` is called. By making these globals exported as properties, they will be resolved dynamically. This also fixes issues importing protractor in config files written in typescript, since the globals are resolved at call time instead of at import time.

Note that until the Runner calls `setupGlobals_`, these exports will be undefined. That's just the nature of these objects, though, and the global objects have the same behavior.