### PR TITLE
feat(plugin): pre-webdriver plugin hook

### DIFF
--- a/lib/plugins.ts
+++ b/lib/plugins.ts
@@ -24,6 +24,24 @@ export interface PluginConfig {
 
 export interface ProtractorPlugin {
   /**
+   * Set up the protractor runtime before the webdriver session has been started.
+   * Use this method if you'd like to dynamically change the browser capabilities,
+   * multiCapabilites, plugin list, or other parameters.
+   *
+   * Note that if you use this method to inject other plugins, you will have to
+   * carefully manage their own initialize() invocations.
+   *
+   * @this {Object} bound to module.exports.
+   *
+   * @throws {*} If this function throws an error, the process will exit.
+   *
+   * @return {Promise=} Can return a promise, in which case protractor will wait
+   *     for the promise to resolve before continuing.  If the promise is
+   *     rejected, the process will exit.
+   */
+  initialize?(config: Config): void|Promise<void>;
+
+  /**
    * Sets up plugins before tests are run. This is called after the WebDriver
    * session has been started, but before the test framework has been set up.
    *
@@ -420,6 +438,7 @@ export class Plugins {
   /**
    * @see docs/plugins.md#writing-plugins for information on these functions
    */
+  initialize = this.pluginFunFactory('initialize', PromiseType.Q);
   setup = this.pluginFunFactory('setup', PromiseType.Q);
   onPrepare = this.pluginFunFactory('onPrepare', PromiseType.Q);
   teardown = this.pluginFunFactory('teardown', PromiseType.Q);


### PR DESCRIPTION
This patch adds an 'initialize' plugin method, which is
invoked before the webdriver session has been initialized. It's aim is
to provide hooks by which a plugin author can modify the protractor configuration
before any serious logic has been executed. For instance, to configure the
multiCapabilities block based on the local environment, or querying a SaaS
selenium API (BrowserStack, SauceLabs, raw Selenium) for available browsers.

Any plugin that hooks into this is presumed to be 'required' - so a rejected
promise (perhaps caused by a missing API key) will terminate the protractor
execution.