### PR TITLE
Fix stack of undefined issue

### DIFF
--- a/lib/util.ts
+++ b/lib/util.ts
@@ -46,16 +46,18 @@ export function runFilenameOrFn_(configDir: string, filenameOrFn: any, args?: an
     }
     if (typeof filenameOrFn === 'function') {
       let results = when(filenameOrFn.apply(null, args), null, (err) => {
-        if (typeof err === 'string') {
-          err = new Error(err);
-        } else {
-          err = err as Error;
-          if (!err.stack) {
-            err.stack = new Error().stack;
+        if(err){
+          if (typeof err === 'string') {
+            err = new Error(err);
+          } else {
+            err = err as Error;
+            if (!err.stack) {
+              err.stack = new Error().stack;
+            }
           }
+          err.stack = exports.filterStackTrace(err.stack);
+          throw err;  
         }
-        err.stack = exports.filterStackTrace(err.stack);
-        throw err;
       });
       resolvePromise(results);
     } else {


### PR DESCRIPTION
In the default logic, this `err` object should be an `Object` or `String`. But in my case when the `err` is undefined or null,  this code will throw an issue as below image.  I add a logic to check if the `err` is not null or undefined.
 
![image](https://user-images.githubusercontent.com/19277425/118215617-72e24600-b4a4-11eb-835a-ad2d48ef1f90.png)

