### PR TITLE
added SELENIUM_PROMISE_MANAGER to the acceptable cli arguments

### DIFF
--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -106,7 +106,8 @@ let allowedNames = [
   'grep',
   'invert-grep',
   'explorer',
-  'stackTrace'
+  'stackTrace',
+  'SELENIUM_PROMISE_MANAGER'
 ];
 
 let optimistOptions: any = {


### PR DESCRIPTION
This is to enable refactoring tests on a spec-file basis to utilize SELENIUM_PROMISE_MANAGER without having to duplicate the protractor.conf file.