### PR TITLE
chore(format): Fix formatting in browser and sauce driver provider

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,6 @@ dependencies:
   cache_directories:
     - testapp/node_modules
   post:
-    - ./node_modules/.bin/gulp lint
     - ./node_modules/.bin/webdriver-manager update
     - wget http://selenium-release.storage.googleapis.com/3.0-beta4/selenium-server-standalone-3.0.0-beta4.jar -P ./node_modules/webdriver-manager/selenium
     - ./node_modules/.bin/webdriver-manager start --versions.standalone 3.0.0-beta4:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -112,7 +112,7 @@ gulp.task('prepublish', function(done) {
 
 gulp.task('pretest', function(done) {
   runSequence('checkVersion',
-    ['webdriver:update', 'jshint', 'tslint', 'format'], 'tsc', 'built:copy', 'tsc:spec',  done);
+    ['webdriver:update', 'lint'], 'tsc', 'built:copy', 'tsc:spec',  done);
 });
 
 gulp.task('default',['prepublish']);

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@types/chalk": "^0.4.28",
     "@types/glob": "^5.0.29",
-    "@types/jasmine": "^2.5.38",
+    "@types/jasmine": "2.5.41",
     "@types/jasminewd2": "^2.0.0",
     "@types/minimatch": "^2.0.28",
     "@types/minimist": "^1.1.28",


### PR DESCRIPTION
This (hopefully) fixes the linting failures we've seen on circle (since circle [runs `gulp lint`](https://github.com/angular/protractor/blob/master/circle.yml#L15) but travis does not). There are a few different PRs where Circle is failing because of this.

I'd like to follow up with a PR that adds lint to the local test commands and Travis, but i'm a little stymied by the variations between the two and need some more time to get a handle on things. Ideally we'd have the same testing steps for each with different environmental setup. Any thoughts or pointers on the ideal situation would be welcome 😄 

Edit: how about running the [`lint`](https://github.com/angular/protractor/blob/master/gulpfile.js#L43-L45) task in `pretest`) so this is caught locally? We could then remove the explicit `gulp lint` from `circle.yml` and have it fall through the tests (we would potentially sacrifice the time spent setting up webdriver-manager and firefox if we don't fail fast)