### PR TITLE
chore(config): Update docs regarding proxies

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -99,14 +99,15 @@ export interface Config {
    */
   seleniumSessionId?: string;
   /**
-   * The address of a proxy server to use for communicating to Sauce Labs rest APIs via the
+   * The address of a proxy server to use for communicating to Sauce Labs REST APIs via the
    * saucelabs node module. For example, the Sauce Labs Proxy can be setup with: sauceProxy:
    * 'http://localhost:3128'
    */
   sauceProxy?: string;
 
   /**
-   * The proxy address that browser traffic will go through which is tied to the browser session.
+   * The proxy address that WebDriver (e.g. Selenium commands) traffic will go through 
+   * which is tied to the browser session.
    */
   webDriverProxy?: string;
 
@@ -136,13 +137,13 @@ export interface Config {
    */
   sauceKey?: string;
   /**
-   * Use sauceAgent if you need custom HTTP agent to connect to saucelabs.com.
+   * Use sauceAgent if you need custom HTTP agent to connect to saucelabs.com APIs.
    * This is needed if your computer is behind a corporate proxy.
    *
    * To match sauce agent implementation, use
    * [HttpProxyAgent](https://github.com/TooTallNate/node-http-proxy-agent)
-   * to generate the agent or use webDriverProxy as an alternative. If a
-   * webDriverProxy is provided, the sauceAgent will be overridden.
+   * to generate the agent or use sauceProxy as an alternative. If a
+   * sauceProxy is provided, the sauceAgent will be overridden.
    */
   sauceAgent?: any;
   /**


### PR DESCRIPTION
This change tries to make the different proxies available easier to differentiate.
The sauceAgent key's comment said that adding a webDriverProxy would override this and this is not true.
sauceAgent is overwritten by sauceProxy since both are passed onto the saucelabs module.

See:
https://github.com/angular/protractor/blob/master/lib/driverProviders/sauce.ts#L60-L61

webDriverProxy on the other hand is passed onto the WebDriver session.
See:
https://github.com/angular/protractor/blob/master/lib/driverProviders/driverProvider.ts#L54

This means that if you're under a corporate proxy and need to proxy both Sauce Labs API calls as well as calls to the Selenium endpoint (ondemand.saucelabs.com) both sauceProxy/sauceAgent and webDriverProxy need to be used.