### PR TITLE
set correct port for sauceSeleniumAddress for HTTP protocol

### DIFF
--- a/lib/driverProviders/sauce.ts
+++ b/lib/driverProviders/sauce.ts
@@ -65,9 +65,10 @@ export class Sauce extends DriverProvider {
     this.config_.capabilities['build'] = this.config_.sauceBuild;
     let protocol = this.config_.sauceSeleniumUseHttp ? 'http://' : 'https://';
     let auth = protocol + this.config_.sauceUser + ':' + this.config_.sauceKey + '@';
+    let saucePort = this.config_.sauceSeleniumUseHttp ? 80 : 443;
     this.config_.seleniumAddress = auth +
         (this.config_.sauceSeleniumAddress ? this.config_.sauceSeleniumAddress :
-                                             'ondemand.saucelabs.com:443/wd/hub');
+                                             'ondemand.saucelabs.com:' + saucePort + '/wd/hub'));
 
     // Append filename to capabilities.name so that it's easier to identify
     // tests.


### PR DESCRIPTION
when sauceSeleniumUseHttp is true, it should set the port to 80 instead of 443