### PR TITLE
docs(browser-setup): update Chrome configuration to v.6

### DIFF
--- a/docs/browser-setup.md
+++ b/docs/browser-setup.md
@@ -43,12 +43,12 @@ You may need to install a separate binary to run another browser, such as IE or 
 Adding Chrome-Specific Options
 ------------------------------
 
-Chrome options are nested in the `chromeOptions` object. A full list of options is at the [ChromeDriver](https://sites.google.com/a/chromium.org/chromedriver/capabilities) site. For example, to show an FPS counter in the upper right, your configuration would look like this:
+Chrome options are nested in the `goog:chromeOptions` object. A full list of options is at the [ChromeDriver](https://sites.google.com/a/chromium.org/chromedriver/capabilities) site. For example, to show an FPS counter in the upper right, your configuration would look like this:
 
 ```javascript
 capabilities: {
   'browserName': 'chrome',
-  'chromeOptions': {
+  'goog:chromeOptions': {
     'args': ['show-fps-counter=true']
   }
 },
@@ -149,7 +149,7 @@ on the commandline like this `--window-size=800,600`.
 capabilities: {
   browserName: 'chrome',
 
-  chromeOptions: {
+  'goog:chromeOptions': {
      args: [ "--headless", "--disable-gpu", "--window-size=800,600" ]
    }
 }


### PR DESCRIPTION
ChromeDriver at version 2.31 changed `chromeOptions` to `goog:ChromeOptions` ( [see: https://chromedriver.storage.googleapis.com/2.31/notes.txt](https://chromedriver.storage.googleapis.com/2.31/notes.txt) ).
While I was trying to use old version (that worked good for v.5.4.2), then I obtained following problems: https://stackoverflow.com/questions/58057678/angular-protractor-update-to-6-0-0-causes-browser-crashes
Following changes unifies configuration with Firefox and allows to easy find reason of problems. It works also for 5.4.2, see part of my test spec log, where `goog:chromeOptions` is visible:
```Capabilities {
  map_:
   Map {
     'acceptInsecureCerts' => false,
     'acceptSslCerts' => false,
     'applicationCacheEnabled' => false,
     'browserConnectionEnabled' => false,
     'browserName' => 'chrome',
     'chrome' => { chromedriverVersion:
        '77.0.3865.40 (f484704e052e0b556f8030b65b953dce96503217-refs/branch-heads/3865@{#442})',
       userDataDir: '/tmp/.com.google.Chrome.ufLBZZ' },
     'cssSelectorsEnabled' => true,
     'databaseEnabled' => false,
     'goog:chromeOptions' => { debuggerAddress: 'localhost:46641' },
     'handlesAlerts' => true,
     'hasTouchScreen' => false,
     'javascriptEnabled' => true,
     'locationContextEnabled' => true,
     'mobileEmulationEnabled' => false,
     'nativeEvents' => true,
     'networkConnectionEnabled' => false,
     'pageLoadStrategy' => 'normal',
     'platform' => 'Linux',
     'proxy' => {},
     'rotatable' => false,
     'setWindowRect' => true,
     'strictFileInteractability' => false,
     'takesHeapSnapshot' => true,
     'takesScreenshot' => true,
     'timeouts' => { implicit: 0, pageLoad: 300000, script: 30000 },
     'unexpectedAlertBehaviour' => 'ignore',
     'version' => '77.0.3865.90',
     'webStorageEnabled' => true } }```