### PR TITLE
fix(types): Fix types for TS 2.0

### DIFF
--- a/lib/debugger.ts
+++ b/lib/debugger.ts
@@ -162,11 +162,11 @@ export class DebugHelper {
         let execFn_ = () => {
           // Run code through vm so that we can maintain a local scope which is
           // isolated from the rest of the execution.
-          let res;
+          let res: wdpromise.Promise<any>;
           try {
             res = vm_.runInContext(code, sandbox);
           } catch (e) {
-            res = 'Error while evaluating command: ' + e;
+            res = wdpromise.when('Error while evaluating command: ' + e);
           }
           if (!wdpromise.isPromise(res)) {
             res = wdpromise.when(res);

--- a/lib/element.ts
+++ b/lib/element.ts
@@ -11,7 +11,7 @@ let clientSideScripts = require('./clientsidescripts');
 let logger = new Logger('element');
 
 export class WebdriverWebElement {}
-export interface WebdriverWebElement extends WebElement {}
+export interface WebdriverWebElement extends WebElement { [key: string]: any; }
 
 let WEB_ELEMENT_FUNCTIONS = [
   'click', 'sendKeys', 'getTagName', 'getCssValue', 'getAttribute', 'getText', 'getSize',
@@ -88,7 +88,7 @@ export class ElementArrayFinder extends WebdriverWebElement {
 
     // TODO(juliemr): might it be easier to combine this with our docs and just
     // wrap each one explicity with its own documentation?
-    WEB_ELEMENT_FUNCTIONS.forEach((fnName: keyof WebdriverWebElement) => {
+    WEB_ELEMENT_FUNCTIONS.forEach((fnName: string) => {
       this[fnName] = (...args: any[]) => {
         let actionFn = (webElem: any) => {
           return webElem[fnName].apply(webElem, args);
@@ -867,7 +867,7 @@ export class ElementFinder extends WebdriverWebElement {
         this.browser_, getWebElements, elementArrayFinder.locator(),
         elementArrayFinder.actionResults_);
 
-    WEB_ELEMENT_FUNCTIONS.forEach((fnName: keyof WebdriverWebElement) => {
+    WEB_ELEMENT_FUNCTIONS.forEach((fnName: string) => {
       (this)[fnName] = (...args: any[]) => {
         return (this.elementArrayFinder_)[fnName]
             .apply(this.elementArrayFinder_, args)

--- a/lib/plugins.ts
+++ b/lib/plugins.ts
@@ -438,7 +438,7 @@ export class Plugins {
    */
   private safeCallPluginFun(
       pluginObj: ProtractorPlugin, funName: string, args: any[], promiseType: PromiseType,
-      failReturnVal: any) {
+      failReturnVal: any): q.Promise<any>|Promise<any>|webdriver.promise.Promise<any> {
     const resolver = (done: (result: any) => void) => {
       const logError = (e: any) => {
         if (this.resultsReported) {


### PR DESCRIPTION
TypeScript 2.0 has less awesome type inference than 2.1, so we need to be a little more explicit in some cases.