### PR TITLE
Fix/add saucelabs eu dc

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -101,9 +101,15 @@ export interface Config {
   /**
    * The address of a proxy server to use for communicating to Sauce Labs rest APIs via the
    * saucelabs node module. For example, the Sauce Labs Proxy can be setup with: sauceProxy:
-   * 'http://localhost:3128'
+   * eu: eu-central-1
    */
   sauceProxy?: string;
+  /**
+   * If you run your tests on SauceLabs you can specify the region you want to run your tests
+   * in via the `region` property. Available short handles for regions are:
+   * 'http://localhost:3128'
+   */
+  sauceRegion?: string;
 
   /**
    * The proxy address that browser traffic will go through which is tied to the browser session.

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -101,13 +101,14 @@ export interface Config {
   /**
    * The address of a proxy server to use for communicating to Sauce Labs rest APIs via the
    * saucelabs node module. For example, the Sauce Labs Proxy can be setup with: sauceProxy:
-   * eu: eu-central-1
+   * 'http://localhost:3128'
    */
   sauceProxy?: string;
   /**
    * If you run your tests on SauceLabs you can specify the region you want to run your tests
-   * in via the `region` property. Available short handles for regions are:
-   * 'http://localhost:3128'
+   * in via the `sauceRegion` property. Available short handles for regions are:
+   * us: us-west-1 (default)
+   * eu: eu-central-1
    */
   sauceRegion?: string;
 

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -104,13 +104,6 @@ export interface Config {
    * 'http://localhost:3128'
    */
   sauceProxy?: string;
-  /**
-   * If you run your tests on SauceLabs you can specify the region you want to run your tests
-   * in via the `sauceRegion` property. Available short handles for regions are:
-   * us: us-west-1 (default)
-   * eu: eu-central-1
-   */
-  sauceRegion?: string;
 
   /**
    * The proxy address that browser traffic will go through which is tied to the browser session.
@@ -142,6 +135,13 @@ export interface Config {
    * ignored. The tests will be run remotely using Sauce Labs.
    */
   sauceKey?: string;
+  /**
+    * If you run your tests on SauceLabs you can specify the region you want to run your tests
+    * in via the `sauceRegion` property. Available short handles for regions are:
+    * us: us-west-1 (default)
+    * eu: eu-central-1
+    */
+  sauceRegion?: string;
   /**
    * Use sauceAgent if you need custom HTTP agent to connect to saucelabs.com.
    * This is needed if your computer is behind a corporate proxy.

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -136,11 +136,11 @@ export interface Config {
    */
   sauceKey?: string;
   /**
-    * If you run your tests on SauceLabs you can specify the region you want to run your tests
-    * in via the `sauceRegion` property. Available short handles for regions are:
-    * us: us-west-1 (default)
-    * eu: eu-central-1
-    */
+   * If you run your tests on SauceLabs you can specify the region you want to run your tests
+   * in via the `sauceRegion` property. Available short handles for regions are:
+   * us: us-west-1 (default)
+   * eu: eu-central-1
+   */
   sauceRegion?: string;
   /**
    * Use sauceAgent if you need custom HTTP agent to connect to saucelabs.com.

--- a/lib/driverProviders/sauce.ts
+++ b/lib/driverProviders/sauce.ts
@@ -88,12 +88,12 @@ export class Sauce extends DriverProvider {
     return deferred.promise;
   }
 
-    /**
-     * Get the Sauce Labs endpoint
-     * @private
-     * @param {string} region
-     * @return {string} The endpoint that needs to be used
-     */
+  /**
+    * Get the Sauce Labs endpoint
+    * @private
+    * @param {string} region
+    * @return {string} The endpoint that needs to be used
+    */
   private getSauceEndpoint(region:string): string{
       const dc = region ?
           typeof SAUCE_REGIONS[region] !== 'undefined' ?

--- a/lib/driverProviders/sauce.ts
+++ b/lib/driverProviders/sauce.ts
@@ -72,7 +72,7 @@ export class Sauce extends DriverProvider {
     let auth = protocol + this.config_.sauceUser + ':' + this.config_.sauceKey + '@';
     this.config_.seleniumAddress = auth +
         (this.config_.sauceSeleniumAddress ? this.config_.sauceSeleniumAddress :
-                                             'ondemand.saucelabs.com:443/wd/hub');
+                                             `ondemand.${this.getSauceEndpoint(this.config_.sauceRegion)}:443/wd/hub`);
 
     // Append filename to capabilities.name so that it's easier to identify
     // tests.

--- a/lib/driverProviders/sauce.ts
+++ b/lib/driverProviders/sauce.ts
@@ -14,6 +14,10 @@ import {Logger} from '../logger';
 import {DriverProvider} from './driverProvider';
 
 const SauceLabs = require('saucelabs');
+const SAUCE_REGIONS:{[key: string]: string} = {
+    'us': '', // default endpoint
+    'eu': 'eu-central-1.'
+};
 
 let logger = new Logger('sauce');
 export class Sauce extends DriverProvider {
@@ -55,6 +59,7 @@ export class Sauce extends DriverProvider {
   protected setupDriverEnv(): q.Promise<any> {
     let deferred = q.defer();
     this.sauceServer_ = new SauceLabs({
+      hostname: this.getSauceEndpoint(this.config_.sauceRegion),
       username: this.config_.sauceUser,
       password: this.config_.sauceKey,
       agent: this.config_.sauceAgent,
@@ -81,5 +86,19 @@ export class Sauce extends DriverProvider {
         this.config_.seleniumAddress.replace(/\/\/.+@/, '//'));
     deferred.resolve();
     return deferred.promise;
+  }
+
+    /**
+     * Get the Sauce Labs endpoint
+     * @private
+     * @param {string} region
+     * @return {string} The endpoint that needs to be used
+     */
+  private getSauceEndpoint(region:string): string{
+      const dc = region ?
+          typeof SAUCE_REGIONS[region] !== 'undefined' ?
+              SAUCE_REGIONS[region] : (region + '.')
+          : '';
+      return `${dc}saucelabs.com`;
   }
 }

--- a/lib/driverProviders/sauce.ts
+++ b/lib/driverProviders/sauce.ts
@@ -14,9 +14,9 @@ import {Logger} from '../logger';
 import {DriverProvider} from './driverProvider';
 
 const SauceLabs = require('saucelabs');
-const SAUCE_REGIONS:{[key: string]: string} = {
-    'us': '', // default endpoint
-    'eu': 'eu-central-1.'
+const SAUCE_REGIONS: {[key: string]: string} = {
+  'us': '',  // default endpoint
+  'eu': 'eu-central-1.'
 };
 
 let logger = new Logger('sauce');
@@ -71,8 +71,9 @@ export class Sauce extends DriverProvider {
     let protocol = this.config_.sauceSeleniumUseHttp ? 'http://' : 'https://';
     let auth = protocol + this.config_.sauceUser + ':' + this.config_.sauceKey + '@';
     this.config_.seleniumAddress = auth +
-        (this.config_.sauceSeleniumAddress ? this.config_.sauceSeleniumAddress :
-                                             `ondemand.${this.getSauceEndpoint(this.config_.sauceRegion)}:443/wd/hub`);
+        (this.config_.sauceSeleniumAddress ?
+             this.config_.sauceSeleniumAddress :
+             `ondemand.${this.getSauceEndpoint(this.config_.sauceRegion)}:443/wd/hub`);
 
     // Append filename to capabilities.name so that it's easier to identify
     // tests.
@@ -89,16 +90,15 @@ export class Sauce extends DriverProvider {
   }
 
   /**
-    * Get the Sauce Labs endpoint
-    * @private
-    * @param {string} region
-    * @return {string} The endpoint that needs to be used
-    */
-  private getSauceEndpoint(region:string): string{
-      const dc = region ?
-          typeof SAUCE_REGIONS[region] !== 'undefined' ?
-              SAUCE_REGIONS[region] : (region + '.')
-          : '';
-      return `${dc}saucelabs.com`;
+   * Get the Sauce Labs endpoint
+   * @private
+   * @param {string} region
+   * @return {string} The endpoint that needs to be used
+   */
+  private getSauceEndpoint(region: string): string {
+    const dc = region ?
+        typeof SAUCE_REGIONS[region] !== 'undefined' ? SAUCE_REGIONS[region] : (region + '.') :
+        '';
+    return `${dc}saucelabs.com`;
   }
 }


### PR DESCRIPTION
## Proposed changes

SauceLabs is expanding their services to other regions in the world. Protractor wants to allow user to easily pick between DCs. 

## Types of changes

This change allows user to define the backend region from sauce via the `sauceRegion` property, e.g. 

```js
    sauceUser: process.env.SAUCE_USERNAME,
    sauceKey: process.env.SAUCE_ACCESS_KEY,
    sauceRegion: 'eu',
```

Will run the test against `https://ondemand.eu-central-1.saucelabs.com:443/wd/hub/.`

```js
    sauceUser: process.env.SAUCE_USERNAME,
    sauceKey: process.env.SAUCE_ACCESS_KEY,
    sauceRegion: 'us',

    // the default
    sauceUser: process.env.SAUCE_USERNAME,
    sauceKey: process.env.SAUCE_ACCESS_KEY,
```

Will run the test against `https://ondemand.saucelabs.com:443/wd/hub/`

It will also set the correct url for updating the status of the test
