### PR TITLE
fix(frameworks): make mocha globals available on onPrepare, similarly to how it works on other frameworks

### DIFF
--- a/lib/frameworks/mocha.js
+++ b/lib/frameworks/mocha.js
@@ -75,13 +75,13 @@ exports.run = function(runner, specs) {
     }
   });
 
+  specs.forEach(function(file) {
+    mocha.addFile(file);
+  });
+
   mocha.loadFiles();
 
   runner.runTestPreparer().then(function() {
-    specs.forEach(function(file) {
-      mocha.addFile(file);
-    });
-
     var testResult = [];
 
     var mochaRunner = mocha.run(function(failures) {


### PR DESCRIPTION
Mocha globals are not available when `onPrepare` is run. This prevents proper setup using `before`, `after` or other Mocha globals.

Mocha's `loadFiles()` method makes its globals available if any test files have been added. Calling `loadFiles()` before adding any test files is noop ([see here](https://github.com/angular/protractor/blob/master/lib/frameworks/mocha.js#L78), [and here](https://github.com/mochajs/mocha/blob/master/lib/mocha.js#L225)).

This change adds the test files **before** calling `mocha.loadFiles()` so it actually loads files, and thus, making these globals available during `onPrepare` and matching the way `mocha` works to other frameworks.

This change is backward compatible and matches the way other frameworks work within `Protractor`.