### PR TITLE
fix(sauce): bring back sauceProxy as a configuration option

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -97,9 +97,14 @@ export interface Config {
    */
   seleniumSessionId?: string;
   /**
-   * The address of a proxy server to use for the connection to the
-   * Selenium Server. If not specified no proxy is configured. Looks like
-   * webDriverProxy: 'http://localhost:3128'
+   * The address of a proxy server to use for communicating to Sauce Labs rest APIs via the
+   * saucelabs node module. For example, the Sauce Labs Proxy can be setup with: sauceProxy:
+   * 'http://localhost:3128'
+   */
+  sauceProxy?: string;
+
+  /**
+   * The proxy address that browser traffic will go through which is tied to the browser session.
    */
   webDriverProxy?: string;
 

--- a/lib/driverProviders/sauce.ts
+++ b/lib/driverProviders/sauce.ts
@@ -58,7 +58,7 @@ export class Sauce extends DriverProvider {
       username: this.config_.sauceUser,
       password: this.config_.sauceKey,
       agent: this.config_.sauceAgent,
-      proxy: this.config_.webDriverProxy
+      proxy: this.config_.sauceProxy
     });
     this.config_.capabilities['username'] = this.config_.sauceUser;
     this.config_.capabilities['accessKey'] = this.config_.sauceKey;


### PR DESCRIPTION
Reverts the change to PR #3868. Protractor should connect to Sauce Labs
via the sauceProxy. This is different than the webDriverProxy. The
webDriverProxy is tied to the browser session where we define where the
traffic will go through.

closes #4405