### PR TITLE
chore(quitDriver): have quitDriver return a webdriver promise directly

### DIFF
--- a/lib/driverProviders/README.md
+++ b/lib/driverProviders/README.md
@@ -25,12 +25,12 @@ DriverProvider.prototype.getNewDriver
 
 /**
  * @param {webdriver.WebDriver} The driver instance to quit.
+ * @return {webdriver.promise.Promise<void>} A promise which resolves when the instance has quit
  */
 DriverProvider.prototype.quitDriver
 
 /**
- * @return {q.promise} A promise which will resolve when the environment
- *     is down.
+ * @return {q.Promise<any>} A promise which will resolve when the environment is down.
  */
 DriverProvider.prototype.teardownEnv
 

--- a/lib/driverProviders/attachSession.ts
+++ b/lib/driverProviders/attachSession.ts
@@ -4,7 +4,7 @@
  *  it down, and setting up the driver correctly.
  */
 import * as q from 'q';
-import {WebDriver} from 'selenium-webdriver';
+import {promise as wdpromise, WebDriver} from 'selenium-webdriver';
 
 import {Config} from '../config';
 import {Logger} from '../logger';
@@ -50,9 +50,7 @@ export class AttachSession extends DriverProvider {
    *
    * @public
    */
-  quitDriver(): q.Promise<WebDriver> {
-    let defer = q.defer<WebDriver>();
-    defer.resolve(null);
-    return defer.promise;
+  quitDriver(): wdpromise.Promise<void> {
+    return wdpromise.when(undefined);
   }
 }

--- a/lib/runner.ts
+++ b/lib/runner.ts
@@ -270,10 +270,9 @@ export class Runner extends EventEmitter {
    * @return {q.Promise} A promise which resolves on finish.
    * @private
    */
-  shutdown_(): q.Promise<any> {
-    return q.all(this.driverprovider_.getExistingDrivers().map((webdriver) => {
-      return this.driverprovider_.quitDriver(webdriver);
-    }));
+  shutdown_(): q.Promise<void> {
+    return DriverProvider.quitDrivers(
+        this.driverprovider_, this.driverprovider_.getExistingDrivers());
   }
 
   /**


### PR DESCRIPTION
Wrapping it in a `q` promise is blocking https://github.com/angular/protractor/issues/3899

Closes https://github.com/angular/protractor/issues/3902

Custom frameworks might not make this change but it'll be fine.  It'll only be a
problem in edge cases and they probably weren't returning the right promise
before anyway.