### PR TITLE
feat(driverProvider) Adding browserstackProxy param in BrowserStack driverProvider

### DIFF
--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -50,6 +50,7 @@ let allowedNames = [
   'sauceSeleniumAddress',
   'browserstackUser',
   'browserstackKey',
+  'browserstackProxy',
   'kobitonUser',
   'kobitonKey',
   'testobjectUser',

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -205,6 +205,13 @@ export interface Config {
    */
   browserstackKey?: string;
 
+  /**
+   * Proxy server to be used for connecting to BrowserStack APIs
+   * e.g. "http://proxy.example.com:1234".
+   * This should be used when you are behind a proxy server.
+   */
+  browserstackProxy?: string;
+
   // ---- 7. To connect directly to Drivers ------------------------------------
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -4285,6 +4285,14 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
+    },
+    "browserstack": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/browserstack/-/browserstack-1.5.1.tgz",
+      "integrity": "sha512-O8VMT64P9NOLhuIoD4YngyxBURefaSdR4QdhG8l6HZ9VxtU7jc3m6jLufFwKA5gaf7fetfB2TnRJnMxyob+heg==",
+      "requires": {
+        "https-proxy-agent": "2.2.1"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@types/q": "^0.0.32",
     "@types/selenium-webdriver": "~2.53.39",
     "blocking-proxy": "^1.0.0",
+    "browserstack": "^1.5.1",
     "chalk": "^1.1.3",
     "glob": "^7.0.3",
     "jasmine": "2.8.0",

--- a/scripts/errorTest.js
+++ b/scripts/errorTest.js
@@ -23,7 +23,7 @@ var checkLogs = function(output, messages) {
 runProtractor = spawn('node',
     ['bin/protractor', 'spec/errorTest/sauceLabsAuthentication.js']);
 output = runProtractor.stdout.toString();
-messages = ['WebDriverError: Sauce Labs Authentication Error.',
+messages = ['WebDriverError: Misconfigured -- Sauce Labs Authentication Error.',
     'Process exited with error code ' + exitCodes.BrowserError.CODE];
 checkLogs(output, messages);
 

--- a/spec/driverprovider_test.js
+++ b/spec/driverprovider_test.js
@@ -6,7 +6,8 @@
  * - selenium jar and chromedriver in protractor/selenium, where
  *   webdriver-manager stores them.
  * - if you want to test saucelabs, test with --sauceUser and --sauceKey
- *
+ * - if you want to test browserstack driverProvider, test with 
+     --browserstackUser and --browserstackKey
  * You should verify that there are no lingering processes when these tests
  * complete.
  */
@@ -19,6 +20,7 @@ var Direct = require('../built/driverProviders/direct').Direct;
 var Hosted = require('../built/driverProviders/hosted').Hosted;
 var Local = require('../built/driverProviders/local').Local;
 var Sauce = require('../built/driverProviders/sauce').Sauce;
+var BrowserStack = require('../built/driverProviders/browserStack').BrowserStack;
 
 var testDriverProvider = function(driverProvider) {
   return driverProvider.setupEnv().then(function() {
@@ -122,5 +124,23 @@ if (argv.sauceUser && argv.sauceKey) {
         console.log('sauce.dp working!');
       }, function(err) {
         console.log('sauce.dp failed with ' + err);
+      });
+}
+
+if (argv.browserstackUser && argv.browserstackKey) {
+  var browserStackConfig = {
+    browserstackUser: argv.browserstackUser,
+    browserstackKey: argv.browserstackKey,
+    capabilities: {
+      'build': 'protractor-browserstack-spec',
+      'name': 'protractor-browserstack-spec',
+      'browserName': 'chrome',
+    }
+  };
+  testDriverProvider(new BrowserStack(browserStackConfig)).
+      then(function() {
+        console.log('browserstack.dp working!');
+      }, function(err) {
+        console.log('browserstack.dp failed with ' + err);
       });
 }


### PR DESCRIPTION
Adding browserstackProxy configuration param to enable users behind proxy to run their tests, example value for this config : "http://proxy.example.com:1234".