### PR TITLE
Update config.ts sauceSeleniumAddress comment to reflect 443 default

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -160,7 +160,7 @@ export interface Config {
    * Use sauceSeleniumAddress if you need to customize the URL Protractor
    * uses to connect to sauce labs (for example, if you are tunneling selenium
    * traffic through a sauce connect tunnel). Default is
-   * ondemand.saucelabs.com:80/wd/hub
+   * ondemand.saucelabs.com:443/wd/hub
    */
   sauceSeleniumAddress?: string;
 


### PR DESCRIPTION
Per the default behavior set in:
https://github.com/angular/protractor/blob/master/lib/driverProviders/sauce.ts#L68-L70

the Sauce OnDemand address will default to ondemand.saucelabs.com:443 unless changed.
The config.ts doc says the default is ondemand.saucelabs.com:80.

This PR simply changes the port number on the config.ts comment.