### PR TITLE
fix: no longer use es6 let statement

### DIFF
--- a/lib/clientsidescripts.js
+++ b/lib/clientsidescripts.js
@@ -137,7 +137,7 @@ functions.waitForAngular = function(rootSelector, callback) {
     if (window.angular && !(window.angular.version &&
           window.angular.version.major > 1)) {
       /* ng1 */
-      let hooks = getNg1Hooks(rootSelector);
+      var hooks = getNg1Hooks(rootSelector);
       if (hooks.$$testability) {
         hooks.$$testability.whenStable(callback);
       } else if (hooks.$injector) {


### PR DESCRIPTION
* Currently in Protractor v5 the Angular detection script uses ES6 features like the `let` modifier. 

This can break Protractor on browsers, which doesn't support those statements. 
> See https://saucelabs.com/beta/tests/275f75091dac40a0a3374d29d912caee/commands#11

**Note**: This currently makes Protractor v5 hard to use on older browsers. (On Material 2 we will update browsers)

cc. @sjelin @cnishina 