### PR TITLE
chore(blockingproxy): Allow using a pre-existing Blocking Proxy instance

### DIFF
--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -41,6 +41,7 @@ let allowedNames = [
   'seleniumSessionId',
   'webDriverProxy',
   'useBlockingProxy',
+  'blockingProxyUrl',
   'sauceUser',
   'sauceKey',
   'sauceAgent',

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -106,8 +106,7 @@ export interface Config {
 
   /**
    * If specified, Protractor will connect to the Blocking Proxy at the given
-   * url instead of starting it's own. Intended for debugging Protractor
-   * features only.
+   * url instead of starting it's own.
    */
   blockingProxyUrl?: string;
 

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -104,6 +104,13 @@ export interface Config {
    */
   useBlockingProxy?: boolean;
 
+  /**
+   * If specified, Protractor will connect to the Blocking Proxy at the given
+   * url instead of starting it's own. Intended for debugging Protractor
+   * features only.
+   */
+  blockingProxyUrl?: string;
+
   // ---- 3. To use remote browsers via Sauce Labs -----------------------------
 
   /**

--- a/lib/driverProviders/driverProvider.ts
+++ b/lib/driverProviders/driverProvider.ts
@@ -31,6 +31,9 @@ export abstract class DriverProvider {
   }
 
   getBPUrl() {
+    if (this.config_.blockingProxyUrl) {
+      return this.config_.blockingProxyUrl;
+    }
     return `http://localhost:${this.bpRunner.port}`;
   }
 
@@ -105,7 +108,7 @@ export abstract class DriverProvider {
    */
   setupEnv(): q.Promise<any> {
     let driverPromise = this.setupDriverEnv();
-    if (this.config_.useBlockingProxy) {
+    if (this.config_.useBlockingProxy && !this.config_.blockingProxyUrl) {
       // TODO(heathkit): If set, pass the webDriverProxy to BP.
       return q.all([driverPromise, this.bpRunner.start()]);
     }


### PR DESCRIPTION
Only intended for debugging.