### PR TITLE
fix(Jasmine): Update Jasmine to support Node8 async/await

### DIFF
--- a/lib/frameworks/jasmine.js
+++ b/lib/frameworks/jasmine.js
@@ -63,7 +63,11 @@ exports.run = function(runner, specs) {
   var jrunner = new JasmineRunner();
   /* global jasmine */
 
-  require('jasminewd2').init(webdriver.promise.controlFlow(), webdriver);
+  // Don't even require JasmineWD if the control
+  // flow is turned off.
+  if (webdriver.promise.USE_PROMISE_MANAGER) {
+    require('jasminewd2').init(webdriver.promise.controlFlow(), webdriver);
+  }
 
   var jasmineNodeOpts = runner.getConfig().jasmineNodeOpts;
 

--- a/spec/ts/basic/element_spec.ts
+++ b/spec/ts/basic/element_spec.ts
@@ -8,8 +8,8 @@ describe('ElementFinder', function() {
     await browser.get('index.html#/form');
     const nameByElement = element(by.binding('username'));
 
-    await expect(nameByElement.getText())
-        .toEqual(browser.findElement(by.binding('username')).getText());
+    expect(await nameByElement.getText())
+        .toEqual(await browser.findElement(by.binding('username')).getText());
   });
 
   it('should wait to grab the WebElement until a method is called', async function() {
@@ -19,11 +19,11 @@ describe('ElementFinder', function() {
 
     await browser.get('index.html#/form');
 
-    await expect(name.getText()).toEqual('Anon');
+    expect(await name.getText()).toEqual('Anon');
 
     await usernameInput.clear();
     await usernameInput.sendKeys('Jane');
-    await expect(name.getText()).toEqual('Jane');
+    expect(await name.getText()).toEqual('Jane');
   });
 
   it('should chain element actions', async function() {
@@ -32,10 +32,10 @@ describe('ElementFinder', function() {
     const usernameInput = element(by.model('username'));
     const name = element(by.binding('username'));
 
-    await expect(name.getText()).toEqual('Anon');
+    expect(await name.getText()).toEqual('Anon');
 
     await((usernameInput.clear() as any) as ElementFinder).sendKeys('Jane');
-    await expect(name.getText()).toEqual('Jane');
+    expect(await name.getText()).toEqual('Jane');
   });
 
   it('should run chained element actions in sequence', function(done: any) {
@@ -75,8 +75,8 @@ describe('ElementFinder', function() {
 
     await browser.get('index.html#/conflict');
 
-    await expect(reused.getText()).toEqual('Inner: inner');
-    await expect(reused.isPresent()).toBe(true);
+    expect(await reused.getText()).toEqual('Inner: inner');
+    expect(await reused.isPresent()).toBe(true);
   });
 
   it('should differentiate elements with the same binding by chaining', async function() {
@@ -85,8 +85,8 @@ describe('ElementFinder', function() {
     const outerReused = element(by.binding('item.reusedBinding'));
     const innerReused = element(by.id('baz')).element(by.binding('item.reusedBinding'));
 
-    await expect(outerReused.getText()).toEqual('Outer: outer');
-    await expect(innerReused.getText()).toEqual('Inner: inner');
+    expect(await outerReused.getText()).toEqual('Outer: outer');
+    expect(await innerReused.getText()).toEqual('Inner: inner');
   });
 
   it('should chain deeper than 2', async function() {
@@ -96,7 +96,7 @@ describe('ElementFinder', function() {
 
     await browser.get('index.html#/conflict');
 
-    await expect(reused.getText()).toEqual('Inner: inner');
+    expect(await reused.getText()).toEqual('Inner: inner');
   });
 
   it('should allow handling errors', async function() {
@@ -129,8 +129,8 @@ describe('ElementFinder', function() {
     const byCss = by.css('body');
     const byBinding = by.binding('greet');
 
-    await expect(element(byCss).locator()).toEqual(byCss);
-    await expect(element(byBinding).locator()).toEqual(byBinding);
+    expect(await element(byCss).locator()).toEqual(byCss);
+    expect(await element(byBinding).locator()).toEqual(byBinding);
   });
 
   it('should propagate exceptions', async function() {
@@ -144,7 +144,7 @@ describe('ElementFinder', function() {
         function() {
           return false;
         } as any as (() => ppromise.Promise<void>));
-    await expect(successful).toEqual(false);
+    expect(await successful).toEqual(false);
   });
 
   it('should be returned from a helper without infinite loops', async function() {
@@ -154,7 +154,7 @@ describe('ElementFinder', function() {
     });
 
     await helperPromise.then(async function(finalResult: ElementFinder) {
-      await expect(finalResult.getText()).toEqual('Hiya');
+      expect(await finalResult.getText()).toEqual('Hiya');
     } as any as (() => ppromise.Promise<void>));
   });
 
@@ -169,8 +169,8 @@ describe('ElementFinder', function() {
 
     const name = element(by.binding('username'));
 
-    await expect(name.getText()).toEqual('Anon');
-    await expect(name.getText().then(null, function() {})).toEqual('Anon');
+    expect(await name.getText()).toEqual('Anon');
+    expect(await name.getText().then(null, function() {})).toEqual('Anon');
 
   });
 
@@ -180,7 +180,7 @@ describe('ElementFinder', function() {
     const usernameInput = element(by.model('username'));
     const name = element(by.binding('username'));
 
-    await expect(usernameInput.equals(usernameInput)).toEqual(true);
-    await expect(usernameInput.equals(name)).toEqual(false);
+    expect(await usernameInput.equals(usernameInput)).toEqual(true);
+    expect(await usernameInput.equals(name)).toEqual(false);
   });
 });

--- a/spec/ts/plugin/plugin_spec.ts
+++ b/spec/ts/plugin/plugin_spec.ts
@@ -3,6 +3,6 @@ import {browser, protractor} from '../../..';
 describe('plugins', function() {
   it('should have run the onPageLoad hook', async function() {
     await browser.get('index.html');
-    await expect((protractor as any).ON_PAGE_LOAD).toBe(true);
+    expect(await (protractor as any).ON_PAGE_LOAD).toBe(true);
   });
 });


### PR DESCRIPTION
fix(jasmine): Update Jasmine to support Node8 async/await
Breaking change for TypeScript:

JasmineWD doesn't know anything about async/await, turns off JasmineWD if control flow was disabled.

It will affect TypeScript tests that are using async/await and
1. miss some await keyword in the test.(Previously, this might cause the
test failed silently and be reported as pass), or
2. use Promise in jasmine expect function

Before
```ts
await expect(getPromise()).toEqual(42);
```

After
```ts
expect(await getPromise()).toEqual(42);
```