### PR TITLE
docs(browser.wait): add default browser.wait default

### DIFF
--- a/lib/selenium-webdriver/webdriver.js
+++ b/lib/selenium-webdriver/webdriver.js
@@ -277,7 +277,7 @@ webdriver.WebDriver.prototype.call = function(fn, opt_scope, var_args) {};
  *           function(!webdriver.WebDriver): T)} condition The condition to
  *     wait on, defined as a promise, condition object, or  a function to
  *     evaluate as a condition.
- * @param {number=} opt_timeout How long to wait for the condition to be true.
+ * @param {number=} opt_timeout How long to wait for the condition to be true. Will default 30 seconds, or to the jasmineNodeOpts.defaultTimeoutInterval in your protractor.conf.js file.
  * @param {string=} opt_message An optional message to use if the wait times
  *     out.
  * @returns {!webdriver.promise.Promise<T>} A promise that will be fulfilled


### PR DESCRIPTION
There's a bit of confusion about the default behavior of the second parameter for the `browser.wait` function (e.g. https://github.com/angular/protractor/issues/2253). Adding this info to the docs might clear that up

```
browser.wait(EC.textToBePresentInElement($('#foo'), 'Example words'), 5000); // 5 seconds
browser.wait(EC.textToBePresentInElement($('#foo'), 'Example words')); // 30 seconds
```
default time comes from an optional param in user's `protractor.conf.js` file
```
jasmineNodeOpts: {
  defaultTimeoutInterval: 30000
}
```

which falls back to the default set in  `lib/configParser.ts` if not set:
```
jasmineNodeOpts: {showColors: true, defaultTimeoutInterval: (30 * 1000)},
```
https://github.com/angular/protractor/blob/bc583321a233453fc2b89472013b2ec3e1d6b6f9/lib/configParser.ts#L37