### PR TITLE
chore(expectedConditions): update generic Function typings

### DIFF
--- a/lib/taskRunner.ts
+++ b/lib/taskRunner.ts
@@ -7,12 +7,12 @@ import {Runner} from './runner';
 import {TaskLogger} from './taskLogger';
 
 export interface RunResults {
-  taskId: number;
-  specs: Array<string>;
-  capabilities: any;
-  failedCount: number;
-  exitCode: number;
-  specResults: Array<any>;
+  taskId?: number;
+  specs?: Array<string>;
+  capabilities?: any;
+  failedCount?: number;
+  exitCode?: number;
+  specResults?: Array<any>;
 }
 
 /**

--- a/spec/basic/expected_conditions_spec.js
+++ b/spec/basic/expected_conditions_spec.js
@@ -1,8 +1,9 @@
-const EC = protractor.ExpectedConditions;
-
 describe('expected conditions', () => {
+  let EC = null;
+
   beforeEach(async () => {
     await browser.get('index.html#/form');
+    EC = protractor.ExpectedConditions;
   });
 
   it('should have alertIsPresent', async () => {


### PR DESCRIPTION
- Use `() => Promise<boolean>` over `Function` typings.
- Fix an ExpectedConditions test where it was set to a const.
- Fix a TypeScript typing interface issue with RunResults in taskRunner.
