### PR TITLE
fix(navigation): ignore unknown JS errors in IE

### DIFF
--- a/lib/browser.ts
+++ b/lib/browser.ts
@@ -900,7 +900,7 @@ export class ProtractorBrowser extends AbstractExtendedWebDriver {
                       return url !== this.resetUrl;
                     },
                     (err: IError) => {
-                      if (err.code == 13) {
+                      if (err.code == 13 || err.name === 'JavascriptError') {
                         // Ignore the error, and continue trying. This is
                         // because IE driver sometimes (~1%) will throw an
                         // unknown error from this execution. See


### PR DESCRIPTION
The `err` object doesn't have the `code` property any more (Selenium Server Standalone 3.3.1 + IEDriver win32 3.3.0), so we need a new way to detect those errors. See #841