### PR TITLE
fix(element): make Element[Array]Finder actually extend WebElement

### DIFF
--- a/lib/element.ts
+++ b/lib/element.ts
@@ -11,35 +11,15 @@ let clientSideScripts = require('./clientsidescripts');
 
 let logger = new Logger('element');
 
-let WEB_ELEMENT_FUNCTIONS = [
+const WEB_ELEMENT_FUNCTIONS = [
   'click', 'sendKeys', 'getTagName', 'getCssValue', 'getAttribute', 'getText', 'getSize',
   'getLocation', 'isEnabled', 'isSelected', 'submit', 'clear', 'isDisplayed', 'getOuterHtml',
   'getInnerHtml', 'getId', 'getRawId', 'serialize', 'takeScreenshot'
 ];
 
-// Explicitly define webdriver.WebElement.
-// TODO: extend WebElement from selenium-webdriver typings
-export class WebdriverWebElement {
-  getDriver: () => WebDriver;
-  getId: () => wdpromise.Promise<any>;
-  getRawId: () => wdpromise.Promise<string>;
-  serialize: () => wdpromise.Promise<any>;
-  findElement: (subLocator: Locator) => wdpromise.Promise<any>;
-  click: () => wdpromise.Promise<void>;
-  sendKeys: (...args: (string|wdpromise.Promise<string>)[]) => wdpromise.Promise<void>;
-  getTagName: () => wdpromise.Promise<string>;
-  getCssValue: (cssStyleProperty: string) => wdpromise.Promise<string>;
-  getAttribute: (attributeName: string) => wdpromise.Promise<string>;
-  getText: () => wdpromise.Promise<string>;
-  getSize: () => wdpromise.Promise<ISize>;
-  getLocation: () => wdpromise.Promise<ILocation>;
-  isEnabled: () => wdpromise.Promise<boolean>;
-  isSelected: () => wdpromise.Promise<boolean>;
-  submit: () => wdpromise.Promise<void>;
-  clear: () => wdpromise.Promise<void>;
-  isDisplayed: () => wdpromise.Promise<boolean>;
-  takeScreenshot: (opt_scroll?: boolean) => wdpromise.Promise<string>;
-}
+// a workaround for https://github.com/Microsoft/TypeScript/issues/11304
+export const WebdriverWebElement: {new (): WebElement} = function() {} as any;
+WebdriverWebElement.prototype = WebElement.prototype;
 
 /**
  * ElementArrayFinder is used for operations on an array of elements (as opposed


### PR DESCRIPTION
An attempt to fix #3721. A change to [angular/jasminewd](https://github.com/angular/jasminewd) is needed for this to work:

**[index.js](https://github.com/angular/jasminewd/blob/35d2ac86623d79f1a3d99a60933ec30986253139/index.js):**
```diff
 var originalExpect = global.expect;
 global.expect = function(actual) {
-  if (actual instanceof webdriver.WebElement) {
+  if (actual instanceof webdriver.WebElement && typeof actual.then !== 'function' && actual.then !== null) {) {
     throw Error('expect called with WebElement argument, expected a Promise. ' +
         'Did you mean to use .getText()?');
   }
```