### PR TITLE
Allow merging of arrays in configParser

### DIFF
--- a/lib/clientsidescripts.js
+++ b/lib/clientsidescripts.js
@@ -178,7 +178,7 @@ functions.waitForAngular = function(rootSelector, callback) {
           }
           catch(e){}
           if (testability) {
-            return testability.whenStable(testCallback);
+            return testability.whenStable(function() { testCallback(); });
           }
         }
 

--- a/lib/configParser.ts
+++ b/lib/configParser.ts
@@ -187,6 +187,8 @@ let merge_ = function(into: any, from: any): any {
     if (into[key] instanceof Object && !(into[key] instanceof Array) &&
         !(into[key] instanceof Function)) {
       merge_(into[key], from[key]);
+    } else if (into[key] instanceof Array && from[key] instanceof Array) {
+      into[key] = into[key].concat(from[key]);
     } else {
       into[key] = from[key];
     }


### PR DESCRIPTION
This is a fix for issue #4587 

This is a breaking change: some users may expect the args[] array to be overwritten.