### PR TITLE
Fix for error "Can't return an ElementFinder from an async function" in TS 3/4

### DIFF
--- a/lib/element.ts
+++ b/lib/element.ts
@@ -816,9 +816,6 @@ export class ElementArrayFinder extends WebdriverWebElement {
 export class ElementFinder extends WebdriverWebElement {
   parentElementArrayFinder: ElementArrayFinder;
   elementArrayFinder_: ElementArrayFinder;
-  then?:
-      (fn: (value: any) => any | wdpromise.IThenable<any>,
-       errorFn?: (error: any) => any) => wdpromise.Promise<any> = null;
 
   constructor(public browser_: ProtractorBrowser, elementArrayFinder: ElementArrayFinder) {
     super();


### PR DESCRIPTION
Fixes ElementFinder so that protractor can be used with Typescript v3, v4.

Typescript fails to compile when ElementFinder is returned from an async function. This is because of optional property "then" present on ElementFinder. Previously this property was removed in #1926 but re-added back in #3835 as an optional. So I suggest that this property be removed again so that protractor can be used with Typescript version 3 and onward.