### PR TITLE
feat (website): remove "JS" from "AngularJS" in the page title

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="css/protractor.css"/>
   <link rel="icon" href="img/favicon.ico" sizes="16x16 32x32 48x48 64x64"
       type="image/x-icon">
-  <title>Protractor - end-to-end testing for AngularJS</title>
+  <title>Protractor - end-to-end testing for Angular</title>
 </head>
 <body ng-app="protractorApp">
 <nav class="navbar navbar-default navbar-static navbar-fixed-top">


### PR DESCRIPTION
The "AngularJS" title in Google search results made me think Protractor was only for old-fashioned AngularJS and I had to find another solution for Angular testing.