### PR TITLE
chore(docs): getCssValue takes param, returns RGB instead of hex

### DIFF
--- a/lib/selenium-webdriver/webdriver.js
+++ b/lib/selenium-webdriver/webdriver.js
@@ -523,18 +523,18 @@ webdriver.WebElement.prototype.getTagName = function() {};
 /**
  * Gets the computed style of an element. If the element inherits the named
  * style from its parent, the parent will be queried for its value. Where
- * possible, color values will be converted to their hex representation (e.g.
- * #00ff00 instead of rgb(0, 255, 0)).
+ * possible, color values will be converted to their rgb representation (e.g.
+ * rgba(247, 247, 247, 1) instead of #f7f7f7).
  *
  * _Warning:_ the value returned will be as the browser interprets it, so
  * it may be tricky to form a proper assertion.
  *
  * @view
- * <span style='color: #000000'>{{person.name}}</span>
+ * <span style='background-color: #f7f7f7'>{{person.name}}</span>
  *
  * @example
- * expect(element(by.binding('person.name')).getCssValue().indexOf(
- *   'color: #000000')).not.toBe(-1);
+ * expect(element(by.binding('person.name')).getCssValue('background-color')
+ *     .toEqual('rgba(247, 247, 247, 1)');
  *
  * @param {string} cssStyleProperty The name of the CSS style property to look
  *     up.


### PR DESCRIPTION
I am using v5.1.1, not sure what which point this changed