### PR TITLE
fix: Add "verbose" option to allowedNames in cli.ts

### DIFF
--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -60,6 +60,7 @@ let allowedNames = [
   'multiCapabilities',
   'getMultiCapabilities',
   'maxSessions',
+  'verbose',
   'verboseMultiSessions',
   'baseUrl',
   'rootElement',


### PR DESCRIPTION
This fixes #4196. Verbose was part of the help text in [`describes`](https://github.com/angular/protractor/blob/master/lib/cli.ts#L110) but not in `allowedNames`