### PR TITLE
chore(webdriver): remove `element.serialize`, since it is no longer p…

### DIFF
--- a/lib/element.ts
+++ b/lib/element.ts
@@ -15,7 +15,7 @@ export interface WebdriverWebElement extends WebElement {}
 
 let WEB_ELEMENT_FUNCTIONS = [
   'click', 'sendKeys', 'getTagName', 'getCssValue', 'getAttribute', 'getText', 'getSize',
-  'getLocation', 'isEnabled', 'isSelected', 'submit', 'clear', 'isDisplayed', 'getId', 'serialize',
+  'getLocation', 'isEnabled', 'isSelected', 'submit', 'clear', 'isDisplayed', 'getId',
   'takeScreenshot'
 ] as (keyof WebdriverWebElement)[];
 

--- a/lib/selenium-webdriver/webdriver.js
+++ b/lib/selenium-webdriver/webdriver.js
@@ -419,14 +419,6 @@ webdriver.WebElement.prototype.getDriver = function() {};
 webdriver.WebElement.prototype.getId = function() {};
 
 /**
- * Returns a promise for the web element's serialized representation.
- *
- * @returns {!webdriver.promise.Promise.<webdriver.WebElement.Id>}
- *     This instance's serialized wire format.
- */
-webdriver.WebElement.prototype.serialize = function() {};
-
-/**
  * Use {@link ElementFinder.prototype.element} instead
  *
  * @see ElementFinder.prototype.element


### PR DESCRIPTION
…art of webdriver

Closes https://github.com/angular/protractor/issues/3744