### PR TITLE
chore(tests): update restart spec specs and plugin specs

### DIFF
--- a/scripts/test.js
+++ b/scripts/test.js
@@ -5,7 +5,7 @@ const Executor = require('./test/test_util').Executor;
 
 const passingTests = [
   'node built/cli.js spec/basicConf.js',
-  // 'node built/cli.js spec/basicConf.js --useBlockingProxy',
+  'node built/cli.js spec/basicConf.js --useBlockingProxy',
   'node built/cli.js spec/multiConf.js',
   'node built/cli.js spec/altRootConf.js',
   'node built/cli.js spec/inferRootConf.js',
@@ -21,7 +21,7 @@ const passingTests = [
   'node built/cli.js spec/suitesConf.js --suite okmany',
   'node built/cli.js spec/suitesConf.js --suite okspec',
   'node built/cli.js spec/suitesConf.js --suite okmany,okspec',
-  // 'node built/cli.js spec/plugins/smokeConf.js',
+  'node built/cli.js spec/plugins/smokeConf.js',
   'node built/cli.js spec/plugins/multiPluginConf.js',
   'node built/cli.js spec/plugins/jasminePostTestConf.js',
   'node built/cli.js spec/plugins/mochaPostTestConf.js',
@@ -37,7 +37,7 @@ const passingTests = [
   'node built/cli.js spec/controlLockConf.js',
   'node built/cli.js spec/customFramework.js',
   'node built/cli.js spec/noGlobalsConf.js',
-  // 'node built/cli.js spec/angular2Conf.js',
+  'node built/cli.js spec/angular2Conf.js',
   'node built/cli.js spec/hybridConf.js',
   'node built/cli.js spec/built/noCFBasicConf.js',
   'node built/cli.js spec/built/noCFBasicConf.js --useBlockingProxy',

--- a/spec/basic/expected_conditions_spec.js
+++ b/spec/basic/expected_conditions_spec.js
@@ -177,7 +177,7 @@ describe('expected conditions', () => {
   describe('for forked browsers', () => {
     // ensure that we can run EC on forked browser instances
     it('should have alertIsPresent', async () => {
-      const browser2 = browser.forkNewDriverInstance();
+      const browser2 = await browser.forkNewDriverInstance().ready;
       await browser2.get('index.html#/form');
       const EC2 = browser2.ExpectedConditions;
       const alertIsPresent = EC2.alertIsPresent();

--- a/spec/plugins/skipStabilityConf.js
+++ b/spec/plugins/skipStabilityConf.js
@@ -3,6 +3,7 @@ var env = require('../environment.js');
 // Verifies that plugins can change skipAngularStability on the fly.
 exports.config = {
   seleniumAddress: env.seleniumAddress,
+  SELENIUM_PROMISE_MANAGER: false,
 
   framework: 'jasmine',
 

--- a/spec/plugins/smokeConf.js
+++ b/spec/plugins/smokeConf.js
@@ -4,6 +4,7 @@ var env = require('../environment.js');
 // Tests the (potential) edge case of exactly one plugin being used
 exports.config = {
   mockSelenium: true,
+  SELENIUM_PROMISE_MANAGER: false,
 
   framework: 'jasmine',
 

--- a/spec/plugins/specs/smoke_spec.js
+++ b/spec/plugins/specs/smoke_spec.js
@@ -1,5 +1,5 @@
-describe('check if plugin setup ran', function() {
-  it('should have set protractor.__BASIC_PLUGIN_RAN_*', function() {
+describe('check if plugin setup ran', () => {
+  it('should have set protractor.__BASIC_PLUGIN_RAN_*', () => {
     expect(protractor.__BASIC_PLUGIN_RAN_SETUP).toBe(true);
     expect(protractor.__BASIC_PLUGIN_RAN_ON_PREPARE).toBe(true);
   });


### PR DESCRIPTION
- update to ES6
- fix the expected conditions to await when the browser is ready after being forked
- enable more tests
