### PR TITLE
source-map-support version updated to 0.5.10 (latest)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "q": "1.4.1",
     "saucelabs": "^1.5.0",
     "selenium-webdriver": "3.6.0",
-    "source-map-support": "~0.4.0",
+    "source-map-support": "0.5.10",
     "webdriver-js-extender": "2.1.0",
     "webdriver-manager": "^12.0.6"
   },


### PR DESCRIPTION
Removed [DEP0005] DeprecationWarning: Buffer()