### PR TITLE
cleanup(types): Fix webelement.then() return type.

### DIFF
--- a/lib/element.ts
+++ b/lib/element.ts
@@ -476,7 +476,7 @@ export class ElementArrayFinder extends WebdriverWebElement {
    *     an array of ElementFinders represented by the ElementArrayFinder.
    */
   then(fn?: (value: any) => any | wdpromise.IThenable<any>, errorFn?: (error: any) => any):
-      wdpromise.Promise<any[]> {
+      wdpromise.Promise<any> {
     if (this.actionResults_) {
       return this.actionResults_.then(fn, errorFn);
     } else {

--- a/spec/basic/restart_spec.js
+++ b/spec/basic/restart_spec.js
@@ -8,7 +8,7 @@ describe('browser.restart', function() {
     browser.get('https://google.com/');
   });
 
-  afterAll(() => {
+  afterAll(function() {
     browser.ignoreSynchronization = false;
   });
 });


### PR DESCRIPTION
Fixes #3696. Also clean up the restart spec test.