### PR TITLE
remove debugger call in spec

### DIFF
--- a/exampleTypescript/asyncAwait/spec.ts
+++ b/exampleTypescript/asyncAwait/spec.ts
@@ -6,7 +6,6 @@ describe('async function', function() {
     await browser.get('http://www.angularjs.org');
     let todoList = element.all(by.repeater('todo in todoList.todos'));
     if ((await todoList.count()) > 1) {
-      debugger
       expect((await todoList.get(1).getText())).toEqual('build an AngularJS app');
     }
   });


### PR DESCRIPTION
It seems like a mistake. Should be removed I think.