### PR TITLE
docs(website): updated reference from ignoreSynchronization to waitFo…

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -37,7 +37,7 @@ How do I deal with my log-in page?
 If your app needs log-in, there are a couple ways to deal with it. If your login
 page is not written with Angular, you'll need to interact with it via 
 unwrapped webdriver, which can be accessed like `browser.driver.get()`. You can also use
-`browser.ignoreSynchronization` as explained [here](/docs/timeouts.md#how-to-disable-waiting-for-angular).
+`browser.waitForAngularEnabled(false)` as explained [here](/docs/timeouts.md#how-to-disable-waiting-for-angular).
 
 Another option is to put your log-in code into an `onPrepare` function, which will be run
 once before any of your tests. See this example ([withLoginConf.js](https://github.com/angular/protractor/blob/master/spec/withLoginConf.js))


### PR DESCRIPTION
docs(website): updated reference from ignoreSynchronization to waitForAngularEnabled(false).

Updated wording to relfect the content it's linked to.
- FAQ how to handle log-in page used old ignoreSynchronization but linked to waitForAngularEnabled(false).