### PR TITLE
fix(direct): Use config's geckoDriver when specified

### DIFF
--- a/lib/driverProviders/direct.ts
+++ b/lib/driverProviders/direct.ts
@@ -91,15 +91,27 @@ export class Direct extends DriverProvider {
         break;
       case 'firefox':
         let geckoDriverFile: string;
-        try {
-          let updateJson = path.resolve(SeleniumConfig.getSeleniumDir(), 'update-config.json');
-          let updateConfig = JSON.parse(fs.readFileSync(updateJson).toString());
-          geckoDriverFile = updateConfig.gecko.last;
-        } catch (e) {
-          throw new BrowserError(
+        if (this.config_.geckoDriver) {
+          geckoDriverFile = this.config_.geckoDriver;
+        } else {
+          try {
+            let updateJson = path.resolve(SeleniumConfig.getSeleniumDir(), 'update-config.json');
+            let updateConfig = JSON.parse(fs.readFileSync(updateJson).toString());
+            geckoDriverFile = updateConfig.gecko.last;
+          } catch (e) {
+            throw new BrowserError(
               logger,
               'Could not find update-config.json. ' +
-                  'Run \'webdriver-manager update\' to download binaries.');
+              'Run \'webdriver-manager update\' to download binaries.'
+            );
+          }
+        }
+
+        if (!fs.existsSync(geckoDriverFile)) {
+          throw new BrowserError(
+            logger,
+            'Could not find geckodriver at ' + geckoDriverFile +
+            '. Run \'webdriver-manager update\' to download binaries.');
         }
 
         // TODO (mgiambalvo): Turn this into an import when the selenium typings are updated.

--- a/lib/driverProviders/direct.ts
+++ b/lib/driverProviders/direct.ts
@@ -100,18 +100,17 @@ export class Direct extends DriverProvider {
             geckoDriverFile = updateConfig.gecko.last;
           } catch (e) {
             throw new BrowserError(
-              logger,
-              'Could not find update-config.json. ' +
-              'Run \'webdriver-manager update\' to download binaries.'
-            );
+                logger,
+                'Could not find update-config.json. ' +
+                    'Run \'webdriver-manager update\' to download binaries.');
           }
         }
 
         if (!fs.existsSync(geckoDriverFile)) {
           throw new BrowserError(
-            logger,
-            'Could not find geckodriver at ' + geckoDriverFile +
-            '. Run \'webdriver-manager update\' to download binaries.');
+              logger,
+              'Could not find geckodriver at ' + geckoDriverFile +
+                  '. Run \'webdriver-manager update\' to download binaries.');
         }
 
         // TODO (mgiambalvo): Turn this into an import when the selenium typings are updated.


### PR DESCRIPTION
This change makes the `firefox` capability more closely match `chrome`'s. The `firefox` capability was not looking for `config_.geckoDriver` like `chrome` was, making the `geckoDriver` configuration useless for directConnect and always resulting in an error if the driver wasn't installed in the default location.