### PR TITLE
Incompatibility with node 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Protractor [![Build Status](https://travis-ci.org/angular/protractor.svg?branch=
 Compatibility
 -------------
 
-Protractor 5 is compatible with nodejs v6 and newer.
+Protractor 5 is compatible with nodejs v6 and v7, but having compatibility issues with v8.
 
 Protractor works with AngularJS versions greater than 1.0.6/1.1.4, and is compatible with Angular applications. Note that for Angular apps, the `binding` and `model` locators are not supported. We recommend using `by.css`.
 

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   },
   "license": "MIT",
   "engines": {
-    "node": ">=6.9.x"
+    "node": ">=6.9.x <8"
   },
   "version": "5.1.2"
 }


### PR DESCRIPTION
Fixing the element explorer with node8 won't be trivial - until then it worth to mention in the readme that protractor not working with the newest node version well.

https://github.com/angular/protractor/issues/4307