### PR TITLE
- added addLocation function usage example with config file(for using with mocha framework)

### DIFF
--- a/example/addLocatorExample/addLocator_usage_example_spec.js
+++ b/example/addLocatorExample/addLocator_usage_example_spec.js
@@ -1,0 +1,9 @@
+describe('angular material checkboxes page', function() {
+  it('should click on checkbox', function() {
+    browser.get('https://material.angular.io/components/checkbox/overview');
+
+    element(by.checkboxText('Check me!')).click();
+
+    expect($('.mat-checkbox-input').getAttribute('aria-checked')).toEqual('true');
+  });
+});

--- a/example/addLocatorExample/conf.js
+++ b/example/addLocatorExample/conf.js
@@ -1,0 +1,27 @@
+// An example configuration file for addLocation function usage with mocha framework.
+exports.config = {
+  directConnect: true,
+
+  // Capabilities to be passed to the webdriver instance.
+  capabilities: {
+    'browserName': 'chrome'
+  },
+
+  specs: ['addLocator_usage_example_spec.js'],
+
+  onPrepare: function() {
+    // Create custom locator to get checkbox component by text
+    By.addLocator('checkboxText', function(checkboxText, opt_parentElement) {
+      // The first argument is checkbox text and second one opt_parentElement
+      // if needed. At first, we search for all [mat-checkbox] components.
+      var using = opt_parentElement || document;
+      var checkboxes = using.querySelectorAll('mat-checkbox');
+
+      // Now filter them and return checkboxes which match user
+      // defined text.
+      return Array.prototype.filter.call(checkboxes, function(checkbox) {
+        return checkbox.textContent.indexOf(checkboxText) !== -1;
+      });
+    });
+  }
+};


### PR DESCRIPTION
I had a problem with using of addLocator function. Tests were written using JavaScript. Example from [Protractor API](https://www.protractortest.org/#/api?view=ProtractorBy.prototype.addLocator) not worked for me. So, I decided to add small example(including config file) to help other engineers and save their time.