### PR TITLE
Update browser-setup.md

### DIFF
--- a/docs/browser-setup.md
+++ b/docs/browser-setup.md
@@ -48,7 +48,7 @@ Chrome options are nested in the `chromeOptions` object. A full list of options 
 ```javascript
 capabilities: {
   'browserName': 'chrome',
-  'chromeOptions': {
+  'goog:chromeOptions': {
     'args': ['show-fps-counter=true']
   }
 },


### PR DESCRIPTION
when using chromeOptions, the options are not picked up by the browser. Using goog:chromeOptions works.

I used the latest (mercury) docker-selenium images.
Also tried it on iron, krypton and lithium and it also failed.