### PR TITLE
Fix typo about Angular 2 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Compatibility
 
 Protractor 5 is compatible with nodejs v6 and newer.
 
-Protractor works with AngularJS versions greater than 1.0.6/1.1.4, and is compatible with Angular applications. Note that for Angular apps, the `binding` and `model` locators are not supported. We recommend using `by.css`.
+Protractor works with AngularJS versions greater than 1.0.6/1.1.4, and is compatible with Angular applications. Note that for Angular 2 apps, the `binding` and `model` locators are not supported. We recommend using `by.css`.
 
 
 Getting Started


### PR DESCRIPTION
A recent change in the Readme deleted wording that said `Angular 2`. It makes it sound like no version of Angular will support the `binding` and `model` locators, which is not true. We should re-add the "2" back to make this more clear.

Original PR that introduced the issue: https://github.com/angular/protractor/commit/af6afa646cacf5dd2f023561f84429c05f508b77#diff-04c6e90faac2675aa89e2176d2eec7d8