### PR TITLE
Corrected compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Protractor [![Build Status](https://travis-ci.org/angular/protractor.svg?branch=
 Compatibility
 -------------
 
-Protractor 5 is compatible with nodejs v6 and newer.
+Protractor 5 is compatible with nodejs v6 and v7.
 
 Protractor works with AngularJS versions greater than 1.0.6/1.1.4, and is compatible with Angular applications. Note that for Angular apps, the `binding` and `model` locators are not supported. We recommend using `by.css`.
 


### PR DESCRIPTION
Updated compatibility to reflect removal of `_debugger` which will break protractor for node v8 when using `browser.pause()`