### PR TITLE
fix(clientsidescript): avoid returning the value of test callback in …

### DIFF
--- a/lib/clientsidescripts.js
+++ b/lib/clientsidescripts.js
@@ -153,7 +153,7 @@ functions.waitForAngular = function(rootSelector, callback) {
           } else if (hooks.$injector) {
             hooks.$injector.get('$browser')
                 .notifyWhenNoOutstandingRequests(callback);
-          } else if (!!rootSelector) {
+          } else if (!rootSelector) {
             throw new Error(
                 'Could not automatically find injector on page: "' +
                 window.location.toString() + '".  Consider using config.rootEl');
@@ -178,7 +178,8 @@ functions.waitForAngular = function(rootSelector, callback) {
           }
           catch(e){}
           if (testability) {
-            return testability.whenStable(function() { testCallback(); });
+            testability.whenStable(testCallback);
+            return;
           }
         }
 
@@ -191,7 +192,8 @@ functions.waitForAngular = function(rootSelector, callback) {
         // No angular2 testability, this happens when
         // going to a hybrid page and going back to a pure angular1 page
         if (count === 0) {
-          return testCallback();
+          testCallback();
+          return;
         }
 
         var decrement = function() {
@@ -696,7 +698,7 @@ functions.findByCssContainingText = function(cssSelector, searchText, using) {
     var elementMatches = searchText instanceof RegExp ?
         searchText.test(elementText) :
         elementText.indexOf(searchText) > -1;
-    
+
     if (elementMatches) {
       matches.push(element);
     }


### PR DESCRIPTION
…waitForAngular

The return value could be interpreted as an error by mistake in some situation
Also fix a wrong if-condition in error reporting