### PR TITLE
Proposal: add seleniumServerStartTimeout in Local DriverProvider

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -29,6 +29,13 @@ export interface Config {
   seleniumServerJar?: string;
 
   /**
+   * The timeout milliseconds waiting for a local standalone Selenium Server to start.
+   *
+   * default: 30000ms
+   */
+  seleniumServerStartTimeout?: number;
+
+  /**
    * Can be an object which will be passed to the SeleniumServer class as args.
    * See a full list of options at
    * https://github.com/SeleniumHQ/selenium/blob/master/javascript/node/selenium-webdriver/remote/index.js

--- a/lib/driverProviders/local.ts
+++ b/lib/driverProviders/local.ts
@@ -103,7 +103,7 @@ export class Local extends DriverProvider {
     this.server_ = new remote.SeleniumServer(this.config_.seleniumServerJar, serverConf);
 
     // start local server, grab hosted address, and resolve promise
-    this.server_.start().then((url: string) => {
+    this.server_.start(this.config_.seleniumServerStartTimeout).then((url: string) => {
       logger.info('Selenium standalone server started at ' + url);
       this.server_.address().then((address: string) => {
         this.config_.seleniumAddress = address;


### PR DESCRIPTION
It's nice to specify how long time the Local DriverProvider waits for the selenium-webdriver server to start.

The Local DriverProvider starts local selenium-webdriver server, and waits for the server in 30,000ms now. That's because `DriverService#start()` of selenium-webdriver/remote has an arg `opt_timeoutMs` default 30,000ms.

30,000ms is almost enough long, but that depends on environment. 