### PR TITLE
Add click and scrollIntoView abstractions

### DIFF
--- a/lib/browser.ts
+++ b/lib/browser.ts
@@ -1224,7 +1224,7 @@ export class ProtractorBrowser extends AbstractExtendedWebDriver {
    * @returns {wdpromise.Promise<T>} 
    * @memberof ProtractorBrowser
    */
-  scroll<T>(element: ElementFinder): wdpromise.Promise<T> {
+  scrollIntoView<T>(element: ElementFinder): wdpromise.Promise<T> {
     return this.driver.executeScript('arguments[0].scrollIntoView();', element);
   }
 

--- a/lib/browser.ts
+++ b/lib/browser.ts
@@ -1203,4 +1203,29 @@ export class ProtractorBrowser extends AbstractExtendedWebDriver {
       return !!wdpromise.ControlFlow;
     }
   }
+
+  /**
+   * Clicks on the specified element, provided it's visible.
+   * 
+   * @template T 
+   * @param {ElementFinder} element 
+   * @returns {wdpromise.Promise<T>} 
+   * @memberof ProtractorBrowser
+   */
+  click<T>(element: ElementFinder): wdpromise.Promise<T> {
+    return this.driver.executeScript('argments[0].click();', element);
+  }
+
+  /**
+   * Scrolls to the specified element.
+   * 
+   * @template T 
+   * @param {ElementFinder} element 
+   * @returns {wdpromise.Promise<T>} 
+   * @memberof ProtractorBrowser
+   */
+  scroll<T>(element: ElementFinder): wdpromise.Promise<T> {
+    return this.driver.executeScript('arguments[0].scrollIntoView();', element);
+  }
+
 }


### PR DESCRIPTION
It would be nice to abstract the `click` and `scrollIntoView` calls a little, so that code such as 

```
(() => browser.executeScript('arguments[0].scrollIntoView();', this.locatorButton.webMail))
(() => browser.executeScript('arguments[0].click();', this.locatorButton.webMail))
```

could be rewritten as 

```
(() => browser.scrollIntoView(this.locatorButton.webMail))
(() => browser.click(this.locatorButton.webMail))
```

If there's interest in and support for this, I'd be happy to contribute more (unit tests, etc.), if needed, to bring this to completion.