### PR TITLE
chore(deps): Update Travis Selenium 3.0 and latest browsers

### DIFF
--- a/spec/basic/elements_spec.js
+++ b/spec/basic/elements_spec.js
@@ -465,7 +465,7 @@ describe('ElementArrayFinder', function() {
     ]);
   });
 
-  fit('should map and resolve multiple promises', function() {
+  it('should map and resolve multiple promises', function() {
     browser.get('index.html#/form');
     var labels = element.all(by.css('#animals ul li')).map(function(elm) {
       return {

--- a/spec/ciFullConf.js
+++ b/spec/ciFullConf.js
@@ -25,7 +25,7 @@ exports.config = {
     'version': '54',
     'selenium-version': '3.0.1',
     'chromedriver-version': '2.26',
-    'platform': 'OS X 10.9'
+    'platform': 'OS X 10.11'
   }, {
     'browserName': 'firefox',
     'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,

--- a/spec/ciFullConf.js
+++ b/spec/ciFullConf.js
@@ -22,9 +22,9 @@ exports.config = {
     'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
     'build': process.env.TRAVIS_BUILD_NUMBER,
     'name': 'Protractor suite tests',
-    'version': '55',
+    'version': '54',
     'selenium-version': '3.0.1',
-    'chromedriver-version': '2.25',
+    'chromedriver-version': '2.26',
     'platform': 'OS X 10.9'
   }, {
     'browserName': 'firefox',

--- a/spec/ciFullConf.js
+++ b/spec/ciFullConf.js
@@ -22,8 +22,8 @@ exports.config = {
     'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
     'build': process.env.TRAVIS_BUILD_NUMBER,
     'name': 'Protractor suite tests',
-    'version': '54',
-    'selenium-version': '2.53.1',
+    'version': '55',
+    'selenium-version': '3.0.1',
     'chromedriver-version': '2.25',
     'platform': 'OS X 10.9'
   }, {
@@ -31,8 +31,8 @@ exports.config = {
     'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
     'build': process.env.TRAVIS_BUILD_NUMBER,
     'name': 'Protractor suite tests',
-    'version': '47',
-    'selenium-version': '2.53.1'
+    'version': '50',
+    'selenium-version': '3.0.1'
   }],
 
   baseUrl: env.baseUrl + '/ng1/',

--- a/spec/ciFullConf.js
+++ b/spec/ciFullConf.js
@@ -23,7 +23,7 @@ exports.config = {
     'build': process.env.TRAVIS_BUILD_NUMBER,
     'name': 'Protractor suite tests',
     'version': '54',
-    'selenium-version': '3.0.1',
+    'selenium-version': '2.53.1',
     'chromedriver-version': '2.26',
     'platform': 'OS X 10.11'
   }, {
@@ -31,8 +31,8 @@ exports.config = {
     'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
     'build': process.env.TRAVIS_BUILD_NUMBER,
     'name': 'Protractor suite tests',
-    'version': '50',
-    'selenium-version': '3.0.1'
+    'version': '47',
+    'selenium-version': '2.53.1'
   }],
 
   baseUrl: env.baseUrl + '/ng1/',

--- a/spec/ciNg2Conf.js
+++ b/spec/ciNg2Conf.js
@@ -11,8 +11,8 @@ exports.config.multiCapabilities = [{
     'build': process.env.TRAVIS_BUILD_NUMBER,
     'name': 'Protractor suite tests',
     'version': '54',
-    'selenium-version': '2.53.1',
-    'chromedriver-version': '2.25',
+    'selenium-version': '3.0.1',
+    'chromedriver-version': '2.26',
     'platform': 'OS X 10.9'
   }];
 exports.config.capabilities = undefined;

--- a/spec/ciNg2Conf.js
+++ b/spec/ciNg2Conf.js
@@ -11,9 +11,9 @@ exports.config.multiCapabilities = [{
     'build': process.env.TRAVIS_BUILD_NUMBER,
     'name': 'Protractor suite tests',
     'version': '54',
-    'selenium-version': '3.0.1',
+    'selenium-version': '2.53.1',
     'chromedriver-version': '2.26',
-    'platform': 'OS X 10.9'
+    'platform': 'OS X 10.11'
   }];
 exports.config.capabilities = undefined;
 exports.config.allScriptsTimeout = 120000;

--- a/spec/ciSmokeConf.js
+++ b/spec/ciSmokeConf.js
@@ -24,7 +24,7 @@ exports.config = {
     'build': process.env.TRAVIS_BUILD_NUMBER,
     'name': 'Protractor smoke tests',
     'version': '54',
-    'selenium-version': '3.0.1',
+    'selenium-version': '2.53.1',
     'chromedriver-version': '2.26',
     'platform': 'OS X 10.11'
   }, {
@@ -32,15 +32,15 @@ exports.config = {
     'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
     'build': process.env.TRAVIS_BUILD_NUMBER,
     'name': 'Protractor smoke tests',
-    'version': '50',
-    'selenium-version': '3.0.1'
+    'version': '47',
+    'selenium-version': '2.53.1'
   }, {
     'browserName': 'safari',
     'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
     'build': process.env.TRAVIS_BUILD_NUMBER,
     'name': 'Protractor smoke tests',
     'version': '10',
-    'selenium-version': '3.0.1',
+    'selenium-version': '2.53.1',
     'platform': 'OS X 10.11'
   }, {
     'browserName': 'MicrosoftEdge',
@@ -48,7 +48,7 @@ exports.config = {
     'build': process.env.TRAVIS_BUILD_NUMBER,
     'name': 'Protractor smoke tests',
     'version': '14.14393',
-    'selenium-version': '3.0.1',
+    'selenium-version': '2.53.1',
     'platform': 'Windows 10'
   }, {
     'browserName': 'Internet Explorer',
@@ -56,7 +56,7 @@ exports.config = {
     'build': process.env.TRAVIS_BUILD_NUMBER,
     'name': 'Protractor smoke tests',
     'version': '11',
-    'selenium-version': '3.0.1',
+    'selenium-version': '2.53.1',
     'platform': 'Windows 8.1'
   }],
 

--- a/spec/ciSmokeConf.js
+++ b/spec/ciSmokeConf.js
@@ -35,13 +35,15 @@ exports.config = {
     'version': '47',
     'selenium-version': '2.53.1'
   }, {
+    // TODO: Add Safari 10 once Saucelabs gets Selenium 3
     'browserName': 'safari',
     'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
     'build': process.env.TRAVIS_BUILD_NUMBER,
     'name': 'Protractor smoke tests',
-    'version': '10',
-    'selenium-version': '2.53.1',
-    'platform': 'OS X 10.11'
+    'version': '9',
+    'platform': 'OS X 10.9',
+    'selenium-version': '2.44.0' // Use an old version because Safari has
+                                 // issues loading pages after 2.44.
   }, {
     'browserName': 'MicrosoftEdge',
     'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,

--- a/spec/ciSmokeConf.js
+++ b/spec/ciSmokeConf.js
@@ -26,7 +26,7 @@ exports.config = {
     'version': '54',
     'selenium-version': '3.0.1',
     'chromedriver-version': '2.26',
-    'platform': 'OS X 10.9'
+    'platform': 'OS X 10.11'
   }, {
     'browserName': 'firefox',
     'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
@@ -40,23 +40,24 @@ exports.config = {
     'build': process.env.TRAVIS_BUILD_NUMBER,
     'name': 'Protractor smoke tests',
     'version': '10',
-    'selenium-version': '3.0.1'
+    'selenium-version': '3.0.1',
+    'platform': 'OS X 10.11'
   }, {
-    'browserName': 'microsoftedge',
+    'browserName': 'MicrosoftEdge',
     'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
     'build': process.env.TRAVIS_BUILD_NUMBER,
     'name': 'Protractor smoke tests',
-    'version': '14',
+    'version': '14.14393',
     'selenium-version': '3.0.1',
     'platform': 'Windows 10'
   }, {
-    'browserName': 'internet explorer',
+    'browserName': 'Internet Explorer',
     'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
     'build': process.env.TRAVIS_BUILD_NUMBER,
     'name': 'Protractor smoke tests',
     'version': '11',
     'selenium-version': '3.0.1',
-    'platform': 'Windows 8'
+    'platform': 'Windows 8.1'
   }],
 
   baseUrl: env.baseUrl + '/ng1/',

--- a/spec/ciSmokeConf.js
+++ b/spec/ciSmokeConf.js
@@ -24,48 +24,39 @@ exports.config = {
     'build': process.env.TRAVIS_BUILD_NUMBER,
     'name': 'Protractor smoke tests',
     'version': '54',
-    'selenium-version': '2.53.1',
-    'chromedriver-version': '2.25',
+    'selenium-version': '3.0.1',
+    'chromedriver-version': '2.26',
     'platform': 'OS X 10.9'
   }, {
     'browserName': 'firefox',
     'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
     'build': process.env.TRAVIS_BUILD_NUMBER,
     'name': 'Protractor smoke tests',
-    'version': '47',
-    'selenium-version': '2.53.1'
+    'version': '50',
+    'selenium-version': '3.0.1'
   }, {
     'browserName': 'safari',
     'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
     'build': process.env.TRAVIS_BUILD_NUMBER,
     'name': 'Protractor smoke tests',
-    'version': '8',
-    'selenium-version': '2.44.0' // Use an old version because Safari has
-                                 // issues loading pages after 2.44.
+    'version': '10',
+    'selenium-version': '3.0.1'
   }, {
-    'browserName': 'safari',
+    'browserName': 'microsoftedge',
     'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
     'build': process.env.TRAVIS_BUILD_NUMBER,
     'name': 'Protractor smoke tests',
-    'version': '9',
-    'selenium-version': '2.44.0' // Use an old version because Safari has
-                                 // issues loading pages after 2.44.
+    'version': '14',
+    'selenium-version': '3.0.1',
+    'platform': 'Windows 10'
   }, {
     'browserName': 'internet explorer',
     'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
     'build': process.env.TRAVIS_BUILD_NUMBER,
     'name': 'Protractor smoke tests',
     'version': '11',
-    'selenium-version': '2.53.1',
-    'platform': 'Windows 7'
-  }, {
-    'browserName': 'internet explorer',
-    'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
-    'build': process.env.TRAVIS_BUILD_NUMBER,
-    'name': 'Protractor smoke tests',
-    'version': '10',
-    'selenium-version': '2.53.1',
-    'platform': 'Windows 7'
+    'selenium-version': '3.0.1',
+    'platform': 'Windows 8'
   }],
 
   baseUrl: env.baseUrl + '/ng1/',

--- a/spec/ciSmokeConf.js
+++ b/spec/ciSmokeConf.js
@@ -41,7 +41,6 @@ exports.config = {
     'build': process.env.TRAVIS_BUILD_NUMBER,
     'name': 'Protractor smoke tests',
     'version': '9',
-    'platform': 'OS X 10.9',
     'selenium-version': '2.44.0' // Use an old version because Safari has
                                  // issues loading pages after 2.44.
   }, {


### PR DESCRIPTION
This also drops support for Safari 9, which doesn't use safaridriver.