### PR TITLE
Package.json requires old selenium types but new selenium package

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@types/node": "^6.0.46",
     "@types/q": "^0.0.32",
-    "@types/selenium-webdriver": "~2.53.39",
+    "@types/selenium-webdriver": "~3.0.8",
     "blocking-proxy": "^1.0.0",
     "chalk": "^1.1.3",
     "glob": "^7.0.3",


### PR DESCRIPTION
The `selenium-webdriver` we require in `package.json` is `3.6.0`, however the `@types/selenium-webdriver` we require is `2.53.39`. Changes made in `selenium-webdriver` API in version `3.0.0` break these old type definitions - see [selenium changelog](https://github.com/SeleniumHQ/selenium/blob/master/javascript/node/selenium-webdriver/CHANGES.md#api-changes-3). We should update the type definitions we require as a part of Protractor to match the version of Selenium we require.