### PR TITLE
Update @types/selenium-webdriver dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@types/jasmine": "^2.5.36",
     "@types/node": "^6.0.46",
     "@types/q": "^0.0.32",
-    "@types/selenium-webdriver": "2.53.37",
+    "@types/selenium-webdriver": "2.53.38",
     "adm-zip": "0.4.7",
     "chalk": "^1.1.3",
     "glob": "^7.0.3",


### PR DESCRIPTION
Fixes issue #3879 (https://github.com/angular/protractor/issues/3879)
Updating @types/selenium-webdriver dependency to @types/selenium-webdriver@2.53.38 which added back the protractor.Key.chord method.