### PR TITLE
fix(ExpectedConditions): allow ExpectedConditions to handle missing e…

### DIFF
--- a/lib/expectedConditions.ts
+++ b/lib/expectedConditions.ts
@@ -1,6 +1,7 @@
 import {error as wderror} from 'selenium-webdriver';
 import {ProtractorBrowser} from './browser';
 import {ElementFinder} from './element';
+import {falseIfMissing} from './util';
 
 /**
  * Represents a library of canned expected conditions that are useful for
@@ -210,7 +211,7 @@ export class ProtractorExpectedConditions {
         // MSEdge does not properly remove newlines, which causes false
         // negatives
         return actualText.replace(/\r?\n|\r/g, '').indexOf(text) > -1;
-      });
+      }, falseIfMissing);
     };
     return this.and(this.presenceOf(elementFinder), hasText);
   }
@@ -235,7 +236,7 @@ export class ProtractorExpectedConditions {
     let hasText = () => {
       return elementFinder.getAttribute('value').then((actualText: string): boolean => {
         return actualText.indexOf(text) > -1;
-      });
+      }, falseIfMissing);
     };
     return this.and(this.presenceOf(elementFinder), hasText);
   }
@@ -388,15 +389,7 @@ export class ProtractorExpectedConditions {
    *     representing whether the element is visible.
    */
   visibilityOf(elementFinder: ElementFinder): Function {
-    return this.and(this.presenceOf(elementFinder), () => {
-      return elementFinder.isDisplayed().then((displayed: boolean) => displayed, (err: any) => {
-        if (err instanceof wderror.NoSuchElementError) {
-          return false;
-        } else {
-          throw err;
-        }
-      });
-    });
+    return this.and(this.presenceOf(elementFinder), elementFinder.isDisplayed.bind(elementFinder));
   }
 
   /**

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -1,5 +1,6 @@
 import {resolve} from 'path';
 import {Promise, when} from 'q';
+import {error as wderror} from 'selenium-webdriver';
 
 let STACK_SUBSTRINGS_TO_FILTER = [
   'node_modules/jasmine/', 'node_modules/selenium-webdriver', 'at Module.', 'at Object.Module.',
@@ -74,4 +75,22 @@ export function joinTestLogs(log1: any, log2: any): any {
     failedCount: log1.failedCount + log2.failedCount,
     specResults: (log1.specResults || []).concat(log2.specResults || [])
   };
+}
+
+/**
+ * Returns false if an error indicates a missing or stale element, re-throws
+ * the error otherwise
+ *
+ * @param {*} The error to check
+ * @throws {*} The error it was passed if it doesn't indicate a missing or stale
+ *   element
+ * @return {boolean} false, if it doesn't re-throw the error
+ */
+export function falseIfMissing(error: any) {
+  if ((error instanceof wderror.NoSuchElementError) ||
+      (error instanceof wderror.StaleElementReferenceError)) {
+    return false;
+  } else {
+    throw error;
+  }
 }


### PR DESCRIPTION
…lements

Expected conditions used `presenceOf` and `visibilityOf` to check that it's
referencing elements which actually exist on the page, but there is a race
condition with this strategy: an element could disappear after the
`presenceOf`/`visibilityOf` check but before other checks, causing an error
to be thrown.  This PR handles this race condition in two ways:

1. `ElementFinder`'s `isEnabled`, `isDisplayed`, and `isSelected` functions now
   return false if no such element exists, rahter than throwing an error
2. `ExpectedConditions`'s `textToBePresent` and `textToBePresentInElementValue`
   now check for errors and also return false in those cases

This is a general solution to the problem referenced in
https://github.com/angular/protractor/issues/3777 and
https://github.com/angular/protractor/pull/3958.

I'm assigning @juliemr, since it's a low level change, and @mgiambalvo, since we discussed this issue earlier today