### PR TITLE
docs: Fix simple typo, borwser -> browser

### DIFF
--- a/spec/plugins/browserGetSyncedConf.js
+++ b/spec/plugins/browserGetSyncedConf.js
@@ -1,6 +1,6 @@
 const env = require('../environment.js');
 
-// Make sure that borwser-related plugin hooks work with browser sync on
+// Make sure that browser-related plugin hooks work with browser sync on
 exports.config = {
   seleniumAddress: env.seleniumAddress,
   SELENIUM_PROMISE_MANAGER: false,

--- a/spec/plugins/browserGetUnsyncedConf.js
+++ b/spec/plugins/browserGetUnsyncedConf.js
@@ -1,6 +1,6 @@
 const env = require('../environment.js');
 
-// Make sure that borwser-related plugin hooks work with browser sync off
+// Make sure that browser-related plugin hooks work with browser sync off
 exports.config = {
   seleniumAddress: env.seleniumAddress,
   SELENIUM_PROMISE_MANAGER: false,


### PR DESCRIPTION
There is a small typo in spec/plugins/browserGetSyncedConf.js, spec/plugins/browserGetUnsyncedConf.js.

Should read `browser` rather than `borwser`.

