### PR TITLE
fix: Add "stackTrace" option to allowedNames in cli.ts

### DIFF
--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -104,7 +104,8 @@ let allowedNames = [
   'build',
   'grep',
   'invert-grep',
-  'explorer'
+  'explorer',
+  'stackTrace'
 ];
 
 let optimistOptions: any = {


### PR DESCRIPTION
This fixes a problem I encountered similar to #4196 - where `stackTrace` is listed as an option but an error is given saying it's an "unknown extra flag"