### PR TITLE
fix(cli): Correctly parse list chromeOptions

### DIFF
--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -200,6 +200,17 @@ if (argv.exclude) {
   argv.exclude = processFilePatterns_(<string>argv.exclude);
 }
 
+if (argv.capabilities && argv.capabilities.chromeOptions) {
+  // ensure that single options (which optimist parses as a string)
+  // are passed in an array in chromeOptions when required:
+  // https://sites.google.com/a/chromium.org/chromedriver/capabilities#TOC-chromeOptions-object
+  ['args', 'extensions', 'excludeSwitches', 'windowTypes'].forEach((key) => {
+    if (typeof argv.capabilities.chromeOptions[key] === 'string') {
+      argv.capabilities.chromeOptions[key] = [argv.capabilities.chromeOptions[key]];
+    }
+  });
+}
+
 // Use default configuration, if it exists.
 let configFile: string = argv._[0];
 if (!configFile) {


### PR DESCRIPTION
Chromedriver requires that certain options always be passed as an array.
Optimist passes --single-option as a string instead of an array which is
invalid. This ensures that we always pass an array, even if a single
option is passed via the cli.

Fixes #4050