### PR TITLE
chore(deps): remove adm-zip from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "@types/node": "^6.0.46",
     "@types/q": "^0.0.32",
     "@types/selenium-webdriver": "2.53.38",
-    "adm-zip": "0.4.7",
     "blocking-proxy": "0.0.2",
     "chalk": "^1.1.3",
     "glob": "^7.0.3",


### PR DESCRIPTION
It's required through webdriver-manager now.