### PR TITLE
Create directory path for 'resultJsonOutputFile'

### DIFF
--- a/lib/launcher.ts
+++ b/lib/launcher.ts
@@ -3,6 +3,7 @@
  * input configuration and launching test runners.
  */
 import * as fs from 'fs';
+import * as path from 'path';
 import * as q from 'q';
 
 import {Config} from './config';
@@ -46,6 +47,13 @@ class TaskResults {
     let jsonOutput = this.results_.reduce((jsonOutput, result) => {
       return jsonOutput.concat(result.specResults);
     }, []);
+
+    // Create directory path if not present
+    (function mkdirp(fpath) {
+      let dirName = path.dirname(fpath);
+      !fs.existsSync(dirName) && mkdirp(dirName) && fs.mkdirSync(dirName);
+      return true;
+    })(path.resolve(filepath));
 
     let json = JSON.stringify(jsonOutput, null, '  ');
     fs.writeFileSync(filepath, json);


### PR DESCRIPTION
When using the option `resultJsonOutputFile` in conf.js, if the intermediate directories are not there,protractor throws as error as shown below
```
[22:56:21] I/launcher - 0 instance(s) of WebDriver still running
[22:56:21] E/launcher - ENOENT: no such file or directory, open 'C:\Source\logs\log.json'
[22:56:21] E/launcher - Error: ENOENT: no such file or directory, open 'C:\Source\logs\log.json'
    at Object.fs.openSync (fs.js:646:18)
    at Object.fs.writeFileSync (fs.js:1299:33)
    at TaskResults.saveResults (C:\Source\sampleprotractor\node_modules\protractor\built\launcher.js:46:12)
    at C:\Source\sampleprotractor\node_modules\protractor\built\launcher.js:268:30
    at _fulfilled (C:\Source\sampleprotractor\node_modules\q\q.js:834:54)
    at self.promiseDispatch.done (C:\Source\sampleprotractor\node_modules\q\q.js:863:30)
    at Promise.promise.promiseDispatch (C:\Source\sampleprotractor\node_modules\q\q.js:796:13)
    at C:\Source\sampleprotractor\node_modules\q\q.js:604:44
    at runSingle (C:\Source\sampleprotractor\node_modules\q\q.js:137:13)
    at flush (C:\Source\sampleprotractor\node_modules\q\q.js:125:13)
[22:56:21] E/launcher - Process exited with error code 199
```
This PR is to create the intermediate folders recursively if it is not present

for eg: in the following case, if 'logs' folder not there,then it is created
`resultJsonOutputFile: '../logs/log.json',`  

@cnishina : can you please review this? 
Thanks!!