### PR TITLE
fix: fix all locator examples

### DIFF
--- a/lib/selenium-webdriver/locators.js
+++ b/lib/selenium-webdriver/locators.js
@@ -25,7 +25,7 @@ webdriver.By = {};
  *
  * @example
  * // Returns the web element for dog
- * var dog = browser.findElement(by.className('dog'));
+ * var dog = element(by.className('dog'));
  * expect(dog.getText()).toBe('Dog');
  *
  * @param {string} className The class name to search for.
@@ -50,7 +50,7 @@ webdriver.By.className = webdriver.Locator.factory_('class name');
  *
  * @example
  * // Returns the web element for cat
- * var cat = browser.findElement(by.css('.pet .cat'));
+ * var cat = element(by.css('.pet .cat'));
  * expect(cat.getText()).toBe('Cat');
  *
  * @param {string} selector The CSS selector to use.
@@ -71,7 +71,7 @@ webdriver.By.css = webdriver.Locator.factory_('css selector');
  *
  * @example
  * // Returns the web element for dog
- * var dog = browser.findElement(by.id('dog_id'));
+ * var dog = element(by.id('dog_id'));
  * expect(dog.getText()).toBe('Dog');
  *
  * @param {string} id The ID to search for.
@@ -140,7 +140,7 @@ webdriver.By.js = function(script, var_args) {};
  *
  * @example
  * // Returns the web element for dog
- * var dog = browser.findElement(by.name('dog_name'));
+ * var dog = element(by.name('dog_name'));
  * expect(dog.getText()).toBe('Dog');
  *
  * @param {string} name The name attribute to search for.
@@ -161,7 +161,7 @@ webdriver.By.name = webdriver.Locator.factory_('name');
  *
  * @example
  * // Returns the 'a' web element for doge meme and navigate to that link
- * var doge = browser.findElement(by.partialLinkText('Doge'));
+ * var doge = element(by.partialLinkText('Doge'));
  * doge.click();
  *
  * @param {string} text The substring to check for in a link's visible text.
@@ -206,7 +206,7 @@ webdriver.By.tagName = webdriver.Locator.factory_('tag name');
  *
  * @example
  * // Returns the 'a' element for doge meme
- * var li = browser.findElement(by.xpath('//ul/li/a'));
+ * var li = element(by.xpath('//ul/li/a'));
  * expect(li.getText()).toBe('Doge meme');
  *
  * @param {string} xpath The XPath selector to use.


### PR DESCRIPTION
replaced all `browser.findElement(..)` for `element(..)` to make the API documentation more consistent