### PR TITLE
chore(test): remove jasmine addMatcher test

### DIFF
--- a/spec/basic/locators_spec.js
+++ b/spec/basic/locators_spec.js
@@ -10,23 +10,6 @@ describe('locators', () => {
       expect(await greeting.getText()).toEqual('Hiya');
     });
 
-    // TODO(selenium4): fix/remove xit after removing jasminewd
-    xit('should allow custom expectations to expect an element', async() => {
-      jasmine.addMatchers({
-        toHaveText: () => {
-          return {
-            compare: async(actual, expected) => {
-              return {
-                pass: (await actual.getText()) === expected
-              };
-            }
-          };
-        }
-      });
-
-      expect(await element(by.binding('greeting'))).toHaveText('Hiya');
-    });
-
     it('should find a binding by partial match', async() => {
       const greeting = element(by.binding('greet'));
 


### PR DESCRIPTION
Removing the addMatchers test since we no longer support async calls
resolve with jasminewd since we removed jasminewd. Also Jasmine does
not appear to support async calls in custom expectations or the
compare method.