### PR TITLE
fix(browser): Fix angularAppRoot() to return a promise

### DIFF
--- a/lib/browser.ts
+++ b/lib/browser.ts
@@ -209,6 +209,7 @@ export class ProtractorBrowser extends AbstractExtendedWebDriver {
           return this.internalRootEl;
         });
       }
+      return wdpromise.when(this.internalRootEl);
     }, `Set angular root selector to ${value}`);
   }
 


### PR DESCRIPTION
By default, it wasn't returning anything. Now it returns a promise that
resolves to internalAngularAppRoot. Fixes #4233