### PR TITLE
Fix CircleCI Build

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,40 +1,72 @@
-machine:
-  node:
-    version: 6.9.1
-  environment:
-    # Fix issue with selenium-server in containers.
-    # See http://github.com/SeleniumHQ/docker-selenium/issues/87
-    DBUS_SESSION_BUS_ADDRESS: /dev/null
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/node:6.14-browsers
+        environment:
+          # Fix issue with selenium-server in containers.
+          # See http://github.com/SeleniumHQ/docker-selenium/issues/87
+          DBUS_SESSION_BUS_ADDRESS: /dev/null
+    steps:
+      - checkout
 
-dependencies:
-  override:
-    - npm i
-  cache_directories:
-    - testapp/node_modules
-  post:
-    - ./node_modules/.bin/gulp lint
-    - ./node_modules/.bin/webdriver-manager update
-    - ./node_modules/.bin/webdriver-manager start:
-        background: true
-    - cd testapp && npm i
-    - npm start:
-          background: true
-    - sudo apt-get update
-    # Install the latest Firefox beta
-    - pip install --upgrade pip
-    - pip install mozdownload mozinstall
-    - mozdownload --version latest --destination firefox.tar.bz2
-    - mozinstall firefox.tar.bz2
-    - sudo cp -R firefox/* /opt/firefox/
-    # Install the latest Chrome
-    - curl -L -o google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-    - sudo dpkg -i google-chrome.deb
-    - sudo sed -i 's|HERE/chrome\"|HERE/chrome\" --disable-setuid-sandbox|g' /opt/google/chrome/google-chrome
-    - rm google-chrome.deb
-    # Extra tcp logging for BlockingProxy
-    - sudo tcpdump -i lo 'tcp && dst localhost' -w $CIRCLE_ARTIFACTS/localdump.pcap:
-          background: true
+      - run:
+          name: Install Dependencies
+          command: |
+            sudo apt-get update
+            sudo apt-get install python-pip tcpdump
 
-test:
-  override:
-    - npm test
+            # Have to update firefox, default is ESR.
+            sudo pip install --upgrade pip
+            sudo pip install mozdownload mozinstall
+            mozdownload --version latest --destination firefox.tar.bz2
+            mozinstall firefox.tar.bz2
+            sudo cp -R firefox/* /opt/firefox/
+
+            # Latest chrome is already installed in the default container.
+            # curl -L -o google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+            # sudo dpkg -i google-chrome.deb
+            # sudo sed -i 's|HERE/chrome\"|HERE/chrome\" --disable-setuid-sandbox|g' /opt/google/chrome/google-chrome
+            # rm google-chrome.deb
+
+      - restore_cache:
+          key: node_modules-{{ .Branch }}-{{ checksum "package-lock.json" }}
+
+      - run:
+          name: NPM Install
+          command: |
+            npm i
+            cd testapp && npm i
+
+      - save_cache:
+          key: node_modules-{{ .Branch }}-{{ checksum "package-lock.json" }}
+          paths:
+            - "node_modules"
+            - "testapp/node_modules"
+
+      - run:
+          name: Lint
+          command: ./node_modules/.bin/gulp lint
+
+      - run:
+          name: Selenium Start
+          background: true
+          command: |
+            ./node_modules/.bin/webdriver-manager update
+            ./node_modules/.bin/webdriver-manager start
+
+      - run:
+          name: TestApp Start
+          background: true
+          command: |
+            npm start
+
+      # Seems like the new circleci container no longer permits packet introspection on lo, even for root.
+      # - run:
+      #    name: Extra tcp logging for BlockingProxy
+      #    background: true
+      #    command: sudo tcpdump -i lo 'tcp && dst localhost' -w $CIRCLE_ARTIFACTS/localdump.pcap
+
+      - run:
+          name: Test
+          command: npm test

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -129,8 +129,8 @@ executor.addCommandlineTest('node built/cli.js spec/errorTest/slowHttpAndTimeout
     .expectExitCode(1)
     .expectErrors([
       {message: 'The following tasks were pending[\\s\\S]*\\$http: slowcall'},
-      {message: 'The following tasks were pending[\\s\\S]*' +
-                '\\$timeout: function \\(\\) {[\\s\\S]*' +
+      {message: 'The following tasks were pending:[\\s\\S]*' +
+                '- \\$timeout: function\\(\\) {[\\s\\S]*' +
                   '\\$scope\\.slowAngularTimeoutStatus = \'done\';[\\s\\S]' +
                 '*}'}
     ]);

--- a/spec/errorTest/slowHttpAndTimeoutConf.js
+++ b/spec/errorTest/slowHttpAndTimeoutConf.js
@@ -15,5 +15,5 @@ exports.config = {
 
   baseUrl: env.baseUrl + '/ng1/',
 
-  allScriptsTimeout: 10000
+  allScriptsTimeout: 4000 // Each test waits on something that has a 5 second tick.
 };


### PR DESCRIPTION
This patch attempts to fix the continually breaking circleci build. The changes made were:
- Switch to using circleci v2 syntax, as the v1 syntax will be deprecated in August. Also, it permits running the build locally using the `circleci` commandline tool.
- Adjust timeouts on error tests to fail consistently on high-performance machines.
- Correct error formatting on error tests.

Fixes #4810