### PR TITLE
feat(debugging): Add webdriver logging and highlight delay

### DIFF
--- a/lib/bpRunner.ts
+++ b/lib/bpRunner.ts
@@ -23,6 +23,12 @@ export class BlockingProxyRunner {
         '--seleniumAddress',
         this.config.seleniumAddress,
       ];
+      if (this.config.webDriverLogDir) {
+        args.push('--logDir', this.config.webDriverLogDir);
+      }
+      if (this.config.highlightDelay) {
+        args.push('--highlightDelay', this.config.highlightDelay.toString());
+      }
       this.bpProcess = fork(BP_PATH, args, {silent: true});
       logger.info('Starting BlockingProxy with args: ' + args.toString());
       this.bpProcess

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -498,6 +498,25 @@ export interface Config {
    */
   ignoreUncaughtExceptions?: boolean;
 
+  /**
+   * If set, will create a log file in the given directory with a readable log of
+   * the webdriver commands it executes.
+   *
+   * This is an experimental feature. Enabling this will also turn on Blocking Proxy
+   * synchronization, which is also experimental.
+   */
+  webDriverLogDir?: string;
+
+  /**
+   * If set, Protractor will pause the specified amount of time (in milliseconds)
+   * before interactions with browser elements (ie, sending keys, clicking). It will
+   * also highlight the element it's about to interact with.
+   *
+   * This is an experimental feature. Enabling this will also turn on Blocking Proxy
+   * synchronization, which is also experimental.
+   */
+  highlightDelay?: number;
+
   // ---------------------------------------------------------------------------
   // ----- The test framework
   // --------------------------------------------------

--- a/lib/runner.ts
+++ b/lib/runner.ts
@@ -348,6 +348,10 @@ export class Runner extends EventEmitter {
       (wdpromise as any).USE_PROMISE_MANAGER = this.config_.SELENIUM_PROMISE_MANAGER;
     }
 
+    if (this.config_.webDriverLogDir || this.config_.highlightDelay) {
+      this.config_.useBlockingProxy = true;
+    }
+
     // 0) Wait for debugger
     return q(this.ready_)
         .then(() => {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@types/node": "^6.0.46",
     "@types/q": "^0.0.32",
     "@types/selenium-webdriver": "~2.53.39",
-    "blocking-proxy": "0.0.3",
+    "blocking-proxy": "0.0.4",
     "chalk": "^1.1.3",
     "glob": "^7.0.3",
     "jasmine": "^2.5.3",


### PR DESCRIPTION
This adds two options, both of which are implemented with Blocking
Proxy. --webDriverLogDir will create a readable log with timing
information of webdriver commands in the specified directory.

--highlightDelay will pause before clicking on elements or sending keys.
While paused, the element that's about to be affected will be
highlighted.