### PR TITLE
docs(expectedconditions): Fix description

### DIFF
--- a/lib/element.ts
+++ b/lib/element.ts
@@ -792,7 +792,9 @@ export class ElementArrayFinder extends WebdriverWebElement {
 export class ElementFinder extends WebdriverWebElement {
   parentElementArrayFinder: ElementArrayFinder;
   elementArrayFinder_: ElementArrayFinder;
-  then: (fn: Function, errorFn?: Function) => wdpromise.Promise<any> = null;
+  then?:
+      (fn: (value: any) => {} | wdpromise.IThenable<any>,
+       errorFn?: (error: any) => any) => wdpromise.Promise<any> = null;
 
   constructor(public browser_: ProtractorBrowser, elementArrayFinder: ElementArrayFinder) {
     super();


### PR DESCRIPTION
- See issue https://github.com/angular/protractor/issues/2138 which I just experienced as well because the documentation here (http://www.protractortest.org/#/api?view=ProtractorExpectedConditions.prototype.invisibilityOf) for invisibilityOf said it would support the element not being visible on the DOM, but it doesn't.