### PR TITLE
chore(types): fixed types to use selenium-webdriver

### DIFF
--- a/lib/browser.ts
+++ b/lib/browser.ts
@@ -30,7 +30,7 @@ for (let foo in webdriver) {
   exports[foo] = webdriver[foo];
 }
 
-// Explicitly define webdriver.WebDriver
+// Explicitly define WebDriver
 // TODO: extend WebDriver from selenium-webdriver typings
 export class Webdriver {
   actions: () => ActionSequence;
@@ -96,7 +96,7 @@ export interface ElementHelper extends Function {
  *
  * @private
  * @param {Browser} browser A browser instance.
- * @returns {function(webdriver.Locator): ElementFinder}
+ * @returns {function(Locator): ElementFinder}
  */
 function buildElementHelper(browser: ProtractorBrowser): ElementHelper {
   let element = ((locator: Locator) => {
@@ -114,8 +114,8 @@ function buildElementHelper(browser: ProtractorBrowser): ElementHelper {
 /**
  * @alias browser
  * @constructor
- * @extends {webdriver.WebDriver}
- * @param {webdriver.WebDriver} webdriver
+ * @extends {WebDriver}
+ * @param {WebDriver} webdriver
  * @param {string=} opt_baseUrl A base URL to run get requests against.
  * @param {string=} opt_rootElement  Selector element that has an ng-app in
  *     scope.
@@ -137,14 +137,14 @@ export class ProtractorBrowser extends Webdriver {
    * The wrapped webdriver instance. Use this to interact with pages that do
    * not contain Angular (such as a log-in screen).
    *
-   * @type {webdriver.WebDriver}
+   * @type {WebDriver}
    */
   driver: WebDriver;
 
   /**
    * Helper function for finding elements.
    *
-   * @type {function(webdriver.Locator): ElementFinder}
+   * @type {function(Locator): ElementFinder}
    */
   element: ElementHelper;
 
@@ -332,7 +332,7 @@ export class ProtractorBrowser extends Webdriver {
    *
    * Set by the runner.
    *
-   * @returns {webdriver.promise.Promise} A promise which resolves to the
+   * @returns {wdpromise.Promise} A promise which resolves to the
    * capabilities object.
    */
   getProcessedConfig(): wdpromise.Promise<any> {
@@ -376,14 +376,14 @@ export class ProtractorBrowser extends Webdriver {
   }
 
   /**
-   * The same as {@code webdriver.WebDriver.prototype.executeScript},
+   * The same as {@code WebDriver.prototype.executeScript},
    * but with a customized description for debugging.
    *
    * @private
    * @param {!(string|Function)} script The script to execute.
    * @param {string} description A description of the command for debugging.
    * @param {...*} var_args The arguments to pass to the script.
-   * @returns {!webdriver.promise.Promise.<T>} A promise that will resolve to
+   * @returns {!wdpromise.Promise.<T>} A promise that will resolve to
    * the scripts return value.
    * @template T
    */
@@ -401,14 +401,14 @@ export class ProtractorBrowser extends Webdriver {
   }
 
   /**
-   * The same as {@code webdriver.WebDriver.prototype.executeAsyncScript},
+   * The same as {@code WebDriver.prototype.executeAsyncScript},
    * but with a customized description for debugging.
    *
    * @private
    * @param {!(string|Function)} script The script to execute.
    * @param {string} description A description for debugging purposes.
    * @param {...*} var_args The arguments to pass to the script.
-   * @returns {!webdriver.promise.Promise.<T>} A promise that will resolve to
+   * @returns {!wdpromise.Promise.<T>} A promise that will resolve to
    * the
    *    scripts return value.
    * @template T
@@ -433,7 +433,7 @@ export class ProtractorBrowser extends Webdriver {
    *
    * @param {string=} opt_description An optional description to be added
    *     to webdriver logs.
-   * @returns {!webdriver.promise.Promise} A promise that will resolve to the
+   * @returns {!wdpromise.Promise} A promise that will resolve to the
    *    scripts return value.
    */
   waitForAngular(opt_description?: string): wdpromise.Promise<any> {
@@ -548,9 +548,9 @@ export class ProtractorBrowser extends Webdriver {
 
   /**
    * Waits for Angular to finish rendering before searching for elements.
-   * @see webdriver.WebDriver.findElement
-   * @returns {!webdriver.promise.Promise} A promise that will be resolved to
-   *      the located {@link webdriver.WebElement}.
+   * @see WebDriver.findElement
+   * @returns {!wdpromise.Promise} A promise that will be resolved to
+   *      the located {@link WebElement}.
    */
   findElement(locator: Locator): WebElement {
     return this.element(locator).getWebElement();
@@ -558,22 +558,22 @@ export class ProtractorBrowser extends Webdriver {
 
   /**
    * Waits for Angular to finish rendering before searching for elements.
-   * @see webdriver.WebDriver.findElements
-   * @returns {!webdriver.promise.Promise} A promise that will be resolved to an
-   *     array of the located {@link webdriver.WebElement}s.
+   * @see WebDriver.findElements
+   * @returns {!wdpromise.Promise} A promise that will be resolved to an
+   *     array of the located {@link WebElement}s.
    */
-  findElements(locator: Locator): webdriver.promise.Promise<any> {
+  findElements(locator: Locator): wdpromise.Promise<any> {
     return this.element.all(locator).getWebElements();
   }
 
   /**
    * Tests if an element is present on the page.
-   * @see webdriver.WebDriver.isElementPresent
-   * @returns {!webdriver.promise.Promise} A promise that will resolve to whether
+   * @see WebDriver.isElementPresent
+   * @returns {!wdpromise.Promise} A promise that will resolve to whether
    *     the element is present on the page.
    */
   isElementPresent(locatorOrElement: ProtractorBy|
-                   webdriver.WebElement): webdriver.promise.Promise<any> {
+                   WebElement): wdpromise.Promise<any> {
     let element =
         ((locatorOrElement as any).isPresent) ? locatorOrElement : this.element(locatorOrElement);
     return (element as any).isPresent();
@@ -646,7 +646,7 @@ export class ProtractorBrowser extends Webdriver {
   }
 
   /**
-   * @see webdriver.WebDriver.get
+   * @see WebDriver.get
    *
    * Navigate to the given destination and loads mock modules before
    * Angular. Assumes that the page being loaded uses Angular.
@@ -778,7 +778,7 @@ export class ProtractorBrowser extends Webdriver {
   }
 
   /**
-   * @see webdriver.WebDriver.refresh
+   * @see WebDriver.refresh
    *
    * Makes a full reload of the current page and loads mock modules before
    * Angular. Assumes that the page being loaded uses Angular.
@@ -820,10 +820,10 @@ export class ProtractorBrowser extends Webdriver {
    *     .toBe('http://angular.github.io/protractor/#/api');
    *
    * @param {string} url In page URL using the same syntax as $location.url()
-   * @returns {!webdriver.promise.Promise} A promise that will resolve once
+   * @returns {!wdpromise.Promise} A promise that will resolve once
    *    page has been changed.
    */
-  setLocation(url: string): webdriver.promise.Promise<any> {
+  setLocation(url: string): wdpromise.Promise<any> {
     this.waitForAngular();
     return this
         .executeScriptWithDescription(
@@ -842,10 +842,10 @@ export class ProtractorBrowser extends Webdriver {
    * browser.get('http://angular.github.io/protractor/#/api');
    * expect(browser.getLocationAbsUrl())
    *     .toBe('http://angular.github.io/protractor/#/api');
-   * @returns {webdriver.promise.Promise<string>} The current absolute url from
+   * @returns {wdpromise.Promise<string>} The current absolute url from
    * AngularJS.
    */
-  getLocationAbsUrl(): webdriver.promise.Promise<any> {
+  getLocationAbsUrl(): wdpromise.Promise<any> {
     this.waitForAngular();
     return this.executeScriptWithDescription(
         clientSideScripts.getLocationAbsUrl, 'Protractor.getLocationAbsUrl()', this.rootEl);
@@ -930,7 +930,7 @@ export class ProtractorBrowser extends Webdriver {
    * @param {number=} opt_debugPort Optional port to use for the debugging
    * process
    */
-  pause(opt_debugPort?: number): webdriver.promise.Promise<any> {
+  pause(opt_debugPort?: number): wdpromise.Promise<any> {
     if (this.debugHelper.isAttached()) {
       logger.info('Encountered browser.pause(), but debugger already attached.');
       return wdpromise.fulfilled(true);
@@ -959,7 +959,7 @@ export class ProtractorBrowser extends Webdriver {
   /**
    * Create a new instance of Browser by wrapping a webdriver instance.
    *
-   * @param {webdriver.WebDriver} webdriver The configured webdriver instance.
+   * @param {WebDriver} webdriver The configured webdriver instance.
    * @param {string=} baseUrl A URL to prepend to relative gets.
    * @param {string=} rootElement The css selector for the element which is the
    *     root of the Angular app.

--- a/lib/browser.ts
+++ b/lib/browser.ts
@@ -572,8 +572,7 @@ export class ProtractorBrowser extends Webdriver {
    * @returns {!wdpromise.Promise} A promise that will resolve to whether
    *     the element is present on the page.
    */
-  isElementPresent(locatorOrElement: ProtractorBy|
-                   WebElement): wdpromise.Promise<any> {
+  isElementPresent(locatorOrElement: ProtractorBy|WebElement): wdpromise.Promise<any> {
     let element =
         ((locatorOrElement as any).isPresent) ? locatorOrElement : this.element(locatorOrElement);
     return (element as any).isPresent();

--- a/lib/ptor.ts
+++ b/lib/ptor.ts
@@ -23,7 +23,7 @@ export class Ptor {
   By: ProtractorBy;
   by: ProtractorBy;
   wrapDriver:
-      (webdriver: webdriver.WebDriver, baseUrl?: string, rootElement?: string,
+      (webdriver: WebDriver, baseUrl?: string, rootElement?: string,
        untrackOutstandingTimeouts?: boolean) => ProtractorBrowser;
   ExpectedConditions: ProtractorExpectedConditions;
 


### PR DESCRIPTION
Currently when installed e.g. with Aurelia skeleton project (in my case) there are several errors thrown when building due to protractor.

```
ERROR in [at-loader] node_modules\protractor\built\browser.d.ts:260:37
    Cannot find namespace 'webdriver'.

ERROR in [at-loader] node_modules\protractor\built\browser.d.ts:267:55
    Cannot find namespace 'webdriver'.

ERROR in [at-loader] node_modules\protractor\built\browser.d.ts:267:78
    Cannot find namespace 'webdriver'.

ERROR in [at-loader] node_modules\protractor\built\browser.d.ts:358:31
    Cannot find namespace 'webdriver'.

ERROR in [at-loader] node_modules\protractor\built\browser.d.ts:369:26
    Cannot find namespace 'webdriver'.

ERROR in [at-loader] node_modules\protractor\built\browser.d.ts:425:36
    Cannot find namespace 'webdriver'.

ERROR in [at-loader] node_modules\protractor\built\ptor.d.ts:13:29
    Cannot find namespace 'webdriver'.
```

This should fix just that.