### PR TITLE
Update selenium-webdriver typings version

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@types/node": "^6.0.46",
     "@types/q": "^0.0.32",
-    "@types/selenium-webdriver": "~2.53.39",
+    "@types/selenium-webdriver": "3.0.8",
     "blocking-proxy": "^1.0.0",
     "chalk": "^1.1.3",
     "glob": "^7.0.3",


### PR DESCRIPTION
@types/selenium-webdriver@2.53.39 is outdated.
For example:
With old typings `browser.manage().addCookie('key', 'value')`
In real `browser.manage().addCookie({name: 'foo', value: 'bar'})`