### PR TITLE
Typings for By.js locator should accept function arguments

### DIFF
--- a/lib/locators.ts
+++ b/lib/locators.ts
@@ -10,7 +10,7 @@ export class WebdriverBy {
   css: (css: string) => By = By.css;
   id: (id: string) => By = By.id;
   linkText: (linkText: string) => By = By.linkText;
-  js: (js: string | Function, ...var_args: any[]) => By = By.js;
+  js: (js: string|Function, ...var_args: any[]) => By = By.js;
   name: (name: string) => By = By.name;
   partialLinkText: (partialText: string) => By = By.partialLinkText;
   tagName: (tagName: string) => By = By.tagName;

--- a/lib/locators.ts
+++ b/lib/locators.ts
@@ -10,7 +10,7 @@ export class WebdriverBy {
   css: (css: string) => By = By.css;
   id: (id: string) => By = By.id;
   linkText: (linkText: string) => By = By.linkText;
-  js: (js: string) => By = By.js;
+  js: (js: string | Function, ...var_args: any[]) => By = By.js;
   name: (name: string) => By = By.name;
   partialLinkText: (partialText: string) => By = By.partialLinkText;
   tagName: (tagName: string) => By = By.tagName;


### PR DESCRIPTION
The Protractor documentation says that By.js is inherited from Selenium Webdriver, and the types for that define the function signature for `js` like I have done in this PR.

https://github.com/SeleniumHQ/selenium/blob/master/javascript/node/selenium-webdriver/lib/by.js#L183

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/selenium-webdriver/index.d.ts#L2441