### PR TITLE
fix(generate-docs): fix generate-docs.sh.

### DIFF
--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -105,8 +105,8 @@ echo "Transfering files to gh-pages..."
 cd ".."
 git branch -D gh-pages
 git pull -f https://github.com/angular/protractor.git gh-pages:gh-pages
-git checkout gh-pages
 git reset --hard
+git checkout gh-pages
 cp -r website/build/* .
 git add -A
 git commit -m "chore(website): automatic docs update for ${VERSION}"


### PR DESCRIPTION
Ignore generated unstaged files before checking out to new branch; otherwise, the git checkout will fail.