### PR TITLE
feat(saucelabs): Add Sauce Labs protocol customization support

### DIFF
--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -46,6 +46,7 @@ let allowedNames = [
   'sauceKey',
   'sauceAgent',
   'sauceBuild',
+  'sauceSeleniumUseHttp',
   'sauceSeleniumAddress',
   'browserstackUser',
   'browserstackKey',

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -137,6 +137,13 @@ export interface Config {
    */
   sauceBuild?: string;
   /**
+   * If true, Protractor will use http:// protocol instead of https:// to
+   * connect to Sauce Labs defined by sauceSeleniumAddress.
+   *
+   * default: false
+   */
+  sauceSeleniumUseHttp?: boolean;
+  /**
    * Use sauceSeleniumAddress if you need to customize the URL Protractor
    * uses to connect to sauce labs (for example, if you are tunneling selenium
    * traffic through a sauce connect tunnel). Default is

--- a/lib/driverProviders/sauce.ts
+++ b/lib/driverProviders/sauce.ts
@@ -63,7 +63,8 @@ export class Sauce extends DriverProvider {
     this.config_.capabilities['username'] = this.config_.sauceUser;
     this.config_.capabilities['accessKey'] = this.config_.sauceKey;
     this.config_.capabilities['build'] = this.config_.sauceBuild;
-    let auth = 'https://' + this.config_.sauceUser + ':' + this.config_.sauceKey + '@';
+    let protocol = this.config_.sauceSeleniumUseHttp ? 'http://' : 'https://';
+    let auth = protocol + this.config_.sauceUser + ':' + this.config_.sauceKey + '@';
     this.config_.seleniumAddress = auth +
         (this.config_.sauceSeleniumAddress ? this.config_.sauceSeleniumAddress :
                                              'ondemand.saucelabs.com:443/wd/hub');


### PR DESCRIPTION
Sauce Connect Proxy listens on 4445 port by default for Selenium communications and always uses HTTP protocol instead of HTTPS. It's not rare to run Sauce Connect Proxy locally or inside private network meaning we're forced to use HTTP and `sauceSeleniumAddressProtocol` is the way to customize which protocol to use.

P.S. In case there are no objections, it'd be nice to have a patch release otherwise we're stuck with dirty looking monkey-patching.