### PR TITLE
display disableChecks option in extra flags error message

### DIFF
--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -181,7 +181,7 @@ if (!argv.disableChecks) {
   });
 
   if (unknownKeys.length > 0) {
-    throw new Error('Found extra flags: ' + unknownKeys.join(', '));
+    throw new Error('Found extra flags: ' + unknownKeys.join(', ') + ', please use --disableChecks flag to disable the custom flag check!');
   }
 }
 

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -181,7 +181,9 @@ if (!argv.disableChecks) {
   });
 
   if (unknownKeys.length > 0) {
-    throw new Error('Found extra flags: ' + unknownKeys.join(', ') + ', please use --disableChecks flag to disable the custom flag check!');
+    throw new Error(
+        'Found extra flags: ' + unknownKeys.join(', ') +
+        ', please use --disableChecks flag to disable the Protractor CLI flag checks.');
   }
 }
 


### PR DESCRIPTION
With reference to this recent [SO question](http://stackoverflow.com/questions/41592870/found-extra-flags-error-in-new-version-of-protractor) , it would be good to display the `--disableChecks` option in the error message thrown in case users have their own custom flags set in the cli.

Users are not aware of this option until they check the changelog, it would help if this is displayed along with the error message thrown in the console itself. 

@cnishina Since you worked on this, any thoughts?