### PR TITLE
docs(browser-support): Fixed incorrect example

### DIFF
--- a/docs/browser-setup.md
+++ b/docs/browser-setup.md
@@ -134,7 +134,7 @@ capabilities: {
   browserName: 'chrome',
 
   chromeOptions: {
-     args: [ "--headless", "--disable-gpu", "--window-size=800x600" ]
+     args: [ "--headless", "--disable-gpu", "--window-size=800,600" ]
    }
 }
 ```


### PR DESCRIPTION
Fixed incorrect example of setting window size with headless Chrome. When `800x600` is used it is ignored. The correct syntax is `800,600`.