### PR TITLE
(feat)Added parameter browserstackUseHttps to use https in BrowserStack Hub url

### DIFF
--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -51,6 +51,7 @@ let allowedNames = [
   'browserstackUser',
   'browserstackKey',
   'browserstackProxy',
+  'browserstackUseHttps',
   'kobitonUser',
   'kobitonKey',
   'testobjectUser',

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -214,6 +214,15 @@ export interface Config {
    */
   browserstackProxy?: string;
 
+  /**
+   * If true, Protractor will use https:// protocol instead of http:// to
+   * connect to BrowserStack defined by seleniumAddress.
+   *
+   * default: false
+   */
+  browserstackUseHttps?: boolean;
+  /**
+
   // ---- 7. To connect directly to Drivers ------------------------------------
 
   /**

--- a/lib/driverProviders/browserStack.ts
+++ b/lib/driverProviders/browserStack.ts
@@ -84,7 +84,8 @@ export class BrowserStack extends DriverProvider {
     let deferred = q.defer();
     this.config_.capabilities['browserstack.user'] = this.config_.browserstackUser;
     this.config_.capabilities['browserstack.key'] = this.config_.browserstackKey;
-    this.config_.seleniumAddress = 'http://hub.browserstack.com/wd/hub';
+    let protocol = this.config_.browserstackUseHttps ? 'https://' : 'http://';
+    this.config_.seleniumAddress = protocol + 'hub.browserstack.com/wd/hub';
 
     this.browserstackClient = BrowserstackClient.createAutomateClient({
       username: this.config_.browserstackUser,


### PR DESCRIPTION
This is duplicate of #4982 Raising this PR again to rerun tests.
