### PR TITLE
Update home.html to reflect changes in protractor 6.0

### DIFF
--- a/website/partials/home.html
+++ b/website/partials/home.html
@@ -57,6 +57,13 @@
       </p>
       <pre>webdriver-manager update</pre>
       <p>
+        The <code>webdriver-manager</code> is now designed to update to the latest version of a driver. 
+        If there is a mismatch for example, due a Chrome release not being out yet, a previous version may be required.
+        In this event, please try this command (use whichever browser/driver version the error message requires. 
+        Here, it requires Browser v73):
+      </p>
+      <pre>webdriver-manager update --versions.chrome=73.0.3683.86</pre>
+      <p>
         Now start up a server with:
       </p>
       <pre>webdriver-manager start</pre>
@@ -104,6 +111,32 @@ describe('angularjs homepage todo list', function() {
   });
 });
 </code></pre>
+<p>
+        Recent changes in Protractor 6.x are designed to take advantage of the JavaScript Asynchronous mode using async/await. 
+        You must modify your spec file code to take account of this change or you will receive an error. I recommend to new and
+        existing users that they please review the "Using async/await" page under the "Reference" drop-down above. Timing will
+        take on greater importance. Kindly note the location of "async" and "await" within the code below.
+</p>        
+<pre><code class="lang-js">
+describe('angularjs homepage todo list', function() {
+  it('should add a todo', async function() {
+    await browser.get('https://angularjs.org');
+
+    await element(by.model('todoList.todoText')).sendKeys('write first protractor test');
+    await element(by.css('[value="add"]')).click();
+
+    var todoList = element.all(by.repeater('todo in todoList.todos'));
+    expect(await todoList.count()).toEqual(3);
+    expect(await todoList.get(2).getText()).toEqual('write first protractor test');
+
+    // You wrote your first test, cross it off the list
+    await todoList.get(2).element(by.css('input')).click();
+    var completedAmount = element.all(by.css('.done-true'));
+    expect(await completedAmount.count()).toEqual(2);
+  });
+});
+</code></pre>        
+        
       </div>
       <p>
         The <code>describe</code> and <code>it</code> syntax is from the Jasmine


### PR DESCRIPTION
docs(*): Update home.html to reflect changes in webdriver-manager and protractor 6.0

- Add explanation of how webdriver-manager now uses the most recent browser version and setting the particular version may be required.
- Add alternative code sample to show how to update to a particular version of webdriver-manager
- Add explanation of how async/await is now required for protractor 6.x and beyond and that users must acquaint themselves with such syntax
- Add new code sample using async/await

Closes #5206