### PR TITLE
docs(page-objects.md): Refactor the existing Page Object example

### DIFF
--- a/docs/page-objects.md
+++ b/docs/page-objects.md
@@ -19,7 +19,7 @@ describe('angularjs homepage', function() {
 });
 ```
 
-With PageObjects
+With Page Objects
 ----------------
 
 To switch to Page Objects, the first thing you need to do is create a Page Object. A Page Object for ‘The Basics’ example on the angularjs.org homepage could look like this:
@@ -41,13 +41,16 @@ var AngularHomepage = function() {
     return greeting.getText();
   };
 };
+module.exports = new AngularHomepage();
 ```
 The next thing you need to do is modify the test script to use the PageObject and its properties. Note that the _functionality_ of the test script itself does not change (nothing is added or deleted).
 
+In the spec, you'll `require` Page Object. The path to the Page Object _will be relative_ to your spec, so adjust accordingly.
+
 ```js
+var angularHomepage = require('./AngularHomepage');
 describe('angularjs homepage', function() {
   it('should greet the named user', function() {
-    var angularHomepage = new AngularHomepage();
     angularHomepage.get();
 
     angularHomepage.setName('Julie');

--- a/docs/page-objects.md
+++ b/docs/page-objects.md
@@ -43,9 +43,9 @@ var AngularHomepage = function() {
 };
 module.exports = new AngularHomepage();
 ```
-The next thing you need to do is modify the test script to use the PageObject and its properties. Note that the _functionality_ of the test script itself does not change (nothing is added or deleted).
+The next thing you need to do is modify the test script to use the Page Object and its properties. Note that the _functionality_ of the test script itself does not change (nothing is added or deleted).
 
-In the spec, you'll `require` Page Object. The path to the Page Object _will be relative_ to your spec, so adjust accordingly.
+In the test script, you'll `require` the Page Object as presented above. The path to the Page Object _will be relative_ to your spec, so adjust accordingly.
 
 ```js
 var angularHomepage = require('./AngularHomepage');


### PR DESCRIPTION

As presented, simply following the example will not run. This presents the Page Object example as a runnable set of spec + Page Object. See #4570

Open possibilities for future work include: carry the initial introduction over into a Page Object. Introduce `world`, etc.