### PR TITLE
feat(frameworks): Support `runner.afterEach` in jasmine and mocha ada…

### DIFF
--- a/lib/frameworks/__protractor_internal_afterEach_setup_spec.js
+++ b/lib/frameworks/__protractor_internal_afterEach_setup_spec.js
@@ -1,0 +1,10 @@
+// This is spec file is automatically added by protractor to implement our
+// `afterEach` functionality for jasmine and mocha.
+
+var hooks = require('./setupAfterEach').hooks;
+
+afterEach(function() {
+  if (hooks.afterEach) { 
+    return hooks.afterEach();
+  }
+});

--- a/lib/frameworks/jasmine.js
+++ b/lib/frameworks/jasmine.js
@@ -75,6 +75,9 @@ exports.run = function(runner, specs) {
   var reporter = new RunnerReporter(runner);
   jasmine.getEnv().addReporter(reporter);
 
+  // Add hooks for afterEach
+  require('./setupAfterEach').setup(runner, specs);
+
   // Filter specs to run based on jasmineNodeOpts.grep and jasmineNodeOpts.invert.
   jasmine.getEnv().specFilter = function(spec) {
     var grepMatch = !jasmineNodeOpts ||

--- a/lib/frameworks/mocha.js
+++ b/lib/frameworks/mocha.js
@@ -12,6 +12,9 @@ exports.run = function(runner, specs) {
   var Mocha = require('mocha'),
       mocha = new Mocha(runner.getConfig().mochaOpts);
 
+  // Add hooks for afterEach
+  require('./setupAfterEach').setup(runner, specs);
+
   var deferred = q.defer();
 
   // Mocha doesn't set up the ui until the pre-require event, so

--- a/lib/frameworks/setupAfterEach.js
+++ b/lib/frameworks/setupAfterEach.js
@@ -1,0 +1,29 @@
+/**
+ * Setup afterEach hook for jasmine/mocha tests.
+ *
+ * One of the main purposes of this file is to give `__protractor_internal_afterEach_setup_spec.js`
+ * a place to look up `runner.afterEach` at runtime without using globals.
+ * This file needs to be separate from `__protractor_internal_afterEach_setup_spec.js` so that that
+ * file is not prematurely executed.
+ */
+
+var path = require('path');
+
+// Queried by `protractor_internal_afterEach_setup_spec.js` for the `afterEach` hook
+var hooks = {
+  afterEach: null
+};
+
+exports.hooks = hooks;
+
+/**
+ * Setup `runner.afterEach` to be called after every spec. 
+ *
+ * @param {Runner} runner The current Protractor Runner.
+ * @param {Array} specs Array of Directory Path Strings.  Must be a reference to the same array
+ *   instance used by the framework
+ */
+exports.setup = function(runner, specs) {
+  hooks.afterEach = runner.afterEach.bind(runner);
+  specs.push(path.resolve(__dirname, '__protractor_internal_afterEach_setup_spec.js'));
+};

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -76,7 +76,7 @@ executor.addCommandlineTest('node built/cli.js spec/errorTest/timeoutConf.js')
       message: 'Timeout - Async callback was not invoked within timeout ' +
           'specified by jasmine.DEFAULT_TIMEOUT_INTERVAL.'
     })
-    .expectTestDuration(0, 100);
+    .expectTestDuration(0, 1000);
 
 executor.addCommandlineTest('node built/cli.js spec/errorTest/afterLaunchChangesExitCodeConf.js')
     .expectExitCode(11)


### PR DESCRIPTION
…pter

Closes https://github.com/angular/protractor/issues/3894,
https://github.com/angular/protractor/issues/3908, and
https://github.com/angular/protractor/issues/3909