### PR TITLE
chore(scripts): clean up package scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,13 +62,13 @@
   "main": "built/index.js",
   "typings": "built/index.d.ts",
   "scripts": {
+    "format": "gulp format",
+    "install_testapp": "cd testapp && npm install",
     "prepublish": "gulp prepublish",
     "pretest": "gulp pretest",
-    "start": "node testapp/scripts/web-server.js",
+    "start": "cd testapp && npm start",
     "test": "node scripts/test.js",
-    "install_testapp": "cd testapp && npm install",
-    "tsc": "./node_modules/typescript/bin/tsc",
-    "tsc:w": "./node_modules/typescript/bin/tsc -w"
+    "website": "cd website && npm start"
   },
   "license": "MIT",
   "engines": {

--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 cd "$( dirname "${BASH_SOURCE[0]}" )/.."
-npm run install_testapp
+cd testapp && npm install
 
-cd website
+cd ../website
 
 # Check that directory is clean
 if [ $(git status --porcelain | wc -l) != "0" ]; then

--- a/scripts/testserver.sh
+++ b/scripts/testserver.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 # Start up the server in a way that won't block Travis.
-
 cd testapp
-node scripts/web-server.js &
+npm run start &
 sleep 1
 echo Test application started

--- a/testapp/package.json
+++ b/testapp/package.json
@@ -2,10 +2,9 @@
   "name": "testapp",
   "version": "0.0.1",
   "scripts": {
-    "start": "concurrently \"npm run tsc:w\" \"npm run lite\" ",
-    "tsc": "tsc",
-    "tsc:w": "tsc -w",
-    "lite": "lite-server"
+    "postinstall": "npm run tsc",
+    "start": "npm install && node scripts/web-server.js",
+    "tsc": "tsc"
   },
   "dependencies": {
     "@angular/common": "2.2.1",

--- a/website/package.json
+++ b/website/package.json
@@ -23,10 +23,14 @@
     "marked": "^0.3.3"
   },
   "scripts": {
-    "prepublish": "node node_modules/bower/bin/bower install",
-    "clean": "gulp clean",
     "build": "gulp",
+    "clean": "gulp clean",
+    "prepublish": "bower install",
+    "prestart": "npm install && npm run prepublish",
     "start": "gulp liveReload",
-    "test": "./run-tests.js"
+    "test": "node run-tests.js"
+  },
+  "engines": {
+    "node": ">=4.0.0 <5.0.x"
   }
 }


### PR DESCRIPTION
- npm start - installs dependencies and starts the testapp
- npm run website - installs dependencies and starts the website
- cleanup testapp package scripts that are not used
- npm run format - shortcut for 'gulp format' for contributors that failed format check test