### PR TITLE
Add support for end users changing the httpAgent.

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -123,6 +123,15 @@ export interface Config {
    */
   blockingProxyUrl?: string;
 
+  /**
+   * If specified, Protractor will configure Selenium-Webdriver to use this
+   * httpAgent.
+   *
+   * Only functions for Selenium-Webdriver 3.0.0-beta-1 and up:
+   * (https://github.com/SeleniumHQ/selenium/blob/master/javascript/node/selenium-webdriver/CHANGES.md#v300-beta-1)
+   */
+  httpAgent?: any;
+
   // ---- 3. To use remote browsers via Sauce Labs -----------------------------
 
   /**
@@ -136,13 +145,15 @@ export interface Config {
    */
   sauceKey?: string;
   /**
-   * Use sauceAgent if you need custom HTTP agent to connect to saucelabs.com.
+   * Use sauceAgent if you need a custom HTTP agent to connect to saucelabs.com.
    * This is needed if your computer is behind a corporate proxy.
    *
    * To match sauce agent implementation, use
    * [HttpProxyAgent](https://github.com/TooTallNate/node-http-proxy-agent)
    * to generate the agent or use webDriverProxy as an alternative. If a
    * webDriverProxy is provided, the sauceAgent will be overridden.
+   *
+   * Setting sauceAgent will override httpAgent.
    */
   sauceAgent?: any;
   /**

--- a/lib/driverProviders/driverProvider.ts
+++ b/lib/driverProviders/driverProvider.ts
@@ -57,6 +57,9 @@ export abstract class DriverProvider {
     if (this.config_.disableEnvironmentOverrides === true) {
       builder.disableEnvironmentOverrides();
     }
+    if (this.config_.httpAgent) {
+      builder.usingHttpAgent(this.config_.httpAgent);
+    }
     let newDriver = builder.build() as WebDriver;
     this.drivers_.push(newDriver);
     return newDriver;

--- a/lib/driverProviders/sauce.ts
+++ b/lib/driverProviders/sauce.ts
@@ -63,6 +63,11 @@ export class Sauce extends DriverProvider {
     this.config_.capabilities['username'] = this.config_.sauceUser;
     this.config_.capabilities['accessKey'] = this.config_.sauceKey;
     this.config_.capabilities['build'] = this.config_.sauceBuild;
+
+    if (this.config_.sauceAgent) {
+      this.config_.httpAgent = this.config_.httpAgent;
+    }
+
     let protocol = this.config_.sauceSeleniumUseHttp ? 'http://' : 'https://';
     let auth = protocol + this.config_.sauceUser + ':' + this.config_.sauceKey + '@';
     this.config_.seleniumAddress = auth +


### PR DESCRIPTION
From version 3.0.0-beta-1, the Selenium-Webdriver package allows
the httpAgent to be configured.

This change adds httpAgent to the config file, as well as support
in driverProvider.

It also sets the httpAgent to sauceAgent, where sauceAgent is in use.
(Making the assumption that anyone who needs a sauceAgent for the
Sauce Labs REST API also needs it to connect to Sauce Labs for testing)

NB: I wasn't sure what kind of tests are appropriate beyond testing that the agent is set, and that that sets the agent... Happy to add that if desired.