### PR TITLE
docs(website): fix issue 4246

### DIFF
--- a/lib/selenium-webdriver/webdriver.js
+++ b/lib/selenium-webdriver/webdriver.js
@@ -533,8 +533,7 @@ webdriver.WebElement.prototype.getTagName = function() {};
  * <span style='color: #000000'>{{person.name}}</span>
  *
  * @example
- * expect(element(by.binding('person.name')).getCssValue().indexOf(
- *   'color: #000000')).not.toBe(-1);
+ * expect(element(by.binding('person.name')).getCssValue('color')).toBe('#000000');
  *
  * @param {string} cssStyleProperty The name of the CSS style property to look
  *     up.


### PR DESCRIPTION
This PR fixes the incorrect example in http://www.protractortest.org/#/api?view=webdriver.WebElement.prototype.getCssValue and is related to https://github.com/angular/protractor/issues/4246