### PR TITLE
feat(browser): chain some promises in `lib/browser.ts` + return promi…

### DIFF
--- a/lib/clientsidescripts.js
+++ b/lib/clientsidescripts.js
@@ -109,8 +109,8 @@ function getNg1Hooks(selector, injectorPlease) {
     return {$injector: $injector, $$testability: $$testability};
   } else {
     return tryEl(document.body) ||
-        trySelector('[ng-app]') || trySelector('[ng:app]') ||
-        trySelector('[ng-controller]') || trySelector('[ng:controller]');
+        trySelector('[ng-app]') || trySelector('[ng\\:app]') ||
+        trySelector('[ng-controller]') || trySelector('[ng\\:controller]');
   }
 }
 


### PR DESCRIPTION
…se from `waitForAngularEnabled`

Minor breaking change since `waitForAngularEnabled` no longer returns a boolean

Part of angular#3904

Chaining `browser.get` has proved surprisingly complex, so I'll do that in a different PR

Also fixed a minor bug in `lib/clientsidescripts.js` while debuging