### PR TITLE
docs(element): Fix docs for #896 (clear() and sendKeys())

### DIFF
--- a/lib/selenium-webdriver/webdriver.js
+++ b/lib/selenium-webdriver/webdriver.js
@@ -479,8 +479,7 @@ webdriver.WebElement.prototype.click = function() {};
  *
  * @param {...(string|!webdriver.promise.Promise<string>)} var_args The sequence
  *     of keys to type. All arguments will be joined into a single sequence.
- * @returns {!webdriver.promise.Promise.<void>} A promise that will be resolved
- *     when all keys have been typed.
+ * @returns {!webdriver.WebElement} The element itself.
  */
 webdriver.WebElement.prototype.sendKeys = function(var_args) {};
 
@@ -694,8 +693,7 @@ webdriver.WebElement.prototype.submit = function() {};
  * foo.clear();
  * expect(foo.getAttribute('value')).toEqual('');
  *
- * @returns {!webdriver.promise.Promise.<void>} A promise that will be resolved
- *     when the element has been cleared.
+ * @returns {!webdriver.WebElement} The element itself.
  */
 webdriver.WebElement.prototype.clear = function() {};
 


### PR DESCRIPTION
Commit 3c0e727 (PR #896) allowed chaining of actions (i.e. `element(By.x).clear().sendKeys('abc)`). Since then, the return type of `clear()` and `sendKeys()` is not longer a `Promise<void>`, but the WebElement itself.

This commit fixes the docs.

It will allow typings for selenium-webdriver to be corrected. Until now, TypeScript complains with:

    error TS2339: Property 'sendKeys' does not exist on type 'Promise<void>'.