### PR TITLE
fix(element): correct typing of method map()

### DIFF
--- a/lib/element.ts
+++ b/lib/element.ts
@@ -650,10 +650,10 @@ export class ElementArrayFinder extends WebdriverWebElement {
    * @returns {!webdriver.promise.Promise} A promise that resolves to an array
    *     of values returned by the map function.
    */
-  map<T>(mapFn: (elementFinder?: ElementFinder, index?: number) => T | any):
+  map<T>(mapFn: (elementFinder: ElementFinder, index: number) => T | any):
       wdpromise.Promise<T[]> {
     return this.asElementFinders_().then<T[]>((arr: ElementFinder[]) => {
-      let list = arr.map((elementFinder?: ElementFinder, index?: number) => {
+      let list = arr.map((elementFinder: ElementFinder, index: number) => {
         let mapResult = mapFn(elementFinder, index);
         // All nested arrays and objects will also be fully resolved.
         return wdpromise.fullyResolved(mapResult) as wdpromise.Promise<T>;


### PR DESCRIPTION
The elementFinder and index arguments of the mapping function passed to ElementArrayFinder.map() will never be undefined.

Fixes #4548