### PR TITLE
deps(webdriver_js_extender): update webdriver_js_extender to 2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4109,9 +4109,9 @@
       }
     },
     "webdriver-js-extender": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/webdriver-js-extender/-/webdriver-js-extender-2.0.0.tgz",
-      "integrity": "sha512-fbyKiVu3azzIc5d4+26YfuPQcFTlgFQV5yQ/0OQj4Ybkl4g1YQuIPskf5v5wqwRJhHJnPHthB6tqCjWHOKLWag==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/webdriver-js-extender/-/webdriver-js-extender-2.1.0.tgz",
+      "integrity": "sha512-lcUKrjbBfCK6MNsh7xaY2UAUmZwe+/ib03AjVOpFobX4O7+83BUveSrLfU0Qsyb1DaKJdQRbuU+kM9aZ6QUhiQ==",
       "requires": {
         "@types/selenium-webdriver": "^3.0.0",
         "selenium-webdriver": "^3.0.1"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "saucelabs": "^1.5.0",
     "selenium-webdriver": "3.6.0",
     "source-map-support": "~0.4.0",
-    "webdriver-js-extender": "2.0.0",
+    "webdriver-js-extender": "2.1.0",
     "webdriver-manager": "^12.0.6"
   },
   "devDependencies": {


### PR DESCRIPTION
@qiyigg this replaces https://github.com/angular/protractor/pull/4911. All changes should be good now.

Following up on https://github.com/angular/webdriver-js-extender/pull/21, updating `webdriver-js-extender` to version 2.1.0.

Making the 2 new endpoints to send custom commands to the DevTools debugger server (available since ChromeDriver version `2.30` [1]):
* `/chromium/send_command`;
* `/chromium/send_command_and_get_result`.

available for use in protractor.

[1] https://chromium.googlesource.com/chromium/src/+/711de0efbb675bd2a4a28ec47c9194d8e498e600