### PR TITLE
chore(release): update selenium-webdriverjs and bump version number

### DIFF
--- a/lib/runner.ts
+++ b/lib/runner.ts
@@ -278,7 +278,8 @@ export class Runner extends EventEmitter {
               return browser_.waitForAngularEnabled(initProperties.waitForAngularEnabled);
             })
             .then(() => {
-              return driver.manage().timeouts().setScriptTimeout(initProperties.allScriptsTimeout);
+              return driver.manage().timeouts().setScriptTimeout(
+                  initProperties.allScriptsTimeout || 0);
             })
             .then(() => {
               return browser_;

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "optimist": "~0.6.0",
     "q": "1.4.1",
     "saucelabs": "~1.3.0",
-    "selenium-webdriver": "3.0.1",
+    "selenium-webdriver": "3.6.0",
     "source-map-support": "~0.4.0",
     "webdriver-js-extender": "^1.0.0",
     "webdriver-manager": "^12.0.6"
@@ -81,5 +81,5 @@
   "engines": {
     "node": ">=6.9.x"
   },
-  "version": "5.1.2"
+  "version": "5.2.0"
 }


### PR DESCRIPTION
1.Update selenium-webdriverjs and bump version number
2.Solve compatibility problem: new webdriver has a more strict method when setting script timeout. If no script timeout was specified, set timeout to 0.