### PR TITLE
feat(config): Allow users to modify config in beforeLaunch

### DIFF
--- a/lib/launcher.ts
+++ b/lib/launcher.ts
@@ -108,7 +108,10 @@ let initFn = function(configFile: string, additionalConfig: Config) {
 
   // Run beforeLaunch
   helper.runFilenameOrFn_(config.configDir, config.beforeLaunch)
-      .then(() => {
+      .then((configFromBeforeLaunch) => {
+        if (configFromBeforeLaunch) {
+          configParser.addConfig(configFromBeforeLaunch);
+        }
 
         return new Promise<any>((resolve: Function, reject: Function) => {
                  // 1) If getMultiCapabilities is set, resolve that as
@@ -251,7 +254,7 @@ let initFn = function(configFile: string, additionalConfig: Config) {
         let createNextTaskRunner = () => {
           let task = scheduler.nextTask();
           if (task) {
-            let taskRunner = new TaskRunner(configFile, additionalConfig, task, forkProcess);
+            let taskRunner = new TaskRunner(config, task, forkProcess);
             taskRunner.run()
                 .then((result) => {
                   if (result.exitCode && !result.failedCount) {

--- a/lib/runnerCli.ts
+++ b/lib/runnerCli.ts
@@ -3,7 +3,6 @@
  * requested by the launcher.
  */
 
-import {ConfigParser} from './configParser';
 import {Logger} from './logger';
 import {Runner} from './runner';
 
@@ -15,15 +14,7 @@ process.on('message', (m: any) => {
       if (!m.capabilities) {
         throw new Error('Run message missing capabilities');
       }
-      // Merge in config file options.
-      let configParser = new ConfigParser();
-      if (m.configFile) {
-        configParser.addFileConfig(m.configFile);
-      }
-      if (m.additionalConfig) {
-        configParser.addConfig(m.additionalConfig);
-      }
-      let config = configParser.getConfig();
+      let config = m.config;
       Logger.set(config);
 
       // Grab capabilities to run from launcher.

--- a/lib/taskRunner.ts
+++ b/lib/taskRunner.ts
@@ -21,16 +21,13 @@ export interface RunResults {
  * './runner.js') or from a new process (via './runnerCli.js').
  *
  * @constructor
- * @param {string} configFile Path of test configuration.
- * @param {object} additionalConfig Additional configuration.
+ * @param {object} config Parsed Configuration.
  * @param {object} task Task to run.
  * @param {boolean} runInFork Whether to run test in a forked process.
  * @constructor
  */
 export class TaskRunner extends EventEmitter {
-  constructor(
-      private configFile: string, private additionalConfig: Config, private task: any,
-      private runInFork: boolean) {
+  constructor(private config: Config, private task: any, private runInFork: boolean) {
     super();
   }
 
@@ -52,14 +49,7 @@ export class TaskRunner extends EventEmitter {
       specResults: []
     };
 
-    let configParser = new ConfigParser();
-    if (this.configFile) {
-      configParser.addFileConfig(this.configFile);
-    }
-    if (this.additionalConfig) {
-      configParser.addConfig(this.additionalConfig);
-    }
-    let config = configParser.getConfig();
+    let config = this.config;
     config.capabilities = this.task.capabilities;
     config.specs = this.task.specs;
 
@@ -117,8 +107,7 @@ export class TaskRunner extends EventEmitter {
 
       childProcess.send({
         command: 'run',
-        configFile: this.configFile,
-        additionalConfig: this.additionalConfig,
+        config: config,
         capabilities: this.task.capabilities,
         specs: this.task.specs
       });

--- a/spec/basic/before_launch_spec.js
+++ b/spec/basic/before_launch_spec.js
@@ -1,0 +1,8 @@
+describe('modifying config in beforeLaunch', function() {
+  it('allows a config file to set params', function() {
+    browser.get('index.html#/form');
+    var greeting = element(by.binding('greeting'));
+
+    expect(greeting.getText()).toEqual('Hiya');
+  });
+});

--- a/spec/beforeLaunchConf.js
+++ b/spec/beforeLaunchConf.js
@@ -1,0 +1,35 @@
+
+var env = require('./environment.js');
+
+exports.config = {
+  seleniumAddress: env.seleniumAddress,
+
+  framework: 'jasmine',
+
+  specs: [
+    'basic/before_launch_spec.js'
+  ],
+
+  multiCapabilities: [{
+    'browserName': 'chrome'
+  }],
+
+  beforeLaunch: function () {
+    // Any object returned from beforeLaunch will be merged
+    // with parsed configuration from this file.
+    // E.g. a user may want to start up a development server
+    // in beforeLaunch and dynamically configure `baseUrl`
+    return new Promise((resolve) => {
+      resolve({
+        baseUrl:  env.baseUrl + '/ng1/'
+      });
+    });
+  },
+
+  params: {
+    login: {
+      user: 'Jane',
+      password: '1234'
+    }
+  }
+};


### PR DESCRIPTION
This is stab at resolving some of the issues in https://github.com/angular/protractor/issues/3590

Essentially, there's no great way for users to modify the config from `beforeLaunch` when running forked through multiCapabilities.

The approach I took:

1. Removes the config file parsing from `taskRunner` and `runnerCli` and instead uses parsed configuration passed in by `launcher`
   - I don't deeply understand either of those classes, so if this is a big faux paux let me know. It seems much cleaner to me to parse once but there may be gotchas.
2. Allow users to merge additional options onto `config` by resolving the promise returned from `beforeLaunch` with an object
     - right now I'm doing a very simple truthy check, I don't know of a way of expressing `if (configFromBeforeLaunch typeof Config)` at runtime :|
        - I'd be happy to more explicitly check for an object here

The following specs were failing for me locally:

- `spec/onPrepare/onPrepare_spec.js`
  - this also fails on `master` locally but could very well be me
- `spec/basic/polling_spec.js`
  - seems environmental as well
