### PR TITLE
fix(ci): Log test output on CircleCI

### DIFF
--- a/scripts/test.js
+++ b/scripts/test.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+var path = require('path');
 
 var Executor = require('./test/test_util').Executor;
 
@@ -144,4 +145,9 @@ executor.addCommandlineTest('node built/cli.js spec/angular2TimeoutConf.js')
       {message: 'Timed out waiting for asynchronous Angular tasks to finish'},
     ]);
 
-executor.execute();
+// If we're running on CircleCI, save stdout and stderr from the test run to a log file.
+if (process.env['CIRCLE_ARTIFACTS']) {
+  executor.execute(path.join(process.env['CIRCLE_ARTIFACTS'], 'test_log.txt'));
+} else {
+  executor.execute();
+}

--- a/scripts/test/test_util.js
+++ b/scripts/test/test_util.js
@@ -79,14 +79,17 @@ var CommandlineTest = function(command) {
         test_process = child_process.spawn(args[0], args.slice(1));
 
         test_process.stdout.on('data', function(data) {
+          process.stdout.write('.');
           output += data;
         });
 
         test_process.stderr.on('data', function(data) {
+          process.stdout.write('.');
           output += data;
         });
       } else {
-        test_process = child_process.spawn(args[0], args.slice(1), {stdio: 'inherit'});
+        test_process = child_process
+            .spawn(args[0], args.slice(1), {stdio: 'inherit', stderr: 'inherit'});
       }
 
       test_process.on('error', function(err) {
@@ -209,10 +212,10 @@ exports.Executor = function() {
       if (i < tests.length) {
         console.log('running: ' + tests[i].command_);
         tests[i].run().then(function() {
-          console.log('>>> \033[1;32mpass\033[0m');
+          console.log('\n>>> \033[1;32mpass\033[0m');
         }, function(err) {
           failed = true;
-          console.log('>>> \033[1;31mfail: ' + err.toString() + '\033[0m');
+          console.log('\n>>> \033[1;31mfail: ' + err.toString() + '\033[0m');
         }).fin(function() {
           runTests(i + 1);
         }).done();

--- a/scripts/test/test_util.js
+++ b/scripts/test/test_util.js
@@ -8,16 +8,9 @@ var CommandlineTest = function(command) {
   var self = this;
   this.command_ = command;
   this.expectedExitCode_ = 0;
-  this.stdioOnlyOnFailures_ = true;
   this.expectedErrors_ = [];
   this.assertExitCodeOnly_ = false;
-
-  // If stdioOnlyOnFailures_ is true, do not stream stdio unless test failed.
-  // This is to prevent tests with expected failures from polluting the output.
-  this.alwaysEnableStdio = function() {
-    self.stdioOnlyOnFailures_ = false;
-    return self;
-  };
+  this.testLogStream = undefined;
 
   // Only assert the exit code and not failures.
   // This must be true if the command you're running does not support
@@ -25,6 +18,10 @@ var CommandlineTest = function(command) {
   this.assertExitCodeOnly = function() {
     self.assertExitCodeOnly_ = true;
     return self;
+  };
+
+  this.setTestLogFile = function(filename) {
+    self.testLogStream = fs.createWriteStream(filename, {flags: 'a'});
   };
 
   // Set the expected exit code for the test command.
@@ -75,22 +72,18 @@ var CommandlineTest = function(command) {
 
       var test_process;
 
-      if (self.stdioOnlyOnFailures_) {
-        test_process = child_process.spawn(args[0], args.slice(1));
+      test_process = child_process.spawn(args[0], args.slice(1));
 
-        test_process.stdout.on('data', function(data) {
-          process.stdout.write('.');
-          output += data;
-        });
+      var processData = function(data) {
+        process.stdout.write('.');
+        output += data;
+        if (self.testLogStream) {
+          self.testLogStream.write(data);
+        }
+      };
 
-        test_process.stderr.on('data', function(data) {
-          process.stdout.write('.');
-          output += data;
-        });
-      } else {
-        test_process = child_process
-            .spawn(args[0], args.slice(1), {stdio: 'inherit', stderr: 'inherit'});
-      }
+      test_process.stdout.on('data', processData);
+      test_process.stderr.on('data', processData);
 
       test_process.on('error', function(err) {
         reject(err);
@@ -103,6 +96,10 @@ var CommandlineTest = function(command) {
       if (self.expectedExitCode_ !== exitCode) {
         flushAndFail('expecting exit code: ' + self.expectedExitCode_ +
               ', actual: ' + exitCode);
+      }
+
+      if (self.testLogStream) {
+        self.testLogStream.end();
       }
 
       // Skip the rest if we are only verify exit code.
@@ -205,12 +202,15 @@ exports.Executor = function() {
     return test;
   };
 
-  this.execute = function() {
+  this.execute = function(logFile) {
     var failed = false;
 
     (function runTests(i) {
       if (i < tests.length) {
         console.log('running: ' + tests[i].command_);
+        if (logFile) {
+          tests[i].setTestLogFile(logFile);
+        }
         tests[i].run().then(function() {
           console.log('\n>>> \033[1;32mpass\033[0m');
         }, function(err) {


### PR DESCRIPTION
CircleCI will timeout the test if it doesn't see any output for 10
minutes. When running in CI, we need to inherit stdio so we don't get
killed if the tests run slowly due to timeouts. This will also give us
more info for debugging.