### PR TITLE
fix(blockingproxy): don't pass "--inspect" to the child process

### DIFF
--- a/lib/bpRunner.ts
+++ b/lib/bpRunner.ts
@@ -29,7 +29,11 @@ export class BlockingProxyRunner {
       if (this.config.highlightDelay) {
         args.push('--highlightDelay', this.config.highlightDelay.toString());
       }
-      this.bpProcess = fork(BP_PATH, args, {silent: true});
+
+      // Prevent BP process from trying to allocate the same port for inspector as the main process
+      let execArgv = process.execArgv.filter(arg => !/^(--inspect|--debug)(-brk)?(?!=0)/.test(arg));
+
+      this.bpProcess = fork(BP_PATH, args, {execArgv, silent: true});
       logger.info('Starting BlockingProxy with args: ' + args.toString());
       this.bpProcess
           .on('message',

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -33,6 +33,7 @@ var passingTests = [
   'node built/cli.js spec/restartBrowserBetweenTestsConf.js',
   'node built/cli.js spec/driverProviderLocalConf.js',
   'node built/cli.js spec/driverProviderLocalConf.js --useBlockingProxy',
+  'node --inspect built/cli.js spec/driverProviderLocalConf.js --useBlockingProxy',
   'node built/cli.js spec/getCapabilitiesConf.js',
   'node built/cli.js spec/controlLockConf.js',
   'node built/cli.js spec/customFramework.js',


### PR DESCRIPTION
If Protractor is started with `--inspect[-brk]`, `child_process.fork`
will create a BlockingProxy process with the same argument, and that
will lead to "address already in use" error.