### PR TITLE
Add docs for debugging with the control flow disabled

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -148,6 +148,20 @@ used from the browser's console.
 // You can also limit the scope of the locator
 > window.clientSideScripts.findInputs('username', document.getElementById('#myEl'));
 ```
+
+**Debugging with the control flow disabled**
+
+If you've set the `SELENIUM_PROMISE_MANAGER` config value to false to [disable the control flow](https://github.com/angular/protractor/blob/master/docs/control-flow.md),
+the above methods will not work. Instead, you can now use native `debugger` statements to pause your code. However, you
+will need to start your tests using Node's `--inspect-brk` option:
+
+```
+node --inspect-brk node_modules/.bin/protractor <config_file>
+```
+
+You will then be able to use the Chrome devtools at chrome://inspect to connect to the tests.
+
+
 Setting Up VSCode for Debugging
 -------------------------------
 VS Code has built-in [debugging](https://code.visualstudio.com/docs/editor/debugging) support for the Node.js runtime and can debug JavaScript, TypeScript, and any other language that gets transpiled to JavaScript.


### PR DESCRIPTION
When the control flow is disabled, `browser.pause()`, `browser.debugger()`, and `browser.enterRepl()` all crash. I couldn't find this documented anywhere other than bug reports, so I've added it to the docs on debugging.