### PR TITLE
(feat)Changing default BrowseStack Hub url to https

### DIFF
--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -51,6 +51,7 @@ let allowedNames = [
   'browserstackUser',
   'browserstackKey',
   'browserstackProxy',
+  'browserstackUseHttp',
   'kobitonUser',
   'kobitonKey',
   'testobjectUser',

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -214,6 +214,15 @@ export interface Config {
    */
   browserstackProxy?: string;
 
+  /**
+   * If true, Protractor will use http:// protocol instead of https:// to
+   * connect to BrowserStack defined by seleniumAddress.
+   *
+   * default: false
+   */
+  browserstackUseHttp?: boolean;
+  /**
+
   // ---- 7. To connect directly to Drivers ------------------------------------
 
   /**

--- a/lib/driverProviders/browserStack.ts
+++ b/lib/driverProviders/browserStack.ts
@@ -84,7 +84,8 @@ export class BrowserStack extends DriverProvider {
     let deferred = q.defer();
     this.config_.capabilities['browserstack.user'] = this.config_.browserstackUser;
     this.config_.capabilities['browserstack.key'] = this.config_.browserstackKey;
-    this.config_.seleniumAddress = 'http://hub.browserstack.com/wd/hub';
+    let protocol = this.config_.browserstackUseHttp ? 'http://' : 'https://';
+    this.config_.seleniumAddress = protocol + 'hub.browserstack.com/wd/hub';
 
     this.browserstackClient = BrowserstackClient.createAutomateClient({
       username: this.config_.browserstackUser,


### PR DESCRIPTION
Adding a parameter `browserstackUseHttp` in case http is required.