### PR TITLE
Update package.json for saucelabs

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "glob": "^7.0.3",
     "jasmine": "^3.3.1",
     "optimist": "~0.6.0",
-    "saucelabs": "^1.5.0",
+    "saucelabs": "^3.0.0",
     "selenium-webdriver": "^4.0.0-alpha.1",
     "source-map-support": "~0.4.0",
     "webdriver-manager": "13.0.0"


### PR DESCRIPTION
https-proxy-agent has a vulnerability. Saucelabs has taken it out of their package, but the version of saucelabs you're using has not removed it yet. If you upgrade your saucelabs package dependency it will eliminate the need for https-proxy-agent and fix the vulnerability.