### PR TITLE
Fix typings for several ElementArrayFinder methods

### DIFF
--- a/lib/element.ts
+++ b/lib/element.ts
@@ -230,7 +230,7 @@ export class ElementArrayFinder extends WebdriverWebElement {
    *     of element that satisfy the filter function.
    */
   filter(
-      filterFn: (element: ElementFinder, index?: number) => boolean |
+      filterFn: (element: ElementFinder, index: number) => boolean |
           wdpromise.Promise<boolean>): ElementArrayFinder {
     let getWebElements = (): wdpromise.Promise<WebElement[]> => {
       return this.getWebElements().then((parentWebElements: WebElement[]) => {
@@ -277,7 +277,7 @@ export class ElementArrayFinder extends WebdriverWebElement {
    * @param {number|webdriver.promise.Promise} index Element index.
    * @returns {ElementFinder} finder representing element at the given index.
    */
-  get(index: number|wdpromise.Promise<number>): ElementFinder {
+  get(index: number | wdpromise.Promise<number>): ElementFinder {
     let getWebElements = (): wdpromise.Promise<WebElement[]> => {
       return wdpromise.all<any>([index, this.getWebElements()]).then(([i, parentWebElements]) => {
         if (i < 0) {
@@ -553,7 +553,7 @@ export class ElementArrayFinder extends WebdriverWebElement {
    *     an array of ElementFinders represented by the ElementArrayFinder.
    */
   then<T>(
-      fn?: (value: ElementFinder[]|any[]) => T | wdpromise.IThenable<T>,
+      fn?: (value: ElementFinder[] | any[]) => T | wdpromise.IThenable<T>,
       errorFn?: (error: any) => any): wdpromise.Promise<T> {
     if (this.actionResults_) {
       return this.actionResults_.then(fn, errorFn);
@@ -597,8 +597,8 @@ export class ElementArrayFinder extends WebdriverWebElement {
    *     function has been called on all the ElementFinders. The promise will
    *     resolve to null.
    */
-  each(fn: (elementFinder?: ElementFinder, index?: number) => any): wdpromise.Promise<any> {
-    return this.map(fn).then((): any => {
+  each(fn: (elementFinder: ElementFinder, index: number) => any): wdpromise.Promise<any> {
+    return this.map(fn).then((): null => {
       return null;
     });
   }
@@ -650,10 +650,10 @@ export class ElementArrayFinder extends WebdriverWebElement {
    * @returns {!webdriver.promise.Promise} A promise that resolves to an array
    *     of values returned by the map function.
    */
-  map<T>(mapFn: (elementFinder?: ElementFinder, index?: number) => T | any):
+  map<T>(mapFn: (elementFinder: ElementFinder, index: number) => T | any):
       wdpromise.Promise<T[]> {
     return this.asElementFinders_().then<T[]>((arr: ElementFinder[]) => {
-      let list = arr.map((elementFinder?: ElementFinder, index?: number) => {
+      let list = arr.map((elementFinder: ElementFinder, index: number) => {
         let mapResult = mapFn(elementFinder, index);
         // All nested arrays and objects will also be fully resolved.
         return wdpromise.fullyResolved(mapResult) as wdpromise.Promise<T>;
@@ -704,7 +704,9 @@ export class ElementArrayFinder extends WebdriverWebElement {
    * @returns {!webdriver.promise.Promise} A promise that resolves to the final
    *     value of the accumulator.
    */
-  reduce(reduceFn: Function, initialValue: any): wdpromise.Promise<any> {
+  reduce(
+      reduceFn: (accumulator: any, current: ElementFinder, index: number, arr: ElementFinder[]) => any,
+      initialValue: any): wdpromise.Promise<any> {
     let valuePromise = wdpromise.when(initialValue);
     return this.asElementFinders_().then((arr: ElementFinder[]) => {
       return arr.reduce((valuePromise: any, elementFinder: ElementFinder, index: number) => {


### PR DESCRIPTION
Some of the callback functions had an incorrect `?` for their arguments.

Done for [#4634|https://github.com/angular/protractor/issues/4634].