### PR TITLE
docs(plugins): improve wording

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -7,7 +7,7 @@ execution to gather more data and potentially modify the test output.
 The Protractor API and available plugins are *BETA* and may change
 without a major version bump.
 
-##In this document:
+## Table of contents
 * [Using Plugins](/docs/plugins.md#using-plugins)
 * [Writing Plugins](/docs/plugins.md#writing-plugins)
 * [First Party Plugins](/docs/plugins.md#first-party-plugins)

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -121,37 +121,29 @@ First Party Plugins
 * Accessibility Plugin
 
   The accessibility plugin runs a set of accessibility audits on your webapp.
-  It is published at the npm module [`protractor-accessibility-plugin`]
-  (https://www.npmjs.com/package/protractor-accessibility-plugin) and stored at
-  the github repo [angular/protractor-accessibility-plugin]
-  (https://github.com/angular/protractor-accessibility-plugin).
+  It is published at the npm module [`protractor-accessibility-plugin`](https://www.npmjs.com/package/protractor-accessibility-plugin) and stored at
+  the github repo [angular/protractor-accessibility-plugin](https://github.com/angular/protractor-accessibility-plugin).
 
 * Timeline Plugin
 
   The timeline plugin gathers test timeline information from various sources and
   presents the output visually.  This improves understanding of where latency
   issues are in tests.  It is published at the npm module
-  [`protractor-timeline-plugin`]
-  (https://www.npmjs.com/package/protractor-timeline-plugin) and stored at the
-  github repo [angular/protractor-timeline-plugin]
-  (https://github.com/angular/protractor-timeline-plugin).
+  [`protractor-timeline-plugin`](https://www.npmjs.com/package/protractor-timeline-plugin) and stored at the
+  github repo [angular/protractor-timeline-plugin](https://github.com/angular/protractor-timeline-plugin).
 
 * Console Plugin (Chrome Only)
 
   The console plugin checks the browser log after each test for warnings and
-  errors.  It is published at the npm module [`protractor-console-plugin`]
-  (https://www.npmjs.com/package/protractor-console-plugin) and stored at the
-  github repo [angular/protractor-console-plugin]
-  (https://github.com/angular/protractor-console-plugin).
+  errors.  It is published at the npm module [`protractor-console-plugin`](https://www.npmjs.com/package/protractor-console-plugin) and stored at the
+  github repo [angular/protractor-console-plugin](https://github.com/angular/protractor-console-plugin).
 
 * ngHint Plugin (NOT MAINTAINED)
 
   The ngHint plugin uses [Angular Hint](https://github.com/angular/angular-hint)
   to generate run-time hinting and then turns these hints into Protractor tests.
-  It is published at the npm module [`protractor-ng-hint-plugin`]
-  (https://www.npmjs.com/package/protractor-ng-hint-plugin) and stored at the
-  github repo [angular/protractor-ng-hint-plugin]
-  (https://github.com/angular/protractor-ng-hint-plugin).
+  It is published at the npm module [`protractor-ng-hint-plugin`](https://www.npmjs.com/package/protractor-ng-hint-plugin) and stored at the
+  github repo [angular/protractor-ng-hint-plugin](https://github.com/angular/protractor-ng-hint-plugin).
 
 Community Plugins
 -----------------
@@ -166,4 +158,4 @@ plugins please report them to the corresponding plugin developer.
 
 * [protractor-numerator](https://github.com/Marketionist/protractor-numerator): This plugin gives you readable functions for getting elements by their numbers inside Protractor tests. Adds functions like `.second()`, `.third()`, etc. instead of `.get(1)`, `.get(2)`, etc.
 
-* [Ng-apimock](https://github.com/mdasberg/ng-apimock): this plugin adds the ability to use scenario based api mocking for local development and protractor testing for both AngularJS 1 and 2 applications.
+* [Ng-apimock](https://github.com/mdasberg/ng-apimock): this plugin adds the ability to use scenario based api mocking for local development and protractor testing for both AngularJS and Angular applications.


### PR DESCRIPTION
Actually a whitespace was missing, but I also thought that `Table of contents` would suite better.