### PR TITLE
Async driver creation & retry mechanism for driver creation

### DIFF
--- a/lib/browser.ts
+++ b/lib/browser.ts
@@ -474,6 +474,22 @@ export class ProtractorBrowser extends AbstractExtendedWebDriver {
   }
 
   /**
+   * Same as forkNewDriverInstance just asynchronously
+   * 
+   * @param {boolean=} useSameUrl Whether to navigate to current url on creation
+   * @param {boolean=} copyMockModules Whether to apply same mock modules on creation
+   * @param {boolean=} copyConfigUpdates Whether to copy over changes to `baseUrl` and similar
+   *   properties initialized to values in the the config.  Defaults to `true`
+   *
+   * @returns {Promise<ProtractorBrowser>} A browser instance.
+   */
+  forkNewDriverInstanceAsync(
+      useSameUrl?: boolean, copyMockModules?: boolean,
+      copyConfigUpdates = true): Promise<ProtractorBrowser> {
+    return null;
+  }
+
+  /**
    * Restart the browser.  This is done by closing this browser instance and creating a new one.
    * A promise resolving to the new instance is returned, and if this function was called on the
    * global `browser` instance then Protractor will automatically overwrite the global `browser`
@@ -1046,8 +1062,8 @@ export class ProtractorBrowser extends AbstractExtendedWebDriver {
                         clientSideScripts.setLocation, 'Protractor.setLocation()', rootEl, url)
                     .then((browserErr: Error) => {
                       if (browserErr) {
-                        throw 'Error while navigating to \'' + url + '\' : ' +
-                            JSON.stringify(browserErr);
+                        throw 'Error while navigating to \'' + url +
+                            '\' : ' + JSON.stringify(browserErr);
                       }
                     }));
   }

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -353,7 +353,7 @@ export interface Config {
   /**
    * Use this option with createBrowserAsync: true, enables to queuing real devices
    * or retry create driver on driver creation failure.
-   * 
+   *
    * example:
    * retryMechanismConf: {
    *    enabled: true, // enable retry driver creation

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -344,6 +344,25 @@ export interface Config {
    */
   verboseMultiSessions?: boolean;
 
+  /**
+   * Choose wether or not to create protractor browser asynchronously.
+   * In practicular this option must be enabled in order to use the queuing mechanism.
+   */
+  createBrowserAsync?: boolean;
+
+  /**
+   * Use this option with createBrowserAsync: true, enables to queuing real devices
+   * or retry create driver on driver creation failure.
+   * 
+   * example:
+   * retryMechanismConf: {
+   *    enabled: true, // enable retry driver creation
+   *    retries: 3, // times to retry
+   *    delay: 50000 // delay between each retry
+   * }
+   */
+  retryMechanismConf?: any;
+
   // ---------------------------------------------------------------------------
   // ----- Global test information
   // ---------------------------------------------

--- a/lib/driverProviders/sauce.ts
+++ b/lib/driverProviders/sauce.ts
@@ -64,9 +64,9 @@ export class Sauce extends DriverProvider {
     this.config_.capabilities['accessKey'] = this.config_.sauceKey;
     this.config_.capabilities['build'] = this.config_.sauceBuild;
     let auth = 'https://' + this.config_.sauceUser + ':' + this.config_.sauceKey + '@';
-    this.config_.seleniumAddress =
-        auth + (this.config_.sauceSeleniumAddress ? this.config_.sauceSeleniumAddress :
-                                                    'ondemand.saucelabs.com:443/wd/hub');
+    this.config_.seleniumAddress = auth +
+        (this.config_.sauceSeleniumAddress ? this.config_.sauceSeleniumAddress :
+                                             'ondemand.saucelabs.com:443/wd/hub');
 
     // Append filename to capabilities.name so that it's easier to identify
     // tests.


### PR DESCRIPTION
Please see: 
https://github.com/angular/protractor/issues/4110

Added a retry mechanism for driver creation.
For users who uses cloud providers such as Perfecto, Sauce labs, etc ... or for local usage.

There's 2 new configurations:
1. createBrowserAsync  - true / false, this option enable/disable async driver creation.
2. retryMechanismConf - enable/disable retry mechanism, set the number of retries and delay between each retry.

Using this 2 configuration the user will be able to make a retry in case driver creation failed. 

Passed local tests (npm test)