### PR TITLE
Firefox 52+ not supporting directConnect

### DIFF
--- a/docs/server-setup.md
+++ b/docs/server-setup.md
@@ -87,7 +87,7 @@ You can optionally set the `name` property in a capability in order to give the 
 Connecting Directly to Browser Drivers
 --------------------------------------
 
-Protractor can test directly against Chrome and Firefox without using a Selenium Server. To use this, in your config file set `directConnect: true`.
+Protractor can test directly against Chrome and Firefox(below version 51) without using a Selenium Server. To use this, in your config file set `directConnect: true`.
 
  - `directConnect: true` -  Your test script communicates directly Chrome Driver or Firefox Driver, bypassing any Selenium Server. If this is true, settings for `seleniumAddress` and `seleniumServerJar` will be ignored. If you attempt to use a browser other than Chrome or Firefox an error will be thrown.
 


### PR DESCRIPTION
Tried running directConnect in firefox 56 and got "unable to parse new session response." error. directConnect not working with FF 52+ and Protractor 5.1.1+. 

Reff: https://github.com/angular/protractor/issues/4253