### PR TITLE
Browser.get break AngularJS on hybrid Angular/AngularJS app (Without UpgradeModule)

### DIFF
--- a/lib/browser.ts
+++ b/lib/browser.ts
@@ -968,6 +968,9 @@ export class ProtractorBrowser extends AbstractExtendedWebDriver {
                         'angular.resumeBootstrap(arguments[0]);',
                     msg('resume bootstrap'), moduleNames));
           } else {
+            // PROPOSAL: Remove the added NG_DEFER_BOOTSTRAP if we are running on Angular
+            this.executeScript('window.name = window.name.replace(' + /^NG_DEFER_BOOTSTRAP!/ + ", '');");
+            
             // TODO: support mock modules in Angular2. For now, error if someone
             // has tried to use one.
             if (this.mockModules_.length > 1) {

--- a/lib/browser.ts
+++ b/lib/browser.ts
@@ -968,7 +968,7 @@ export class ProtractorBrowser extends AbstractExtendedWebDriver {
                         'angular.resumeBootstrap(arguments[0]);',
                     msg('resume bootstrap'), moduleNames));
           } else {
-            // PROPOSAL: Remove the added NG_DEFER_BOOTSTRAP if we are running on Angular
+            // Remove the added NG_DEFER_BOOTSTRAP if we are running on Angular
             this.executeScript('window.name = window.name.replace(' + /^NG_DEFER_BOOTSTRAP!/ + ", '');");
             
             // TODO: support mock modules in Angular2. For now, error if someone


### PR DESCRIPTION
When running tests between Angular and AngularJS, Protractor will set a flag when calling browser.get to defer the bootstraping of AngularJS but this flag is also set with Angular.
The window.name variable end with a ton of NG_DEFER_BOOTSTRAP! because they are not removed when navigating to an Angular page.
See issue #5125.