### PR TITLE
fix(grep): change excluded tests to disabled instead of pending

### DIFF
--- a/lib/frameworks/jasmine.js
+++ b/lib/frameworks/jasmine.js
@@ -85,7 +85,7 @@ exports.run = function(runner, specs) {
         spec.getFullName().match(new RegExp(jasmineNodeOpts.grep)) != null;
     var invertGrep = !!(jasmineNodeOpts && jasmineNodeOpts.invertGrep);
     if (grepMatch == invertGrep) {
-      spec.pend();
+      spec.disable();
     }
     return true;
   };


### PR DESCRIPTION
This is an attempt to fix #3952 .

In Jasmine, `beforeAll()` is executed for `pending` tests, but not `disabled` tests. This pr set all tests that are excluded from running to `disabled` so the corresponding `beforeAll()` won't run.