### PR TITLE
fix(elementexplorer): Use cross-platform safe regexps when setting breakpoints

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -19,7 +19,9 @@ dependencies:
     - cd testapp && npm update
     - npm start:
           background: true
+    - sudo apt-get update
     # Install the latest Firefox beta
+    - pip install --upgrade pip
     - pip install mozdownload mozinstall
     - mozdownload --version latest --destination firefox.tar.bz2
     - mozinstall firefox.tar.bz2

--- a/lib/debugger/debuggerCommons.js
+++ b/lib/debugger/debuggerCommons.js
@@ -1,4 +1,5 @@
 var baseDebugger = require('_debugger');
+var path = require('path');
 
 /**
  * Create a debugger client and attach to a running protractor process.
@@ -34,11 +35,13 @@ exports.attachDebugger = function(pid, opt_port) {
 
 /**
  * Set a breakpoint for evaluating REPL statements.
+ * This sets a breakpoint in Protractor's breakpointhook.js, so that we'll
+ * break after executing a command from the REPL.
  */
 exports.setEvaluateBreakpoint = function(client, cb) {
   client.setBreakpoint({
     type: 'scriptRegExp',
-    target: 'built/breakpointhook\.js', //jshint ignore:line
+    target: prepareDebuggerPath('built', 'breakpointhook.js'),
     line: 2
   }, function(err, response) {
     if (err) {
@@ -50,11 +53,18 @@ exports.setEvaluateBreakpoint = function(client, cb) {
 
 /**
  * Set a breakpoint for moving forward by one webdriver command.
+ * This sets a breakpoint in selenium-webdriver/lib/http.js, and is
+ * extremely sensitive to the selenium version. It works for
+ * selenium-webdriver 3.0.1
+ * This breaks on the following line in http.js:
+ *      let request = buildRequest(this.customCommands_, this.w3c, command);
+ * And will need to break at a similar point in future selenium-webdriver
+ * versions.
  */
 exports.setWebDriverCommandBreakpoint = function(client, cb) {
   client.setBreakpoint({
     type: 'scriptRegExp',
-    target: 'lib/http\.js', //jshint ignore:line
+    target: prepareDebuggerPath('lib', 'http.js'),
     line: 433
   }, function(err, response) {
     if (err) {
@@ -63,6 +73,15 @@ exports.setWebDriverCommandBreakpoint = function(client, cb) {
     cb(response.breakpoint);
   });
 };
+
+/**
+ * Create a cross-platform friendly path for setting scriptRegExp breakpoints.
+ */
+function prepareDebuggerPath(...parts) {
+  return path.join(...parts)
+    .replace('\\', '\\\\')
+    .replace('.', '\\.');
+}
 
 /**
  * Trim excess symbols from the repl command so that it is consistent with

--- a/package.json
+++ b/package.json
@@ -19,14 +19,14 @@
     "chalk": "^1.1.3",
     "glob": "^7.0.3",
     "jasmine": "^2.5.3",
-    "jasminewd2": "^2.0.0",
+    "jasminewd2": "^2.1.0",
     "optimist": "~0.6.0",
     "q": "1.4.1",
     "saucelabs": "~1.3.0",
     "selenium-webdriver": "3.0.1",
     "source-map-support": "~0.4.0",
     "webdriver-js-extender": "^1.0.0",
-    "webdriver-manager": "^12.0.1"
+    "webdriver-manager": "^12.0.6"
   },
   "devDependencies": {
     "@types/chalk": "^0.4.28",


### PR DESCRIPTION
Fixes #4011