### PR TITLE
fix(spec): Fix failing test

### DIFF
--- a/spec/basic/elements_spec.js
+++ b/spec/basic/elements_spec.js
@@ -151,13 +151,12 @@ describe('ElementFinder', function() {
 
   it('should propagate exceptions', function() {
     browser.get('index.html#/form');
-    var successful = protractor.promise.defer();
 
     var invalidElement = element(by.binding('INVALID'));
-    invalidElement.getText().then(function(/* string */) {
-      successful.fulfill(true);
-    }, function(/* error */) {
-      successful.fulfill(false);
+    var successful = invalidElement.getText().then(function() {
+      return true;
+    }, function() {
+      return false;
     });
     expect(successful).toEqual(false);
   });


### PR DESCRIPTION
With https://github.com/angular/jasminewd/pull/78, jasminewd no longer supports passing deferreds to expect(). Change the test to pass a promise, instead.