### PR TITLE
fix(frameworks) specFilter should return false if spec not in filter

### DIFF
--- a/lib/frameworks/jasmine.js
+++ b/lib/frameworks/jasmine.js
@@ -86,6 +86,7 @@ exports.run = function(runner, specs) {
     var invertGrep = !!(jasmineNodeOpts && jasmineNodeOpts.invertGrep);
     if (grepMatch == invertGrep) {
       spec.pend();
+      return false;
     }
     return true;
   };


### PR DESCRIPTION
We override jasmine.env.specFilter function in protractor but it will always returns true while jasmine's implementation returns true or false:

```
this.env.specFilter = function(spec) {
  return specFilter.matches(spec.getFullName());
};
```

This is to resolve:
https://github.com/angular/protractor/issues/3952