### PR TITLE
chore(examples): Fix TSC issues with exampleTypescript

### DIFF
--- a/exampleTypescript/package.json
+++ b/exampleTypescript/package.json
@@ -10,7 +10,7 @@
     "test": "protractor tmp/conf.js"
   },
   "dependencies": {
-    "@types/jasmine": "^2.5.38",
+    "@types/jasmine": "2.5.41",
     "@types/jasminewd2": "^2.0.0",
     "jasmine": "^2.4.1",
     "protractor": "file:../",

--- a/exampleTypescript/tsconfig.json
+++ b/exampleTypescript/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "module": "commonjs",
     "moduleResolution": "node",
     "sourceMap": false,


### PR DESCRIPTION
This makes some small updates to TS config and TS related deps to allow compilation with the version of TS installed by the example.

I'm still familiarizing myself with the TS ecosystem and the way things should be done, so please let me know if there's a convention that I've missed here.


Issues Resolved
---

Jasmine typing issues (see https://github.com/DefinitelyTyped/DefinitelyTyped/issues/14569 for more details), Pinning the jasmine typings prevents the following compilation error:

```shell
typescript-example-updates ᎒ npm run tsc

> example-typescript@1.0.0 tsc /Users/ntomlin/workspace/protractor/exampleTypescript
> tsc

node_modules/@types/jasmine/index.d.ts(39,52): error TS1005: '=' expected.

npm ERR! Darwin 16.4.0
```

We could also resolve this by pinning the typescript depedency of the example to `^2.2.0`


Missing `Promise` definitions. Updating the target to es6 (which seems sane to me since we are now node 6+) prevents issues with Promise typings:

```shell
> example-typescript@1.0.0 tsc /Users/ntomlin/workspace/protractor/exampleTypescript
> tsc

node_modules/@types/jasminewd2/index.d.ts(9,60): error TS2304: Cannot find name 'Promise'.
node_modules/@types/jasminewd2/index.d.ts(10,61): error TS2304: Cannot find name 'Promise'.
node_modules/@types/jasminewd2/index.d.ts(11,61): error TS2304: Cannot find name 'Promise'.
node_modules/@types/jasminewd2/index.d.ts(12,43): error TS2304: Cannot find name 'Promise'.
node_modules/@types/jasminewd2/index.d.ts(13,42): error TS2304: Cannot find name 'Promise'.
node_modules/@types/jasminewd2/index.d.ts(14,42): error TS2304: Cannot find name 'Promise'.
node_modules/@types/jasminewd2/index.d.ts(15,41): error TS2304: Cannot find name 'Promise'.
node_modules/blocking-proxy/built/lib/angular_wait_barrier.d.ts(43,43): error TS2304: Cannot find name 'Promise'
```
